### PR TITLE
Fix error in CI for address-sanitizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
     name: Address sanitizer
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with: {toolchain: nightly, profile: minimal, override: true}


### PR DESCRIPTION
This fixes an error in the CI pass introduced by #4, which forgot to check out the repository