### PR TITLE
Fix Clippy lints and add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [ master ]
 
 jobs:
+  lint_and_clippy:
+    name: Lint and Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          components: 'rustfmt,clippy'
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
   build:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2.33.0"
 console = "0.11"
 num = "0.3.1"
 num_enum = "0.5.1"
-openjpeg-sys = "1.0.2"
+openjpeg-sys = "1.0.3"
 
 [target.'cfg(unix)'.dependencies]
 pager = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,17 @@ homepage = "https://github.com/noritada/grib-rs"
 categories = ["science"]
 keywords = ["GRIB", "weather", "meteorology"]
 
-[target.'cfg(unix)'.dependencies]
+[dependencies]
 chrono = "0.4"
 clap = "2.33.0"
 console = "0.11"
 num = "0.3.1"
 num_enum = "0.5.1"
 openjpeg-sys = "1.0.2"
+
+[target.'cfg(unix)'.dependencies]
 pager = "0.15"
 which = "4"
-
-[target.'cfg(not(unix))'.dependencies]
-chrono = "0.4"
-clap = "2.33.0"
-console = "0.11"
-num = "0.3.1"
-num_enum = "0.5.1"
-openjpeg-sys = "1.0.2"
 
 [dev-dependencies]
 assert_cmd = "1.0.*"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-use grib_build;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/gen/src/lib.rs
+++ b/gen/src/lib.rs
@@ -86,7 +86,7 @@ impl CodeTable {
         format!(
             "\
 /// {}
-const {}: &'static [&'static str] = &{:#?};",
+const {}: &[& str] = &{:#?};",
             self.desc,
             name,
             self.to_vec(),

--- a/src/bin/gribber/cli.rs
+++ b/src/bin/gribber/cli.rs
@@ -13,36 +13,36 @@ use grib::error::*;
 use grib::reader::SeekableGrib2Reader;
 
 pub enum CliError {
-    GribError(GribError),
-    ParseNumberError(ParseIntError),
-    IOError(Error, String),
+    Grib(GribError),
+    ParseNumber(ParseIntError),
+    IO(Error, String),
 }
 
 impl Display for CliError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::GribError(e) => write!(f, "{}", e),
-            Self::ParseNumberError(e) => write!(f, "{:#?}", e),
-            Self::IOError(e, path) => write!(f, "{}: {}", e, path),
+            Self::Grib(e) => write!(f, "{}", e),
+            Self::ParseNumber(e) => write!(f, "{:#?}", e),
+            Self::IO(e, path) => write!(f, "{}: {}", e, path),
         }
     }
 }
 
 impl From<GribError> for CliError {
     fn from(e: GribError) -> Self {
-        Self::GribError(e)
+        Self::Grib(e)
     }
 }
 
 impl From<ParseIntError> for CliError {
     fn from(e: ParseIntError) -> Self {
-        Self::ParseNumberError(e)
+        Self::ParseNumber(e)
     }
 }
 
 pub fn grib(file_name: &str) -> Result<Grib2<SeekableGrib2Reader<BufReader<File>>>, CliError> {
     let path = Path::new(file_name);
-    let f = File::open(&path).map_err(|e| CliError::IOError(e, path.display().to_string()))?;
+    let f = File::open(&path).map_err(|e| CliError::IO(e, path.display().to_string()))?;
     let f = BufReader::new(f);
     Ok(Grib2::<SeekableGrib2Reader<BufReader<File>>>::read_with_seekable(f)?)
 }

--- a/src/bin/gribber/commands/decode.rs
+++ b/src/bin/gribber/commands/decode.rs
@@ -41,7 +41,7 @@ pub fn exec(args: &ArgMatches<'static>) -> Result<(), cli::CliError> {
                 }
                 Ok(())
             })
-            .map_err(|e| cli::CliError::IOError(e, out_path.to_string()))?;
+            .map_err(|e| cli::CliError::IO(e, out_path.to_string()))?;
     } else if args.is_present("little-endian") {
         let out_path = args.value_of("little-endian").unwrap();
         File::create(out_path)
@@ -51,7 +51,7 @@ pub fn exec(args: &ArgMatches<'static>) -> Result<(), cli::CliError> {
                 }
                 Ok(())
             })
-            .map_err(|e| cli::CliError::IOError(e, out_path.to_string()))?;
+            .map_err(|e| cli::CliError::IO(e, out_path.to_string()))?;
     } else {
         cli::start_pager();
         println!("{:#?}", values);

--- a/src/bin/gribber/commands/decode.rs
+++ b/src/bin/gribber/commands/decode.rs
@@ -37,7 +37,7 @@ pub fn exec(args: &ArgMatches<'static>) -> Result<(), cli::CliError> {
         File::create(out_path)
             .and_then(|mut f| {
                 for value in values.iter() {
-                    f.write(&value.to_be_bytes())?;
+                    f.write_all(&value.to_be_bytes())?;
                 }
                 Ok(())
             })
@@ -47,7 +47,7 @@ pub fn exec(args: &ArgMatches<'static>) -> Result<(), cli::CliError> {
         File::create(out_path)
             .and_then(|mut f| {
                 for value in values.iter() {
-                    f.write(&value.to_le_bytes())?;
+                    f.write_all(&value.to_le_bytes())?;
                 }
                 Ok(())
             })

--- a/src/bin/gribber/commands/inspect.rs
+++ b/src/bin/gribber/commands/inspect.rs
@@ -56,7 +56,7 @@ pub fn exec(args: &ArgMatches<'static>) -> Result<(), cli::CliError> {
         let tmpls = grib.list_templates();
         view.add(InspectItem::Templates(InspectTemplatesItem::new(tmpls)));
     }
-    if view.items.len() == 0 {
+    if view.items.is_empty() {
         view.add(InspectItem::Sections(InspectSectionsItem::new(
             grib.sections(),
         )));
@@ -99,8 +99,8 @@ pub fn exec(args: &ArgMatches<'static>) -> Result<(), cli::CliError> {
             InspectItem::Templates(item) => print!("{}", item),
         }
 
-        if let Some(_) = items.peek() {
-            println!("");
+        if items.peek().is_some() {
+            println!();
         }
     }
 
@@ -121,7 +121,7 @@ impl<'i> InspectView<'i> {
     }
 
     fn with_headers(&self) -> bool {
-        !(self.items.len() < 2)
+        self.items.len() >= 2
     }
 
     fn num_lines(&self) -> usize {
@@ -167,7 +167,7 @@ struct InspectSectionsItem<'i> {
 
 impl<'i> InspectSectionsItem<'i> {
     fn new(data: &'i [SectionInfo]) -> Self {
-        Self { data: data }
+        Self { data }
     }
 
     fn len(&self) -> usize {
@@ -178,9 +178,9 @@ impl<'i> InspectSectionsItem<'i> {
 impl<'i> Display for InspectSectionsItem<'i> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         for (i, sect) in self.data.iter().enumerate() {
-            write!(
+            writeln!(
                 f,
-                "{:>5} │ {:016x} - {:016x} │ Section {}\n",
+                "{:>5} │ {:016x} - {:016x} │ Section {}",
                 i,
                 sect.offset,
                 sect.offset + sect.size,
@@ -197,7 +197,7 @@ struct InspectSubMessagesItem<'i> {
 
 impl<'i> InspectSubMessagesItem<'i> {
     fn new(data: SubMessageIterator<'i>) -> Self {
-        Self { data: data }
+        Self { data }
     }
 
     fn len(&self) -> usize {
@@ -236,9 +236,9 @@ impl<'i> Display for InspectSubMessagesItem<'i> {
         write!(f, "{}", style.apply_to(header))?;
 
         for (i, submessage) in self.data.clone().enumerate() {
-            write!(
+            writeln!(
                 f,
-                "{:>5} │ {} {} {} {} {} {} │ {} {} {}\n",
+                "{:>5} │ {} {} {} {} {} {} │ {} {} {}",
                 i,
                 format_section_index_optional(&submessage.2),
                 format_section_index(&submessage.3),
@@ -261,7 +261,7 @@ struct InspectTemplatesItem {
 
 impl InspectTemplatesItem {
     fn new(data: Vec<TemplateInfo>) -> Self {
-        Self { data: data }
+        Self { data }
     }
 
     fn len(&self) -> usize {
@@ -274,10 +274,10 @@ impl Display for InspectTemplatesItem {
         for tmpl in self.data.iter() {
             match tmpl.describe() {
                 Some(s) => {
-                    write!(f, "{:<8} - {}\n", tmpl.to_string(), s)?;
+                    writeln!(f, "{:<8} - {}", tmpl.to_string(), s)?;
                 }
                 None => {
-                    write!(f, "{}\n", tmpl)?;
+                    writeln!(f, "{}", tmpl)?;
                 }
             }
         }

--- a/src/bin/gribber/commands/list.rs
+++ b/src/bin/gribber/commands/list.rs
@@ -54,10 +54,7 @@ struct ListView<'i> {
 
 impl<'i> ListView<'i> {
     fn new(data: SubMessageIterator<'i>, mode: ListViewMode) -> Self {
-        Self {
-            data: data,
-            mode: mode,
-        }
+        Self { data, mode }
     }
 
     fn num_lines(&self) -> usize {
@@ -70,8 +67,7 @@ impl<'i> ListView<'i> {
             ListViewMode::Dump => {
                 let unit_height = 8; // lines of output from SubMessage.describe(), hard-coded as of now
                 let (len, _) = self.data.size_hint();
-                let total_height = (unit_height + 2) * len - 1;
-                total_height
+                (unit_height + 2) * len - 1
             }
         }
     }
@@ -103,24 +99,24 @@ impl<'i> Display for ListView<'i> {
                                 .lookup(usize::from(n))
                                 .to_string()
                         })
-                        .unwrap_or(String::new());
+                        .unwrap_or_default();
                     let generating_process = prod_def
                         .generating_process()
                         .map(|v| CodeTable4_3.lookup(usize::from(v)).to_string())
-                        .unwrap_or(String::new());
+                        .unwrap_or_default();
                     let forecast_time = prod_def
                         .forecast_time()
                         .map(|ft| ft.to_string())
-                        .unwrap_or(String::new());
+                        .unwrap_or_default();
                     let surfaces = prod_def
                         .fixed_surfaces()
                         .map(|(first, second)| {
                             (first.value().to_string(), second.value().to_string())
                         })
                         .unwrap_or((String::new(), String::new()));
-                    write!(
+                    writeln!(
                         f,
-                        "{:>5} │ {:<31} {:<18} {:>14} {:>17} {:>17}\n",
+                        "{:>5} │ {:<31} {:<18} {:>14} {:>17} {:>17}",
                         i, category, generating_process, forecast_time, surfaces.0, surfaces.1,
                     )?;
                 }

--- a/src/codetables/old.rs
+++ b/src/codetables/old.rs
@@ -5,8 +5,8 @@ pub struct LookupResult(Result<&'static &'static str, ConversionError>);
 impl Display for LookupResult {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let s = match &self.0 {
-            Ok(s) => format!("{}", s),
-            Err(e) => format!("{}", e),
+            Ok(s) => s.to_string(),
+            Err(e) => e.to_string(),
         };
         write!(f, "{}", s)
     }
@@ -249,7 +249,7 @@ impl<T: ArrayLookup> Lookup for T {
     }
 }
 
-const CODE_TABLE_UNSUPPORTED: &'static [&'static str] = &[];
+const CODE_TABLE_UNSUPPORTED: &[&str] = &[];
 
 pub(crate) const SUPPORTED_PROD_DEF_TEMPLATE_NUMBERS: [u16; 71] = [
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 30, 31, 32, 33, 34, 35, 40, 41, 42,

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -187,11 +187,11 @@ impl ProdDefinition {
 
     fn read_surface_from(&self, index: usize) -> Option<FixedSurface> {
         let surface_type = self.templated.get(index).copied();
-        let scale_factor = self.templated.get(index + 1).map(|v| (*v).into_grib_int());
+        let scale_factor = self.templated.get(index + 1).map(|v| (*v).as_grib_int());
         let start = index + 2;
         let end = index + 6;
         let scaled_value =
-            u32::from_be_bytes(self.templated[start..end].try_into().unwrap()).into_grib_int();
+            u32::from_be_bytes(self.templated[start..end].try_into().unwrap()).as_grib_int();
         surface_type
             .zip(scale_factor)
             .map(|(stype, factor)| FixedSurface::new(stype, factor, scaled_value))

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -56,7 +56,7 @@ impl ProdDefinition {
     /// returned numerical value.
     pub fn parameter_category(&self) -> Option<u8> {
         if self.template_supported {
-            self.templated.get(0).map(|v| *v)
+            self.templated.get(0).copied()
         } else {
             None
         }
@@ -66,7 +66,7 @@ impl ProdDefinition {
     /// returned numerical value.
     pub fn parameter_number(&self) -> Option<u8> {
         if self.template_supported {
-            self.templated.get(1).map(|v| *v)
+            self.templated.get(1).copied()
         } else {
             None
         }
@@ -102,7 +102,7 @@ impl ProdDefinition {
                 1000..=1101 => Some(2),
                 _ => None,
             }?;
-            self.templated.get(index).map(|v| *v)
+            self.templated.get(index).copied()
         } else {
             None
         }
@@ -138,7 +138,7 @@ impl ProdDefinition {
                 1000..=1101 => Some(8),
                 _ => None,
             }?;
-            let unit = self.templated.get(unit_index).map(|v| *v);
+            let unit = self.templated.get(unit_index).copied();
             let start = unit_index + 1;
             let end = unit_index + 5;
             let time = u32::from_be_bytes(self.templated[start..end].try_into().unwrap());
@@ -186,7 +186,7 @@ impl ProdDefinition {
     }
 
     fn read_surface_from(&self, index: usize) -> Option<FixedSurface> {
-        let surface_type = self.templated.get(index).map(|v| *v);
+        let surface_type = self.templated.get(index).copied();
         let scale_factor = self.templated.get(index + 1).map(|v| (*v).into_grib_int());
         let start = index + 2;
         let end = index + 6;

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -45,8 +45,8 @@ impl<R: Grib2Read> Grib2DataDecode<R> for ComplexPackingDecoder {
 
         let sect5_data = reader.read_sect_body_bytes(sect5)?;
         let ref_val = read_as!(f32, sect5_data, 6);
-        let exp = read_as!(u16, sect5_data, 10).into_grib_int();
-        let dig = read_as!(u16, sect5_data, 12).into_grib_int();
+        let exp = read_as!(u16, sect5_data, 10).as_grib_int();
+        let dig = read_as!(u16, sect5_data, 12).as_grib_int();
         let nbit = read_as!(u8, sect5_data, 14);
         let ngroup = read_as!(u32, sect5_data, 26);
         let group_width_ref = read_as!(u8, sect5_data, 30);
@@ -60,9 +60,9 @@ impl<R: Grib2Read> Grib2DataDecode<R> for ComplexPackingDecoder {
 
         let sect7_data = reader.read_sect_body_bytes(sect7)?;
 
-        let z1 = read_as!(u16, sect7_data, 0).into_grib_int();
-        let z2 = read_as!(u16, sect7_data, 2).into_grib_int();
-        let z_min = read_as!(u16, sect7_data, 4).into_grib_int();
+        let z1 = read_as!(u16, sect7_data, 0).as_grib_int();
+        let z2 = read_as!(u16, sect7_data, 2).as_grib_int();
+        let z_min = read_as!(u16, sect7_data, 4).as_grib_int();
 
         fn get_octet_length(nbit: u8, ngroup: u32) -> usize {
             let total_bit: u32 = ngroup * u32::from(nbit);
@@ -197,7 +197,7 @@ where
                     NBitwiseIterator::new(&self.data[self.pos..pos_end + offset_byte], width)
                         .with_offset(self.start_offset_bits)
                         .take(length)
-                        .map(|v| v.into_grib_int() + _ref + self.z_min)
+                        .map(|v| v.as_grib_int() + _ref + self.z_min)
                         .collect::<Vec<i32>>();
                 self.pos = pos_end;
                 self.start_offset_bits = offset_byte;

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -97,7 +97,7 @@ impl<R: Grib2Read> Grib2DataDecode<R> for ComplexPackingDecoder {
         );
         let group_lens_iter = group_lens_iter
             .take((ngroup - 1) as usize)
-            .map(|v| u32::from(group_len_ref) + u32::from(group_len_inc) * v)
+            .map(|v| group_len_ref + u32::from(group_len_inc) * v)
             .chain(iter::once(group_len_last));
 
         let unpacked_data = ComplexPackingValueDecodeIterator::new(
@@ -158,11 +158,11 @@ impl<'a, I, J, K> ComplexPackingValueDecodeIterator<'a, I, J, K> {
         data: &'a [u8],
     ) -> Self {
         Self {
-            ref_iter: ref_iter,
-            width_iter: width_iter,
-            length_iter: length_iter,
+            ref_iter,
+            width_iter,
+            length_iter,
             z_min: i32::from(z_min),
-            data: data,
+            data,
             pos: 0,
             start_offset_bits: 0,
         }
@@ -218,7 +218,7 @@ struct SpatialDiff2ndOrderDecodeIterator<I> {
 impl<I> SpatialDiff2ndOrderDecodeIterator<I> {
     fn new(iter: I) -> Self {
         Self {
-            iter: iter,
+            iter,
             count: 0,
             prev1: 0,
             prev2: 0,

--- a/src/decoders/jpeg2000/ext.rs
+++ b/src/decoders/jpeg2000/ext.rs
@@ -53,15 +53,15 @@ impl Stream {
 
             let user_data = p_user_data as *mut SliceWithOffset;
 
-            let len = (&*user_data).buf.len();
+            let len = (*user_data).buf.len();
 
-            let offset = (&*user_data).offset;
+            let offset = (*user_data).offset;
 
             let bytes_left = len - offset;
 
             let bytes_read = std::cmp::min(bytes_left, p_nb_bytes);
 
-            let slice = &(&*user_data).buf[offset..offset + bytes_read];
+            let slice = &(*user_data).buf[offset..offset + bytes_read];
 
             std::ptr::copy_nonoverlapping(slice.as_ptr(), p_buffer as *mut u8, bytes_read);
 
@@ -106,7 +106,7 @@ impl Codec {
 
     pub(crate) fn create(format: OPJ_CODEC_FORMAT) -> Result<Self, Jpeg2000CodeStreamDecodeError> {
         NonNull::new(unsafe { opj::opj_create_decompress(format) })
-            .map(|c| Self(c))
+            .map(Self)
             .ok_or(Jpeg2000CodeStreamDecodeError::DecoderSetupError)
     }
 }
@@ -128,11 +128,11 @@ impl Image {
     }
 
     pub(crate) fn width(&self) -> u32 {
-        unsafe { (&*self.0).x1 - (&*self.0).x0 }
+        unsafe { (*self.0).x1 - (*self.0).x0 }
     }
 
     pub(crate) fn height(&self) -> u32 {
-        unsafe { (&*self.0).y1 - (&*self.0).y0 }
+        unsafe { (*self.0).y1 - (*self.0).y0 }
     }
 
     pub(crate) fn num_components(&self) -> u32 {

--- a/src/decoders/jpeg2000/mod.rs
+++ b/src/decoders/jpeg2000/mod.rs
@@ -50,8 +50,8 @@ impl<R: Grib2Read> Grib2DataDecode<R> for Jpeg2000CodeStreamDecoder {
 
         let sect5_data = reader.read_sect_body_bytes(sect5)?;
         let ref_val = read_as!(f32, sect5_data, 6);
-        let exp = read_as!(u16, sect5_data, 10).into_grib_int();
-        let dig = read_as!(u16, sect5_data, 12).into_grib_int();
+        let exp = read_as!(u16, sect5_data, 10).as_grib_int();
+        let dig = read_as!(u16, sect5_data, 12).as_grib_int();
         //let nbit = read_as!(u8, sect5_data, 14);
         let value_type = read_as!(u8, sect5_data, 15);
 

--- a/src/decoders/run_length.rs
+++ b/src/decoders/run_length.rs
@@ -69,13 +69,13 @@ impl<R: Grib2Read> Grib2DataDecode<R> for RunLengthEncodingDecoder {
             maxv,
             Some(sect5_body.num_points as usize),
         )
-        .map_err(|e| DecodeError::RunLengthEncodingDecodeError(e))?;
+        .map_err(DecodeError::RunLengthEncodingDecodeError)?;
 
         let level_to_value = |level: &u16| -> Result<f32, DecodeError> {
             let index: usize = (*level).into();
             level_map
                 .get(index)
-                .map(|l| *l)
+                .copied()
                 .ok_or(DecodeError::RunLengthEncodingDecodeError(
                     RunLengthEncodingDecodeError::InvalidLevelValue(*level),
                 ))

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -80,8 +80,8 @@ pub(crate) struct SimplePackingDecodeIterator<I> {
 impl<I> SimplePackingDecodeIterator<I> {
     pub(crate) fn new(iter: I, ref_val: f32, exp: i16, dig: i16) -> Self {
         Self {
-            iter: iter,
-            ref_val: ref_val,
+            iter,
+            ref_val,
             exp: exp.into(),
             dig: dig.into(),
         }

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -44,8 +44,8 @@ impl<R: Grib2Read> Grib2DataDecode<R> for SimplePackingDecoder {
 
         let sect5_data = reader.read_sect_body_bytes(sect5)?;
         let ref_val = read_as!(f32, sect5_data, 6);
-        let exp = read_as!(u16, sect5_data, 10).into_grib_int();
-        let dig = read_as!(u16, sect5_data, 12).into_grib_int();
+        let exp = read_as!(u16, sect5_data, 10).as_grib_int();
+        let dig = read_as!(u16, sect5_data, 12).as_grib_int();
         let nbit = read_as!(u8, sect5_data, 14);
         let value_type = read_as!(u8, sect5_data, 15);
 
@@ -119,13 +119,9 @@ mod tests {
 
         let ref_val = f32::from_be_bytes(ref_val_bytes[..].try_into().unwrap());
         let iter = NBitwiseIterator::new(&input, 16);
-        let actual = SimplePackingDecodeIterator::new(
-            iter,
-            ref_val,
-            exp.into_grib_int(),
-            dig.into_grib_int(),
-        )
-        .collect::<Vec<_>>();
+        let actual =
+            SimplePackingDecodeIterator::new(iter, ref_val, exp.as_grib_int(), dig.as_grib_int())
+                .collect::<Vec<_>>();
 
         assert_eq!(actual.len(), expected.len());
         let mut i = 0;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,11 +8,11 @@ use crate::context::{SectionBody, SectionInfo};
 use crate::datatypes::*;
 use crate::error::*;
 
-const SECT0_IS_MAGIC: &'static [u8] = b"GRIB";
+const SECT0_IS_MAGIC: &[u8] = b"GRIB";
 const SECT0_IS_MAGIC_SIZE: usize = SECT0_IS_MAGIC.len();
 const SECT0_IS_SIZE: usize = 16;
 const SECT_HEADER_SIZE: usize = 5;
-const SECT8_ES_MAGIC: &'static [u8] = b"7777";
+const SECT8_ES_MAGIC: &[u8] = b"7777";
 const SECT8_ES_SIZE: usize = SECT8_ES_MAGIC.len();
 
 macro_rules! read_as {
@@ -108,7 +108,7 @@ impl<R: Read + Seek> Grib2Read for SeekableGrib2Reader<R> {
         let fsize = read_as!(u64, buf, 8);
 
         Ok(Indicator {
-            discipline: discipline,
+            discipline,
             total_length: fsize,
         })
     }
@@ -233,7 +233,7 @@ pub fn unpack_sect4_body<R: Read>(f: &mut R, body_size: usize) -> Result<Section
 
     Ok(SectionBody::Section4(ProdDefinition {
         num_coordinates: read_as!(u16, buf, 0),
-        prod_tmpl_num: prod_tmpl_num,
+        prod_tmpl_num,
         templated: templated.into_boxed_slice(),
         template_supported: SUPPORTED_PROD_DEF_TEMPLATE_NUMBERS.contains(&prod_tmpl_num),
     }))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,11 @@
 pub(crate) trait GribInt<I> {
-    fn into_grib_int(&self) -> I;
+    fn as_grib_int(&self) -> I;
 }
 
 macro_rules! add_impl_for_ints {
     ($(($ty_src:ty, $ty_dst:ty),)*) => ($(
         impl GribInt<$ty_dst> for $ty_src {
-            fn into_grib_int(&self) -> $ty_dst {
+            fn as_grib_int(&self) -> $ty_dst {
                 if self.leading_zeros() == 0 {
                     let abs = (self << 1 >> 1) as $ty_dst;
                     -abs
@@ -100,7 +100,7 @@ mod tests {
         while pos < input.len() {
             let val = u8::from_be_bytes(input[pos..pos + 1].try_into().unwrap());
             pos += 1;
-            let val = val.into_grib_int();
+            let val = val.as_grib_int();
             actual.push(val);
         }
 
@@ -120,7 +120,7 @@ mod tests {
         while pos < input.len() {
             let val = u16::from_be_bytes(input[pos..pos + 2].try_into().unwrap());
             pos += 2;
-            let val = val.into_grib_int();
+            let val = val.as_grib_int();
             actual.push(val);
         }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,8 +35,8 @@ pub(crate) struct NBitwiseIterator<'a> {
 impl<'a> NBitwiseIterator<'a> {
     pub(crate) fn new(slice: &'a [u8], size: usize) -> Self {
         Self {
-            slice: slice,
-            size: size,
+            slice,
+            size,
             pos: 0,
             offset: 0,
         }


### PR DESCRIPTION
This PR consists mostly of fixes for clippy lints to make the code a bit more rusty.

Two other larger changes are in the `GribInt` trait and postfix on `CliError` to comply with the clippy lints.

This PR also fixes a bug with potentially [unused IO](https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount) which could cause issues in the future.