### PR TITLE
Add crates.io and deps.rs shields to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # grib-rs
 
 [![docs](https://docs.rs/grib/badge.svg)](https://docs.rs/grib)
+[![Crates.io](https://img.shields.io/crates/v/grib)](https://crates.io/crates/grib)
+[![dependency status](https://deps.rs/repo/github/noritada/grib-rs/status.svg)](https://deps.rs/repo/github/noritada/grib-rs)
 [![License (Apache 2.0)](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/noritada/grib-rs/blob/master/LICENSE-APACHE)
 [![License (MIT)](https://img.shields.io/badge/license-MIT-blue)](https://github.com/noritada/grib-rs/blob/master/LICENSE-MIT)
 [![Build](https://github.com/noritada/grib-rs/workflows/CI/badge.svg)](https://github.com/noritada/grib-rs/actions?query=workflow%3ACI)


### PR DESCRIPTION
Add crates.io and deps.rs shields to README for easier access to those websites from the repo.

Deps.rs badge also informs about security of dependencies used in the crate, which can be really helpful for users. Currently, it shows `insecure` ([as for many other crates](https://github.com/chronotope/chrono/issues/602)) due to issues with chrono but I believe it is useful in long term to have such badge in README.