### PR TITLE
Fix build failures with openjpeg-sys 1.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2"
 console = "0.15"
 num = "0.4"
 num_enum = "0.5"
-openjpeg-sys = "1"
+openjpeg-sys = ">= 1.0.3, < 1.0.4"
 
 [target.'cfg(unix)'.dependencies]
 pager = "0.16"


### PR DESCRIPTION
As noted in comments in PR #6, openjpeg-sys 1.0.2 also triggered a build failure on `windows-latest`.
So, this PR limits openjpeg-sys to 1.0.3 for now as a workaround.

Closes #16.