### PR TITLE
CLI: add support for multi-message data

### DIFF
--- a/src/bin/gribber/commands/info.rs
+++ b/src/bin/gribber/commands/info.rs
@@ -19,53 +19,43 @@ pub fn cli() -> Command<'static> {
 pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
     let file_name = args.get_one::<PathBuf>("FILE").unwrap();
     let grib = cli::grib(file_name)?;
-    let info = InfoItem::new(grib.info()?);
+    let (indicator, identification) = grib.info()?;
+    let info = InfoView(indicator, identification);
     print!("{}", info);
     Ok(())
 }
 
-struct InfoItem<'i> {
-    indicator: &'i Indicator,
-    identification: &'i Identification,
-}
+struct InfoView<'i>(&'i Indicator, &'i Identification);
 
-impl<'i> InfoItem<'i> {
-    fn new(info: (&'i Indicator, &'i Identification)) -> Self {
-        Self {
-            indicator: info.0,
-            identification: info.1,
-        }
-    }
-}
-
-impl<'i> Display for InfoItem<'i> {
+impl<'i> Display for InfoView<'i> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let Self(indicator, identification) = self;
         write!(
             f,
             "\
-Discipline:                             {}
-Total Length:                           {}
-Originating/generating centre:          {}
-Originating/generating sub-centre:      {}
-GRIB Master Tables Version Number:      {} ({})
-GRIB Local Tables Version Number:       {} ({})
-Significance of Reference Time:         {}
-Reference time of data:                 {}
-Production status of processed data:    {}
-Type of processed data:                 {}
+    Discipline:                             {}
+    Total Length:                           {}
+    Originating/generating centre:          {}
+    Originating/generating sub-centre:      {}
+    GRIB Master Tables Version Number:      {} ({})
+    GRIB Local Tables Version Number:       {} ({})
+    Significance of Reference Time:         {}
+    Reference time of data:                 {}
+    Production status of processed data:    {}
+    Type of processed data:                 {}
 ",
-            CodeTable0_0.lookup(self.indicator.discipline as usize),
-            self.indicator.total_length,
-            CommonCodeTable11.lookup(self.identification.centre_id() as usize),
-            self.identification.subcentre_id(),
-            self.identification.master_table_version(),
-            CommonCodeTable00.lookup(self.identification.master_table_version() as usize),
-            self.identification.local_table_version(),
-            CodeTable1_1.lookup(self.identification.local_table_version() as usize),
-            CodeTable1_2.lookup(self.identification.ref_time_significance() as usize),
-            self.identification.ref_time(),
-            CodeTable1_3.lookup(self.identification.prod_status() as usize),
-            CodeTable1_4.lookup(self.identification.data_type() as usize)
+            CodeTable0_0.lookup(indicator.discipline as usize),
+            indicator.total_length,
+            CommonCodeTable11.lookup(identification.centre_id() as usize),
+            identification.subcentre_id(),
+            identification.master_table_version(),
+            CommonCodeTable00.lookup(identification.master_table_version() as usize),
+            identification.local_table_version(),
+            CodeTable1_1.lookup(identification.local_table_version() as usize),
+            CodeTable1_2.lookup(identification.ref_time_significance() as usize),
+            identification.ref_time(),
+            CodeTable1_3.lookup(identification.prod_status() as usize),
+            CodeTable1_4.lookup(identification.data_type() as usize)
         )
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -109,11 +109,6 @@ impl<R: Grib2Read> Grib2<R> {
         let mut cacher = Vec::new();
         let parser = Grib2SubmessageIndexStream::new(sect_stream.by_ref()).with_cacher(&mut cacher);
         let submessages = parser.collect::<Result<Vec<_>, _>>()?;
-        // tentatively extract only submessages in the first message
-        let submessages = submessages
-            .into_iter()
-            .filter(|index| index.message_index().0 == 0)
-            .collect::<Vec<_>>();
         Ok(Self {
             reader: RefCell::new(sect_stream.into_reader()),
             sections: cacher.into_boxed_slice(),

--- a/tests/cli/commands/info.rs
+++ b/tests/cli/commands/info.rs
@@ -9,16 +9,16 @@ fn info() -> Result<(), Box<dyn std::error::Error>> {
     let arg_path = tempfile.path();
 
     let out_str = "\
-Discipline:                             Meteorological products
-Total Length:                           10321
-Originating/generating centre:          Tokyo (RSMC), Japan Meteorological Agency
-Originating/generating sub-centre:      0
-GRIB Master Tables Version Number:      5 (4 November 2009)
-GRIB Local Tables Version Number:       1 (Number of local tables version used)
-Significance of Reference Time:         Analysis
-Reference time of data:                 2016-08-22 02:00:00 UTC
-Production status of processed data:    Operational products
-Type of processed data:                 Analysis and forecast products
+    Discipline:                             Meteorological products
+    Total Length:                           10321
+    Originating/generating centre:          Tokyo (RSMC), Japan Meteorological Agency
+    Originating/generating sub-centre:      0
+    GRIB Master Tables Version Number:      5 (4 November 2009)
+    GRIB Local Tables Version Number:       1 (Number of local tables version used)
+    Significance of Reference Time:         Analysis
+    Reference time of data:                 2016-08-22 02:00:00 UTC
+    Production status of processed data:    Operational products
+    Type of processed data:                 Analysis and forecast products
 ";
 
     let mut cmd = Command::cargo_bin(CMD_NAME)?;

--- a/tests/cli/commands/info.rs
+++ b/tests/cli/commands/info.rs
@@ -3,12 +3,31 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
 
-#[test]
-fn info() -> Result<(), Box<dyn std::error::Error>> {
-    let tempfile = utils::testdata::grib2::jma_tornado_nowcast()?;
-    let arg_path = tempfile.path();
+macro_rules! test_display {
+    ($(($name:ident, $input:expr, $expected_stdout:expr),)*) => ($(
+        #[test]
+        fn $name() -> Result<(), Box<dyn std::error::Error>> {
+            let input = $input;
 
-    let out_str = "\
+            let mut cmd = Command::cargo_bin(CMD_NAME)?;
+            cmd.arg("info").arg(input.path());
+            cmd.assert()
+                .success()
+                .stdout(predicate::str::diff($expected_stdout))
+                .stderr(predicate::str::is_empty());
+
+            Ok(())
+        }
+    )*);
+}
+
+test_display! {
+    (
+        display_of_single_message_data,
+        utils::testdata::grib2::jma_tornado_nowcast()?,
+        "\
+Message 0
+
     Discipline:                             Meteorological products
     Total Length:                           10321
     Originating/generating centre:          Tokyo (RSMC), Japan Meteorological Agency
@@ -19,14 +38,52 @@ fn info() -> Result<(), Box<dyn std::error::Error>> {
     Reference time of data:                 2016-08-22 02:00:00 UTC
     Production status of processed data:    Operational products
     Type of processed data:                 Analysis and forecast products
-";
 
-    let mut cmd = Command::cargo_bin(CMD_NAME)?;
-    cmd.arg("info").arg(arg_path);
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::diff(out_str))
-        .stderr(predicate::str::is_empty());
+"
+    ),
+    (
+        display_of_multi_message_data,
+        utils::testdata::grib2::multi_message_data(3)?,
+        "\
+Message 0
 
-    Ok(())
+    Discipline:                             Meteorological products
+    Total Length:                           193
+    Originating/generating centre:          Offenbach (RSMC)
+    Originating/generating sub-centre:      255
+    GRIB Master Tables Version Number:      19 (3 May 2017)
+    GRIB Local Tables Version Number:       1 (Number of local tables version used)
+    Significance of Reference Time:         Start of forecast
+    Reference time of data:                 2021-11-20 18:00:00 UTC
+    Production status of processed data:    Operational products
+    Type of processed data:                 Forecast products
+
+Message 1
+
+    Discipline:                             Meteorological products
+    Total Length:                           193
+    Originating/generating centre:          Offenbach (RSMC)
+    Originating/generating sub-centre:      255
+    GRIB Master Tables Version Number:      19 (3 May 2017)
+    GRIB Local Tables Version Number:       1 (Number of local tables version used)
+    Significance of Reference Time:         Start of forecast
+    Reference time of data:                 2021-11-20 18:00:00 UTC
+    Production status of processed data:    Operational products
+    Type of processed data:                 Forecast products
+
+Message 2
+
+    Discipline:                             Meteorological products
+    Total Length:                           193
+    Originating/generating centre:          Offenbach (RSMC)
+    Originating/generating sub-centre:      255
+    GRIB Master Tables Version Number:      19 (3 May 2017)
+    GRIB Local Tables Version Number:       1 (Number of local tables version used)
+    Significance of Reference Time:         Start of forecast
+    Reference time of data:                 2021-11-20 18:00:00 UTC
+    Production status of processed data:    Operational products
+    Type of processed data:                 Forecast products
+
+"
+    ),
 }

--- a/tests/cli/commands/inspect.rs
+++ b/tests/cli/commands/inspect.rs
@@ -22,7 +22,7 @@ macro_rules! test_display_with_arguments {
 
 test_display_with_arguments! {
     (
-        display_without_options,
+        display_multiple_submessages_without_options,
         utils::testdata::grib2::jma_tornado_nowcast()?,
         Vec::<&str>::new(),
         "\
@@ -74,6 +74,52 @@ Templates:
 3.0      - Latitude/longitude
 4.0      - Analysis or forecast at a horizontal level or in a horizontal layer at a point in time
 5.200    - Run length packing with level values
+"
+    ),
+    (
+        display_multiple_messages_without_options,
+        utils::testdata::grib2::multi_message_data(3)?,
+        Vec::<&str>::new(),
+        "\
+Sections:
+    0 │ 0000000000000000 - 0000000000000010 │ Section 0
+    1 │ 0000000000000010 - 0000000000000025 │ Section 1
+    2 │ 0000000000000025 - 0000000000000040 │ Section 2
+    3 │ 0000000000000040 - 0000000000000063 │ Section 3
+    4 │ 0000000000000063 - 000000000000009d │ Section 4
+    5 │ 000000000000009d - 00000000000000b2 │ Section 5
+    6 │ 00000000000000b2 - 00000000000000b8 │ Section 6
+    7 │ 00000000000000b8 - 00000000000000bd │ Section 7
+    8 │ 00000000000000bd - 00000000000000c1 │ Section 8
+    9 │ 00000000000000c1 - 00000000000000d1 │ Section 0
+   10 │ 00000000000000d1 - 00000000000000e6 │ Section 1
+   11 │ 00000000000000e6 - 0000000000000101 │ Section 2
+   12 │ 0000000000000101 - 0000000000000124 │ Section 3
+   13 │ 0000000000000124 - 000000000000015e │ Section 4
+   14 │ 000000000000015e - 0000000000000173 │ Section 5
+   15 │ 0000000000000173 - 0000000000000179 │ Section 6
+   16 │ 0000000000000179 - 000000000000017e │ Section 7
+   17 │ 000000000000017e - 0000000000000182 │ Section 8
+   18 │ 0000000000000182 - 0000000000000192 │ Section 0
+   19 │ 0000000000000192 - 00000000000001a7 │ Section 1
+   20 │ 00000000000001a7 - 00000000000001c2 │ Section 2
+   21 │ 00000000000001c2 - 00000000000001e5 │ Section 3
+   22 │ 00000000000001e5 - 000000000000021f │ Section 4
+   23 │ 000000000000021f - 0000000000000234 │ Section 5
+   24 │ 0000000000000234 - 000000000000023a │ Section 6
+   25 │ 000000000000023a - 000000000000023f │ Section 7
+   26 │ 000000000000023f - 0000000000000243 │ Section 8
+
+SubMessages:
+      id │    S2    S3    S4    S5    S6    S7 │ Tmpl3   Tmpl4   Tmpl5  
+     0.0 │     2     3     4     5     6     7 │ 3.101   4.8     5.0    
+     1.0 │    11    12    13    14    15    16 │ 3.101   4.8     5.0    
+     2.0 │    20    21    22    23    24    25 │ 3.101   4.8     5.0    
+
+Templates:
+3.101    - General unstructured grid
+4.8      - Average, accumulation, extreme values or other statistically processed values at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval
+5.0      - Grid point data - simple packing
 "
     ),
     (

--- a/tests/cli/commands/list.rs
+++ b/tests/cli/commands/list.rs
@@ -89,6 +89,16 @@ test_display_with_no_options! {
 "
     ),
     (
+        displaying_grib2_with_multiple_messages,
+        utils::testdata::grib2::multi_message_data(3)?,
+        Vec::<&str>::new(),
+        "      id │ Parameter                       Generating process  Forecast time 1st fixed surface 2nd fixed surface |   #points (nan/total)
+     0.0 │ Total precipitation rate        Forecast                    0 [m]                 0               NaN |          0/   2949120
+     1.0 │ Total precipitation rate        Forecast                    0 [m]                 0               NaN |          0/   2949120
+     2.0 │ Total precipitation rate        Forecast                    0 [m]                 0               NaN |          0/   2949120
+"
+    ),
+    (
         displaying_grib2_with_multiple_submessages_with_opt_d,
         utils::testdata::grib2::jma_tornado_nowcast()?,
         vec!["-d"],
@@ -218,6 +228,67 @@ Product:                                Analysis or forecast at a horizontal lev
   2nd Scaled Value:                     Missing
 Data Representation:                    Run length packing with level values
   Number of represented values:         86016
+
+"
+    ),
+    (
+        displaying_grib2_with_multiple_messages_with_opt_d,
+        utils::testdata::grib2::multi_message_data(3)?,
+        vec!["-d"],
+        "\
+0.0
+Grid:                                   General unstructured grid
+  Number of points:                     2949120
+Product:                                Average, accumulation, extreme values or other statistically processed values at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval
+  Parameter Category:                   Moisture
+  Parameter:                            Total precipitation rate
+  Generating Proceess:                  Forecast
+  Forecast Time:                        0
+  Forecast Time Unit:                   Minute
+  1st Fixed Surface Type:               Ground or water surface
+  1st Scale Factor:                     0
+  1st Scaled Value:                     0
+  2nd Fixed Surface Type:               code '255' is not implemented
+  2nd Scale Factor:                     Missing
+  2nd Scaled Value:                     Missing
+Data Representation:                    Grid point data - simple packing
+  Number of represented values:         2949120
+
+1.0
+Grid:                                   General unstructured grid
+  Number of points:                     2949120
+Product:                                Average, accumulation, extreme values or other statistically processed values at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval
+  Parameter Category:                   Moisture
+  Parameter:                            Total precipitation rate
+  Generating Proceess:                  Forecast
+  Forecast Time:                        0
+  Forecast Time Unit:                   Minute
+  1st Fixed Surface Type:               Ground or water surface
+  1st Scale Factor:                     0
+  1st Scaled Value:                     0
+  2nd Fixed Surface Type:               code '255' is not implemented
+  2nd Scale Factor:                     Missing
+  2nd Scaled Value:                     Missing
+Data Representation:                    Grid point data - simple packing
+  Number of represented values:         2949120
+
+2.0
+Grid:                                   General unstructured grid
+  Number of points:                     2949120
+Product:                                Average, accumulation, extreme values or other statistically processed values at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval
+  Parameter Category:                   Moisture
+  Parameter:                            Total precipitation rate
+  Generating Proceess:                  Forecast
+  Forecast Time:                        0
+  Forecast Time Unit:                   Minute
+  1st Fixed Surface Type:               Ground or water surface
+  1st Scale Factor:                     0
+  1st Scaled Value:                     0
+  2nd Fixed Surface Type:               code '255' is not implemented
+  2nd Scale Factor:                     Missing
+  2nd Scaled Value:                     Missing
+Data Representation:                    Grid point data - simple packing
+  Number of represented values:         2949120
 
 "
     ),

--- a/tests/cli/utils/testdata.rs
+++ b/tests/cli/utils/testdata.rs
@@ -1,5 +1,6 @@
 use crate::utils::{cat_to_tempfile, unxz_as_bytes, unxz_to_tempfile};
-use std::io::{self, Write};
+use std::fs::File;
+use std::io::{self, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
@@ -37,6 +38,10 @@ pub(crate) mod grib2 {
         testdata_dir().join("CMC_glb_TMP_ISBL_1_latlon.24x.24_2021051800_P000.grib2")
     }
 
+    fn dwd_icon_file() -> PathBuf {
+        testdata_dir().join("icon_global_icosahedral_single-level_2021112018_000_TOT_PREC.grib2")
+    }
+
     pub(crate) fn jma_kousa() -> Result<NamedTempFile, io::Error> {
         unxz_to_tempfile(
             testdata_dir()
@@ -63,6 +68,20 @@ pub(crate) mod grib2 {
             testdata_dir()
                 .join("Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.bin.xz"),
         )
+    }
+
+    pub(crate) fn multi_message_data(n: usize) -> Result<NamedTempFile, io::Error> {
+        let mut buf = Vec::new();
+        let mut out = NamedTempFile::new()?;
+
+        let f = File::open(dwd_icon_file())?;
+        let mut f = BufReader::new(f);
+        f.read_to_end(&mut buf)?;
+        for _ in 0..n {
+            out.write_all(&buf)?;
+        }
+
+        Ok(out)
     }
 }
 


### PR DESCRIPTION
This PR adds multi-message data support for CLI.
Regarding support for multi-message data, this is not a complete end, as there are still some usability and data accessibility issues in the library crate.

Part of #13.