### PR TITLE
Introduce SubMessage::decode() and remove Grib2::get_values()

### DIFF
--- a/cli/src/bin/gribber/commands/decode.rs
+++ b/cli/src/bin/gribber/commands/decode.rs
@@ -39,8 +39,12 @@ pub fn exec(args: &ArgMatches) -> Result<()> {
     let file_name = args.get_one::<PathBuf>("FILE").unwrap();
     let grib = cli::grib(file_name)?;
     let index = args.get_one::<String>("INDEX").unwrap();
-    let cli::CliMessageIndex(index) = index.parse()?;
-    let values = grib.get_values(index)?;
+    let cli::CliMessageIndex(message_index) = index.parse()?;
+    let (_, submessage) = grib
+        .iter()
+        .find(|(index, _)| *index == message_index)
+        .ok_or_else(|| anyhow::anyhow!("no such index: {}.{}", message_index.0, message_index.1))?;
+    let values = submessage.decode()?;
 
     if args.contains_id("big-endian") {
         let out_path = args.get_one::<PathBuf>("big-endian").unwrap();

--- a/cli/src/bin/gribber/commands/inspect.rs
+++ b/cli/src/bin/gribber/commands/inspect.rs
@@ -58,16 +58,16 @@ pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
     Ok(())
 }
 
-struct InspectView<'i> {
-    items: Vec<InspectItem<'i>>,
+struct InspectView<'i, R> {
+    items: Vec<InspectItem<'i, R>>,
 }
 
-impl<'i> InspectView<'i> {
+impl<'i, R> InspectView<'i, R> {
     fn new() -> Self {
         Self { items: Vec::new() }
     }
 
-    fn add(&mut self, item: InspectItem<'i>) {
+    fn add(&mut self, item: InspectItem<'i, R>) {
         self.items.push(item);
     }
 
@@ -76,7 +76,7 @@ impl<'i> InspectView<'i> {
     }
 }
 
-impl<'i> cli::PredictableNumLines for InspectView<'i> {
+impl<'i, R> cli::PredictableNumLines for InspectView<'i, R> {
     fn num_lines(&self) -> usize {
         let mut count = 0;
         for item in self.items.iter() {
@@ -90,7 +90,7 @@ impl<'i> cli::PredictableNumLines for InspectView<'i> {
     }
 }
 
-impl<'i> Display for InspectView<'i> {
+impl<'i, R> Display for InspectView<'i, R> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let with_header = self.with_headers();
         let mut items = self.items.iter().peekable();
@@ -121,13 +121,13 @@ impl<'i> Display for InspectView<'i> {
     }
 }
 
-enum InspectItem<'i> {
+enum InspectItem<'i, R> {
     Sections(InspectSectionsItem<'i>),
-    SubMessages(InspectSubMessagesItem<'i>),
+    SubMessages(InspectSubMessagesItem<'i, R>),
     Templates(InspectTemplatesItem),
 }
 
-impl<'i> InspectItem<'i> {
+impl<'i, R> InspectItem<'i, R> {
     fn title(&self) -> &'static str {
         match self {
             InspectItem::Sections(_) => "Sections",
@@ -175,12 +175,12 @@ impl<'i> Display for InspectSectionsItem<'i> {
     }
 }
 
-struct InspectSubMessagesItem<'i> {
-    data: SubmessageIterator<'i>,
+struct InspectSubMessagesItem<'i, R> {
+    data: SubmessageIterator<'i, R>,
 }
 
-impl<'i> InspectSubMessagesItem<'i> {
-    fn new(data: SubmessageIterator<'i>) -> Self {
+impl<'i, R> InspectSubMessagesItem<'i, R> {
+    fn new(data: SubmessageIterator<'i, R>) -> Self {
         Self { data }
     }
 
@@ -190,7 +190,7 @@ impl<'i> InspectSubMessagesItem<'i> {
     }
 }
 
-impl<'i> Display for InspectSubMessagesItem<'i> {
+impl<'i, R> Display for InspectSubMessagesItem<'i, R> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         fn format_section_index(s: &SubMessageSection) -> String {
             format!("{:>5}", s.index.to_string())

--- a/cli/src/bin/gribber/commands/inspect.rs
+++ b/cli/src/bin/gribber/commands/inspect.rs
@@ -219,7 +219,7 @@ impl<'i, R> Display for InspectSubMessagesItem<'i, R> {
         let style = Style::new().bold();
         writeln!(f, "{}", style.apply_to(header.trim_end()))?;
 
-        for (i, submessage) in self.data.clone() {
+        for (i, submessage) in &self.data {
             let id = format!("{}.{}", i.0, i.1);
             writeln!(
                 f,

--- a/cli/src/bin/gribber/commands/list.rs
+++ b/cli/src/bin/gribber/commands/list.rs
@@ -30,18 +30,18 @@ pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
     Ok(())
 }
 
-struct ListView<'i> {
-    data: SubmessageIterator<'i>,
+struct ListView<'i, R> {
+    data: SubmessageIterator<'i, R>,
     mode: ListViewMode,
 }
 
-impl<'i> ListView<'i> {
-    fn new(data: SubmessageIterator<'i>, mode: ListViewMode) -> Self {
+impl<'i, R> ListView<'i, R> {
+    fn new(data: SubmessageIterator<'i, R>, mode: ListViewMode) -> Self {
         Self { data, mode }
     }
 }
 
-impl<'i> cli::PredictableNumLines for ListView<'i> {
+impl<'i, R> cli::PredictableNumLines for ListView<'i, R> {
     fn num_lines(&self) -> usize {
         match self.mode {
             ListViewMode::OneLine => {
@@ -58,7 +58,7 @@ impl<'i> cli::PredictableNumLines for ListView<'i> {
     }
 }
 
-impl<'i> Display for ListView<'i> {
+impl<'i, R> Display for ListView<'i, R> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let entries = self.data.clone();
         match self.mode {

--- a/cli/src/bin/gribber/commands/list.rs
+++ b/cli/src/bin/gribber/commands/list.rs
@@ -60,7 +60,7 @@ impl<'i, R> cli::PredictableNumLines for ListView<'i, R> {
 
 impl<'i, R> Display for ListView<'i, R> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let entries = self.data.clone();
+        let entries = &self.data;
         match self.mode {
             ListViewMode::OneLine => {
                 let header = format!(

--- a/examples/decode_surface.rs
+++ b/examples/decode_surface.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn decode_surface<P>(path: P, index: (usize, usize)) -> Result<(), Box<dyn Error>>
+fn decode_surface<P>(path: P, message_index: (usize, usize)) -> Result<(), Box<dyn Error>>
 where
     P: AsRef<Path>,
 {
@@ -33,9 +33,15 @@ where
     // Read with the reader.
     let grib2 = grib::from_reader(f)?;
 
+    // Find the target submessage.
+    let (_index, submessage) = grib2
+        .iter()
+        .find(|(index, _)| *index == message_index)
+        .ok_or_else(|| "no such index")?;
+
     // There are various methods available for compressing GRIB2 data, but some are
     // not yet supported by this library and may return errors.
-    let values = grib2.get_values(index)?;
+    let values = submessage.decode()?;
 
     // Iterate over decoded values.
     for value in values.iter() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -294,6 +294,18 @@ impl<'a, R> Iterator for SubmessageIterator<'a, R> {
     }
 }
 
+impl<'a, R> IntoIterator for &'a SubmessageIterator<'a, R> {
+    type Item = (MessageIndex, SubMessage<'a, R>);
+    type IntoIter = SubmessageIterator<'a, R>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SubmessageIterator {
+            context: self.context,
+            pos: self.pos,
+        }
+    }
+}
+
 pub struct SubMessage<'a, R>(
     pub SubMessageSection<'a>,
     pub SubMessageSection<'a>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -210,22 +210,6 @@ impl<R: Grib2Read> Grib2<R> {
         Grib2::<SeekableGrib2Reader<SR>>::read(r)
     }
 
-    /// Decodes grid values of a surface specified by `message_index`.
-    pub fn get_values(&self, message_index: MessageIndex) -> Result<Box<[f32]>, GribError> {
-        let (_, submessage) = self
-            .iter()
-            .find(|(index, _)| *index == message_index)
-            .ok_or_else(|| {
-                GribError::OperationError(format!(
-                    "no such index: {}.{}",
-                    message_index.0, message_index.1
-                ))
-            })?;
-
-        let values = decoders::dispatch(submessage)?;
-        Ok(values)
-    }
-
     pub fn list_templates(&self) -> Vec<TemplateInfo> {
         get_templates(&self.sections)
     }
@@ -426,6 +410,7 @@ Data Representation:                    {}
 }
 
 impl<'a, R: Grib2Read> SubMessage<'a, R> {
+    /// Decodes grid values of `self`.
     pub fn decode(self) -> Result<Box<[f32]>, GribError> {
         let values = decoders::dispatch(self)?;
         Ok(values)

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -146,9 +146,13 @@ mod tests {
         let f = Cursor::new(buf);
 
         let grib = from_reader(f).unwrap();
-        let index = (0, 0);
+        let message_index = (0, 0);
+        let (_, submessage) = grib
+            .iter()
+            .find(|(index, _)| *index == message_index)
+            .unwrap();
         // Runs `SimplePackingDecoder::decode()` internally.
-        let actual = grib.get_values(index).unwrap();
+        let actual = submessage.decode().unwrap();
         let expected = vec![0f32; 0x002d0000].into_boxed_slice();
         assert_eq!(actual, expected);
     }


### PR DESCRIPTION
This PR introduces `SubMessage::decode()` and removes `Grib2::get_values()`.

### Background of this change

Until now, it was necessary to use `Grib2::get_values()` to call a decoding function on data. However, it does not work well with other APIs, especially the submessage iterators that are being enhanced recently.

Submessage iterators make it easy to discover and filter submessages. However, decoding found submessages is inefficient because users need to pass the indices of the found submessages to `Grib2::get_values()` one by one.

This PR adds a `decode()` method to the submessage itself, allowing users to directly decode the submessages identified using the iterator.