### PR TITLE
Return an iterator instead of a boxed slice when decoding

### DIFF
--- a/examples/decode_surface.rs
+++ b/examples/decode_surface.rs
@@ -39,12 +39,16 @@ where
         .find(|(index, _)| *index == message_index)
         .ok_or_else(|| "no such index")?;
 
+    // Prepare a decoder.
+    let decoder = grib::decoders::Grib2SubmessageDecoder::from(submessage)?;
+
+    // Actually dispatch a decoding process and get an iterator of decoded values.
     // There are various methods available for compressing GRIB2 data, but some are
     // not yet supported by this library and may return errors.
-    let values = submessage.decode()?;
+    let values = decoder.dispatch()?;
 
     // Iterate over decoded values.
-    for value in values.iter() {
+    for value in values {
         println!("{}", value);
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,6 @@ use crate::codetables::{
     CodeTable3_1, CodeTable4_0, CodeTable4_1, CodeTable4_2, CodeTable4_3, CodeTable5_0, Lookup,
 };
 use crate::datatypes::*;
-use crate::decoders;
 use crate::error::*;
 use crate::parser::Grib2SubmessageIndexStream;
 use crate::reader::{Grib2Read, Grib2SectionStream, SeekableGrib2Reader, SECT8_ES_SIZE};
@@ -406,15 +405,6 @@ Data Representation:                    {}
             self.5.describe().unwrap_or_default(),
             self.repr_def().num_points(),
         )
-    }
-}
-
-impl<'a, R: Grib2Read> SubMessage<'a, R> {
-    /// Decodes grid values of `self`.
-    pub fn decode(self) -> Result<Box<[f32]>, GribError> {
-        let decoder = decoders::Grib2SubmessageDecoder::from(self)?;
-        let values = decoder.dispatch()?;
-        Ok(values)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -412,7 +412,8 @@ Data Representation:                    {}
 impl<'a, R: Grib2Read> SubMessage<'a, R> {
     /// Decodes grid values of `self`.
     pub fn decode(self) -> Result<Box<[f32]>, GribError> {
-        let values = decoders::dispatch(self)?;
+        let decoder = decoders::Grib2SubmessageDecoder::from(self)?;
+        let values = decoder.dispatch()?;
         Ok(values)
     }
 }

--- a/src/decoders/common.rs
+++ b/src/decoders/common.rs
@@ -90,10 +90,10 @@ impl Grib2SubmessageDecoder {
         &self,
     ) -> Result<Grib2DecodedValues<impl Iterator<Item = f32> + '_>, GribError> {
         let decoder = match self.template_num {
-            0 => Grib2SubmessageDecoderWrapper::Template0(simple::decode(self)?),
-            3 => Grib2SubmessageDecoderWrapper::Template3(complex::decode(self)?),
-            40 => Grib2SubmessageDecoderWrapper::Template40(jpeg2000::decode(self)?),
-            200 => Grib2SubmessageDecoderWrapper::Template200(run_length::decode(self)?),
+            0 => Grib2SubmessageDecoderIteratorWrapper::Template0(simple::decode(self)?),
+            3 => Grib2SubmessageDecoderIteratorWrapper::Template3(complex::decode(self)?),
+            40 => Grib2SubmessageDecoderIteratorWrapper::Template40(jpeg2000::decode(self)?),
+            200 => Grib2SubmessageDecoderIteratorWrapper::Template200(run_length::decode(self)?),
             _ => {
                 return Err(GribError::DecodeError(
                     DecodeError::TemplateNumberUnsupported,
@@ -125,14 +125,14 @@ where
     }
 }
 
-pub(crate) enum Grib2SubmessageDecoderWrapper<I, J, K> {
+enum Grib2SubmessageDecoderIteratorWrapper<I, J, K> {
     Template0(SimplePackingDecodeIteratorWrapper<I>),
     Template3(SimplePackingDecodeIterator<J>),
     Template40(SimplePackingDecodeIterator<K>),
     Template200(std::vec::IntoIter<f32>),
 }
 
-impl<I, J, K> Iterator for Grib2SubmessageDecoderWrapper<I, J, K>
+impl<I, J, K> Iterator for Grib2SubmessageDecoderIteratorWrapper<I, J, K>
 where
     I: Iterator,
     <I as Iterator>::Item: ToPrimitive,

--- a/src/decoders/common.rs
+++ b/src/decoders/common.rs
@@ -11,6 +11,33 @@ use crate::reader::Grib2Read;
 use num::ToPrimitive;
 
 /// Decoder for grid point values of GRIB2 submessages.
+///
+/// # Examples
+/// ```
+/// use grib::decoders::Grib2SubmessageDecoder;
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let f =
+///         std::fs::File::open("testdata/CMC_glb_TMP_ISBL_1_latlon.24x.24_2021051800_P000.grib2")?;
+///     let f = std::io::BufReader::new(f);
+///     let grib2 = grib::from_reader(f)?;
+///     let (_index, first_submessage) = grib2.iter().next().unwrap();
+///
+///     let decoder = Grib2SubmessageDecoder::from(first_submessage)?;
+///     let mut decoded = decoder.dispatch()?;
+///     assert_eq!(decoded.size_hint(), (1126500, Some(1126500)));
+///
+///     let first_value = decoded.next();
+///     assert_eq!(first_value.map(|f| f.round()), Some(236.0_f32));
+///
+///     let last_value = decoded.nth(1126498);
+///     assert_eq!(last_value.map(|f| f.round()), Some(286.0_f32));
+///
+///     let next_to_last_value = decoded.next();
+///     assert_eq!(next_to_last_value, None);
+///     Ok(())
+/// }
+/// ```
 pub struct Grib2SubmessageDecoder {
     num_points_total: usize,
     pub(crate) num_points_encoded: usize,

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -18,7 +18,7 @@ pub(crate) struct ComplexPackingDecoder {}
 impl ComplexPackingDecoder {
     pub(crate) fn decode(
         encoded: Grib2SubmessageEncoded,
-    ) -> Result<impl Iterator<Item = f32>, GribError> {
+    ) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32>>, GribError> {
         let sect5_data = encoded.sect5_payload;
         let ref_val = read_as!(f32, sect5_data, 6);
         let exp = read_as!(u16, sect5_data, 10).as_grib_int();

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -13,9 +13,9 @@ pub enum ComplexPackingDecodeError {
     LengthMismatch,
 }
 
-pub(crate) fn decode<'a>(
-    target: &'a Grib2SubmessageDecoder,
-) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32> + 'a>, GribError> {
+pub(crate) fn decode(
+    target: &Grib2SubmessageDecoder,
+) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32> + '_>, GribError> {
     let sect5_data = &target.sect5_payload;
     let ref_val = read_as!(f32, sect5_data, 6);
     let exp = read_as!(u16, sect5_data, 10).as_grib_int();

--- a/src/decoders/jpeg2000/mod.rs
+++ b/src/decoders/jpeg2000/mod.rs
@@ -23,7 +23,7 @@ pub(crate) struct Jpeg2000CodeStreamDecoder {}
 impl Jpeg2000CodeStreamDecoder {
     pub(crate) fn decode(
         encoded: Grib2SubmessageEncoded,
-    ) -> Result<impl Iterator<Item = f32>, GribError> {
+    ) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32>>, GribError> {
         let sect5_data = encoded.sect5_payload;
         let ref_val = read_as!(f32, sect5_data, 6);
         let exp = read_as!(u16, sect5_data, 10).as_grib_int();

--- a/src/decoders/jpeg2000/mod.rs
+++ b/src/decoders/jpeg2000/mod.rs
@@ -18,34 +18,30 @@ pub enum Jpeg2000CodeStreamDecodeError {
     LengthMismatch,
 }
 
-pub(crate) struct Jpeg2000CodeStreamDecoder {}
+pub(crate) fn decode(
+    encoded: Grib2SubmessageEncoded,
+) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32>>, GribError> {
+    let sect5_data = encoded.sect5_payload;
+    let ref_val = read_as!(f32, sect5_data, 6);
+    let exp = read_as!(u16, sect5_data, 10).as_grib_int();
+    let dig = read_as!(u16, sect5_data, 12).as_grib_int();
+    //let nbit = read_as!(u8, sect5_data, 14);
+    let value_type = read_as!(u8, sect5_data, 15);
 
-impl Jpeg2000CodeStreamDecoder {
-    pub(crate) fn decode(
-        encoded: Grib2SubmessageEncoded,
-    ) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32>>, GribError> {
-        let sect5_data = encoded.sect5_payload;
-        let ref_val = read_as!(f32, sect5_data, 6);
-        let exp = read_as!(u16, sect5_data, 10).as_grib_int();
-        let dig = read_as!(u16, sect5_data, 12).as_grib_int();
-        //let nbit = read_as!(u8, sect5_data, 14);
-        let value_type = read_as!(u8, sect5_data, 15);
-
-        if value_type != 0 {
-            return Err(GribError::DecodeError(
-                DecodeError::SimplePackingDecodeError(
-                    SimplePackingDecodeError::OriginalFieldValueTypeNotSupported,
-                ),
-            ));
-        }
-
-        let stream = Stream::from_bytes(&encoded.sect7_payload)
-            .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;
-        let jp2_unpacked = decode_jp2(stream)
-            .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;
-        let decoder = SimplePackingDecodeIterator::new(jp2_unpacked, ref_val, exp, dig);
-        Ok(decoder)
+    if value_type != 0 {
+        return Err(GribError::DecodeError(
+            DecodeError::SimplePackingDecodeError(
+                SimplePackingDecodeError::OriginalFieldValueTypeNotSupported,
+            ),
+        ));
     }
+
+    let stream = Stream::from_bytes(&encoded.sect7_payload)
+        .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;
+    let jp2_unpacked = decode_jp2(stream)
+        .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;
+    let decoder = SimplePackingDecodeIterator::new(jp2_unpacked, ref_val, exp, dig);
+    Ok(decoder)
 }
 
 fn decode_jp2(stream: Stream) -> Result<impl Iterator<Item = i32>, Jpeg2000CodeStreamDecodeError> {

--- a/src/decoders/jpeg2000/mod.rs
+++ b/src/decoders/jpeg2000/mod.rs
@@ -19,9 +19,9 @@ pub enum Jpeg2000CodeStreamDecodeError {
 }
 
 pub(crate) fn decode(
-    encoded: Grib2SubmessageEncoded,
+    target: &Grib2SubmessageDecoder,
 ) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32>>, GribError> {
-    let sect5_data = encoded.sect5_payload;
+    let sect5_data = &target.sect5_payload;
     let ref_val = read_as!(f32, sect5_data, 6);
     let exp = read_as!(u16, sect5_data, 10).as_grib_int();
     let dig = read_as!(u16, sect5_data, 12).as_grib_int();
@@ -36,7 +36,7 @@ pub(crate) fn decode(
         ));
     }
 
-    let stream = Stream::from_bytes(&encoded.sect7_payload)
+    let stream = Stream::from_bytes(&target.sect7_payload)
         .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;
     let jp2_unpacked = decode_jp2(stream)
         .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;

--- a/src/decoders/run_length.rs
+++ b/src/decoders/run_length.rs
@@ -17,7 +17,7 @@ pub(crate) struct RunLengthEncodingDecoder {}
 impl RunLengthEncodingDecoder {
     pub(crate) fn decode(
         encoded: Grib2SubmessageEncoded,
-    ) -> Result<impl Iterator<Item = f32>, GribError> {
+    ) -> Result<std::vec::IntoIter<f32>, GribError> {
         let sect5_data = encoded.sect5_payload;
         let nbit = read_as!(u8, sect5_data, 6);
         let maxv = read_as!(u16, sect5_data, 7);

--- a/src/decoders/run_length.rs
+++ b/src/decoders/run_length.rs
@@ -12,52 +12,48 @@ pub enum RunLengthEncodingDecodeError {
     InvalidLevelValue(u16),
 }
 
-pub(crate) struct RunLengthEncodingDecoder {}
+pub(crate) fn decode(
+    encoded: Grib2SubmessageEncoded,
+) -> Result<std::vec::IntoIter<f32>, GribError> {
+    let sect5_data = encoded.sect5_payload;
+    let nbit = read_as!(u8, sect5_data, 6);
+    let maxv = read_as!(u16, sect5_data, 7);
+    let max_level = read_as!(u16, sect5_data, 9);
+    let num_digits = read_as!(u8, sect5_data, 11);
 
-impl RunLengthEncodingDecoder {
-    pub(crate) fn decode(
-        encoded: Grib2SubmessageEncoded,
-    ) -> Result<std::vec::IntoIter<f32>, GribError> {
-        let sect5_data = encoded.sect5_payload;
-        let nbit = read_as!(u8, sect5_data, 6);
-        let maxv = read_as!(u16, sect5_data, 7);
-        let max_level = read_as!(u16, sect5_data, 9);
-        let num_digits = read_as!(u8, sect5_data, 11);
+    let mut level_map = Vec::with_capacity(max_level.into());
+    level_map.push(f32::NAN);
+    let mut pos = 12;
 
-        let mut level_map = Vec::with_capacity(max_level.into());
-        level_map.push(f32::NAN);
-        let mut pos = 12;
-
-        for _ in 0..max_level {
-            let val: f32 = read_as!(u16, sect5_data, pos).into();
-            let num_digits: i32 = num_digits.into();
-            let factor = 10_f32.powi(-num_digits);
-            let val = val * factor;
-            level_map.push(val);
-            pos += std::mem::size_of::<u16>();
-        }
-
-        let decoded_levels = rleunpack(
-            encoded.sect7_payload.to_vec(),
-            nbit,
-            maxv,
-            Some(encoded.num_points_encoded),
-        )
-        .map_err(DecodeError::RunLengthEncodingDecodeError)?;
-
-        let level_to_value = |level: &u16| -> Result<f32, DecodeError> {
-            let index: usize = (*level).into();
-            level_map
-                .get(index)
-                .copied()
-                .ok_or(DecodeError::RunLengthEncodingDecodeError(
-                    RunLengthEncodingDecodeError::InvalidLevelValue(*level),
-                ))
-        };
-
-        let decoded: Result<Vec<_>, _> = (*decoded_levels).iter().map(level_to_value).collect();
-        Ok(decoded?.into_iter())
+    for _ in 0..max_level {
+        let val: f32 = read_as!(u16, sect5_data, pos).into();
+        let num_digits: i32 = num_digits.into();
+        let factor = 10_f32.powi(-num_digits);
+        let val = val * factor;
+        level_map.push(val);
+        pos += std::mem::size_of::<u16>();
     }
+
+    let decoded_levels = rleunpack(
+        encoded.sect7_payload.to_vec(),
+        nbit,
+        maxv,
+        Some(encoded.num_points_encoded),
+    )
+    .map_err(DecodeError::RunLengthEncodingDecodeError)?;
+
+    let level_to_value = |level: &u16| -> Result<f32, DecodeError> {
+        let index: usize = (*level).into();
+        level_map
+            .get(index)
+            .copied()
+            .ok_or(DecodeError::RunLengthEncodingDecodeError(
+                RunLengthEncodingDecodeError::InvalidLevelValue(*level),
+            ))
+    };
+
+    let decoded: Result<Vec<_>, _> = (*decoded_levels).iter().map(level_to_value).collect();
+    Ok(decoded?.into_iter())
 }
 
 // Since maxv is represented as a 16-bit integer, values are 16 bits or less.

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -39,9 +39,9 @@ pub enum SimplePackingDecodeError {
     LengthMismatch,
 }
 
-pub(crate) fn decode<'a>(
-    target: &'a Grib2SubmessageDecoder,
-) -> Result<SimplePackingDecodeIteratorWrapper<impl Iterator<Item = u32> + 'a>, GribError> {
+pub(crate) fn decode(
+    target: &Grib2SubmessageDecoder,
+) -> Result<SimplePackingDecodeIteratorWrapper<impl Iterator<Item = u32> + '_>, GribError> {
     let sect5_data = &target.sect5_payload;
     let ref_val = read_as!(f32, sect5_data, 6);
     let exp = read_as!(u16, sect5_data, 10).as_grib_int();

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -44,7 +44,7 @@ pub(crate) struct SimplePackingDecoder {}
 impl SimplePackingDecoder {
     pub(crate) fn decode(
         encoded: Grib2SubmessageEncoded,
-    ) -> Result<impl Iterator<Item = f32>, GribError> {
+    ) -> Result<SimplePackingDecodeIteratorWrapper<impl Iterator<Item = u32>>, GribError> {
         let sect5_data = encoded.sect5_payload;
         let ref_val = read_as!(f32, sect5_data, 6);
         let exp = read_as!(u16, sect5_data, 10).as_grib_int();

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -154,9 +154,10 @@ mod tests {
             .iter()
             .find(|(index, _)| *index == message_index)
             .unwrap();
+        let decoder = Grib2SubmessageDecoder::from(submessage).unwrap();
         // Runs `SimplePackingDecoder::decode()` internally.
-        let actual = submessage.decode().unwrap();
-        let expected = vec![0f32; 0x002d0000].into_boxed_slice();
+        let actual = decoder.dispatch().unwrap().collect::<Vec<_>>();
+        let expected = vec![0f32; 0x002d0000];
         assert_eq!(actual, expected);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,15 +33,15 @@ macro_rules! read_as {
 pub(crate) use read_as;
 
 #[derive(Clone)]
-pub(crate) struct NBitwiseIterator {
-    slice: Vec<u8>,
+pub(crate) struct NBitwiseIterator<'a> {
+    slice: &'a [u8],
     size: usize,
     pos: usize,
     offset: usize,
 }
 
-impl NBitwiseIterator {
-    pub(crate) fn new(slice: Vec<u8>, size: usize) -> Self {
+impl<'a> NBitwiseIterator<'a> {
+    pub(crate) fn new(slice: &'a [u8], size: usize) -> Self {
         Self {
             slice,
             size,
@@ -58,7 +58,7 @@ impl NBitwiseIterator {
     }
 }
 
-impl Iterator for NBitwiseIterator {
+impl<'a> Iterator for NBitwiseIterator<'a> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
@@ -142,7 +142,7 @@ mod tests {
     fn nbitwise_iterator_u2() {
         let slice: [u8; 5] = [0, 255, 255, 0, 0];
 
-        let mut iter = NBitwiseIterator::new(slice.to_vec(), 2);
+        let mut iter = NBitwiseIterator::new(&slice, 2);
         assert_eq!(iter.next(), Some(0b00));
         assert_eq!(iter.next(), Some(0b00));
         assert_eq!(iter.next(), Some(0b00));
@@ -155,7 +155,7 @@ mod tests {
     fn nbitwise_iterator_u5() {
         let slice: [u8; 5] = [0, 255, 255, 0, 0];
 
-        let mut iter = NBitwiseIterator::new(slice.to_vec(), 5);
+        let mut iter = NBitwiseIterator::new(&slice, 5);
         assert_eq!(iter.next(), Some(0b00000));
         assert_eq!(iter.next(), Some(0b00011));
         assert_eq!(iter.next(), Some(0b11111));
@@ -172,7 +172,7 @@ mod tests {
     fn nbitwise_iterator_u9() {
         let slice: [u8; 5] = [0, 255, 255, 0, 0];
 
-        let mut iter = NBitwiseIterator::new(slice.to_vec(), 9);
+        let mut iter = NBitwiseIterator::new(&slice, 9);
         assert_eq!(iter.next(), Some(0b000000001));
         assert_eq!(iter.next(), Some(0b111111111));
         assert_eq!(iter.next(), Some(0b111111000));
@@ -184,7 +184,7 @@ mod tests {
     fn nbitwise_iterator_u13() {
         let slice: [u8; 5] = [0, 255, 255, 0, 0];
 
-        let mut iter = NBitwiseIterator::new(slice.to_vec(), 13);
+        let mut iter = NBitwiseIterator::new(&slice, 13);
         assert_eq!(iter.next(), Some(0b0000000011111));
         assert_eq!(iter.next(), Some(0b1111111111100));
         assert_eq!(iter.next(), Some(0b0000000000000));
@@ -195,7 +195,7 @@ mod tests {
     fn nbitwise_iterator_with_offset() {
         let slice: [u8; 5] = [0, 255, 255, 0, 0];
 
-        let mut iter = NBitwiseIterator::new(slice.to_vec(), 2).with_offset(7);
+        let mut iter = NBitwiseIterator::new(&slice, 2).with_offset(7);
         assert_eq!(iter.next(), Some(0b01));
     }
 
@@ -203,7 +203,7 @@ mod tests {
     fn nbitwise_iterator_empty() {
         let slice: [u8; 0] = [];
 
-        let mut iter = NBitwiseIterator::new(slice.to_vec(), 0);
+        let mut iter = NBitwiseIterator::new(&slice, 0);
         assert_eq!(iter.next(), None);
     }
 }


### PR DESCRIPTION
This PR introduces `Grib2SubmessageDecoder`, which replaces `SubMessage::decode()`, to return an iterator instead of a boxed slice when decoding.

### Background of this change

Until now, a boxed slice was returned when decoding. However, in many cases, users loop over the return values. Also, they often want to use a vector as a data structure to store that collection of values.

Now, by returning an iterator in decoding, users can loop directly over values or store the collection of values in a data structure of their choice.

A slight speedup is also achieved. Until now, while using iterators in the decoding process, the results of decoding were temporarily stored in a vector and passed to subsequent processing or finally stored in a boxed slice. This time, we were able to eliminate such unnecessary storage (although a small part of the process still uses vectors in the process).

The use of iterators for decoded grid point values is also a preparation for coupling with geographic coordinates, which we plan to implement in the future.