### PR TITLE
Chrono v0.4.23 migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ categories = ["science"]
 keywords = ["GRIB", "weather", "meteorology"]
 
 [dependencies]
-chrono = "0.4.20" # avoiding vulnerable time 0.1 dependency
+chrono = "0.4.23" # `TimeZone::with_ymd_and_hms` needed
 num = "0.4"
 num_enum = "0.5"
 openjpeg-sys = "1.0.5" # avoiding 1.0.2/1.0.4

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+chrono = "0.4.23"
 clap = { version = "4", features = ["cargo"] }
 console = "0.15"
 grib = { path = "..", version = "=0.5.0" }

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -65,7 +65,7 @@ Message {}
             identification.local_table_version(),
             CodeTable1_1.lookup(identification.local_table_version() as usize),
             CodeTable1_2.lookup(identification.ref_time_significance() as usize),
-            identification.ref_time(),
+            identification.ref_time().unwrap(),
             CodeTable1_3.lookup(identification.prod_status() as usize),
             CodeTable1_4.lookup(identification.data_type() as usize)
         )

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use clap::{arg, ArgMatches, Command};
 use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
@@ -27,17 +28,25 @@ pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
         if let (Some(SectionBody::Section0(sect0_body)), Some(SectionBody::Section1(sect1_body))) =
             (&submessage.0.body.body, &submessage.1.body.body)
         {
-            print!("{}", InfoView(message_index.0, sect0_body, sect1_body));
+            print!(
+                "{}",
+                InfoView(
+                    message_index.0,
+                    sect0_body,
+                    sect1_body,
+                    sect1_body.ref_time()?
+                )
+            );
         }
     }
     Ok(())
 }
 
-struct InfoView<'i>(usize, &'i Indicator, &'i Identification);
+struct InfoView<'i>(usize, &'i Indicator, &'i Identification, DateTime<Utc>);
 
 impl<'i> Display for InfoView<'i> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let Self(index, indicator, identification) = self;
+        let Self(index, indicator, identification, ref_time) = self;
         write!(
             f,
             "\
@@ -65,7 +74,7 @@ Message {}
             identification.local_table_version(),
             CodeTable1_1.lookup(identification.local_table_version() as usize),
             CodeTable1_2.lookup(identification.ref_time_significance() as usize),
-            identification.ref_time().unwrap(),
+            ref_time,
             CodeTable1_3.lookup(identification.prod_status() as usize),
             CodeTable1_4.lookup(identification.data_type() as usize)
         )

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -1,4 +1,4 @@
-use chrono::{offset::TimeZone, DateTime, Utc};
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use std::convert::TryInto;
 use std::slice::Iter;
 
@@ -69,15 +69,12 @@ impl Identification {
     }
 
     /// Reference time of data
-    #[inline]
-    pub fn ref_time(&self) -> DateTime<Utc> {
+    pub fn ref_time(&self) -> Result<DateTime<Utc>, GribError> {
         let payload = &self.payload;
-        Utc.ymd(
+        create_date_time(
             read_as!(u16, payload, 7).into(),
             self.payload[9].into(),
             self.payload[10].into(),
-        )
-        .and_hms(
             self.payload[11].into(),
             self.payload[12].into(),
             self.payload[13].into(),
@@ -95,6 +92,25 @@ impl Identification {
     #[inline]
     pub fn data_type(&self) -> u8 {
         self.payload[15]
+    }
+}
+
+#[inline]
+fn create_date_time(
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> Result<DateTime<Utc>, GribError> {
+    let result = Utc.with_ymd_and_hms(year, month, day, hour, minute, second);
+    if let LocalResult::None = result {
+        Err(GribError::InvalidValueError(format!(
+            "invalid date time: {year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"
+        )))
+    } else {
+        Ok(result.unwrap())
     }
 }
 
@@ -377,6 +393,42 @@ pub struct BitMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    macro_rules! test_date_time_creation {
+        ($((
+            $name:ident,
+            $year:expr,
+            $month:expr,
+            $day:expr,
+            $hour:expr,
+            $minute:expr,
+            $second:expr,
+            $ok_expected:expr
+        ),)*) => ($(
+            #[test]
+            fn $name() {
+                let result = create_date_time($year, $month, $day, $hour, $minute, $second);
+                assert_eq!(result.is_ok(), $ok_expected);
+            }
+        )*);
+    }
+
+    test_date_time_creation! {
+        (date_time_creation_for_valid_date_time, 2022, 1, 1, 0, 0, 0, true),
+        (date_time_creation_for_invalid_date, 2022, 11, 31, 0, 0, 0, false),
+        (date_time_creation_for_invalid_time, 2022, 1, 1, 0, 61, 0, false),
+    }
+
+    #[test]
+    fn error_in_date_time_creation() {
+        let result = create_date_time(2022, 11, 31, 0, 0, 0);
+        assert_eq!(
+            result,
+            Err(GribError::InvalidValueError(
+                "invalid date time: 2022-11-31 00:00:00".to_owned()
+            ))
+        );
+    }
 
     #[test]
     fn prod_definition_parameters() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum GribError {
     InternalDataError,
     ParseError(ParseError),
     DecodeError(DecodeError),
+    InvalidValueError(String),
 }
 
 impl Error for GribError {
@@ -35,6 +36,7 @@ impl Display for GribError {
             Self::InternalDataError => write!(f, "Something unexpected happend"),
             Self::ParseError(e) => write!(f, "{e}"),
             Self::DecodeError(e) => write!(f, "{e:#?}"),
+            Self::InvalidValueError(s) => write!(f, "invalid value ({s})"),
         }
     }
 }


### PR DESCRIPTION
This PR provides migration to Chrono v0.4.23.

In Chrono v0.4.23, `Utc::ymd()` and `Date::and_hms()`, which cause panics for invalid inputs, are deprecated in favor of APIs returning `LocalResult`. Also, `Utc::with_ymd_and_hms()` is newly introduced.

This PR makes an API change; `Identification::ref_time()` now returns `chrono::DateTime` wrapped by `Result`.