### PR TITLE
Add support for cases where nbit is 0 in complex packing and JPEG 2000 code stream format

### DIFF
--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -107,13 +107,13 @@ test_operation_with_data_without_nan_values_and_byte_order_options! {
     //     "-l",
     //     utils::testdata::flat_binary::noaa_gdas_0_le()?
     // ),
-    // (
-    //     decoding_complex_packing_with_all_values_being_0_as_little_endian,
-    //     utils::testdata::grib2::noaa_gdas_46()?,
-    //     "0.0",
-    //     "-l",
-    //     utils::testdata::flat_binary::noaa_gdas_46_le()?
-    // ),
+    (
+        decoding_complex_packing_where_nbit_is_zero,
+        utils::testdata::grib2::noaa_gdas_46()?,
+        "0.0",
+        "-l",
+        utils::testdata::flat_binary::noaa_gdas_46_le()?
+    ),
 }
 
 #[test]

--- a/cli/tests/cli/utils/testdata.rs
+++ b/cli/tests/cli/utils/testdata.rs
@@ -78,9 +78,9 @@ pub(crate) mod grib2 {
         unxz_to_tempfile(testdata_dir().join("gdas.t12z.pgrb2.0p25.f000.12.xz"))
     }
 
-    // pub(crate) fn noaa_gdas_46() -> Result<NamedTempFile, io::Error> {
-    //     unxz_to_tempfile(testdata_dir().join("gdas.t12z.pgrb2.0p25.f000.46.xz"))
-    // }
+    pub(crate) fn noaa_gdas_46() -> Result<NamedTempFile, io::Error> {
+        unxz_to_tempfile(testdata_dir().join("gdas.t12z.pgrb2.0p25.f000.46.xz"))
+    }
 
     pub(crate) fn multi_message_data(n: usize) -> Result<NamedTempFile, io::Error> {
         let mut buf = Vec::new();
@@ -144,7 +144,7 @@ pub(crate) mod flat_binary {
         unxz_as_bytes(testdata_dir().join("gen").join("gdas-12-wgrib2-le.bin.xz"))
     }
 
-    // pub(crate) fn noaa_gdas_46_le() -> Result<Vec<u8>, io::Error> {
-    //     unxz_as_bytes(testdata_dir().join("gen").join("gdas-46-wgrib2-le.bin.xz"))
-    // }
+    pub(crate) fn noaa_gdas_46_le() -> Result<Vec<u8>, io::Error> {
+        unxz_as_bytes(testdata_dir().join("gen").join("gdas-46-wgrib2-le.bin.xz"))
+    }
 }

--- a/src/decoders/common.rs
+++ b/src/decoders/common.rs
@@ -3,9 +3,7 @@ use crate::decoders::bitmap::{create_bitmap_for_nonnullable_data, BitmapDecodeIt
 use crate::decoders::complex::{self, ComplexPackingDecodeError};
 use crate::decoders::jpeg2000::{self, Jpeg2000CodeStreamDecodeError};
 use crate::decoders::run_length::{self, RunLengthEncodingDecodeError};
-use crate::decoders::simple::{
-    self, SimplePackingDecodeError, SimplePackingDecodeIterator, SimplePackingDecodeIteratorWrapper,
-};
+use crate::decoders::simple::{self, SimplePackingDecodeError, SimplePackingDecodeIteratorWrapper};
 use crate::error::*;
 use crate::reader::Grib2Read;
 use num::ToPrimitive;
@@ -154,8 +152,8 @@ where
 
 enum Grib2SubmessageDecoderIteratorWrapper<I, J, K> {
     Template0(SimplePackingDecodeIteratorWrapper<I>),
-    Template3(SimplePackingDecodeIterator<J>),
-    Template40(SimplePackingDecodeIterator<K>),
+    Template3(SimplePackingDecodeIteratorWrapper<J>),
+    Template40(SimplePackingDecodeIteratorWrapper<K>),
     Template200(std::vec::IntoIter<f32>),
 }
 

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -32,10 +32,10 @@ pub(crate) fn decode(
     let spdiff_param_octet = read_as!(u8, sect5_data, 43);
 
     if nbit == 0 {
-        // Based on the implementation of wgrib2, if nbits equals 0, return a constant
-        // field where the data value at each grid point is the reference value.
-        let decoded = vec![ref_val; target.num_points_encoded];
-        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(decoded.into_iter());
+        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
+            ref_val,
+            target.num_points_encoded,
+        ));
         return Ok(decoder);
     };
 

--- a/src/decoders/jpeg2000/mod.rs
+++ b/src/decoders/jpeg2000/mod.rs
@@ -33,10 +33,10 @@ pub(crate) fn decode(
             "WARNING: nbit = 0 for JPEG 2000 code stream format decoder is not tested.
             Please report your data and help us develop the library."
         );
-        // Based on the implementation of wgrib2, if nbits equals 0, return a constant
-        // field where the data value at each grid point is the reference value.
-        let decoded = vec![ref_val; target.num_points_encoded];
-        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(decoded.into_iter());
+        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
+            ref_val,
+            target.num_points_encoded,
+        ));
         return Ok(decoder);
     };
 

--- a/src/decoders/jpeg2000/mod.rs
+++ b/src/decoders/jpeg2000/mod.rs
@@ -20,13 +20,25 @@ pub enum Jpeg2000CodeStreamDecodeError {
 
 pub(crate) fn decode(
     target: &Grib2SubmessageDecoder,
-) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = i32>>, GribError> {
+) -> Result<SimplePackingDecodeIteratorWrapper<impl Iterator<Item = i32>>, GribError> {
     let sect5_data = &target.sect5_payload;
     let ref_val = read_as!(f32, sect5_data, 6);
     let exp = read_as!(u16, sect5_data, 10).as_grib_int();
     let dig = read_as!(u16, sect5_data, 12).as_grib_int();
-    //let nbit = read_as!(u8, sect5_data, 14);
+    let nbit = read_as!(u8, sect5_data, 14);
     let value_type = read_as!(u8, sect5_data, 15);
+
+    if nbit == 0 {
+        eprintln!(
+            "WARNING: nbit = 0 for JPEG 2000 code stream format decoder is not tested.
+            Please report your data and help us develop the library."
+        );
+        // Based on the implementation of wgrib2, if nbits equals 0, return a constant
+        // field where the data value at each grid point is the reference value.
+        let decoded = vec![ref_val; target.num_points_encoded];
+        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(decoded.into_iter());
+        return Ok(decoder);
+    };
 
     if value_type != 0 {
         return Err(GribError::DecodeError(
@@ -41,6 +53,7 @@ pub(crate) fn decode(
     let jp2_unpacked = decode_jp2(stream)
         .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;
     let decoder = SimplePackingDecodeIterator::new(jp2_unpacked, ref_val, exp, dig);
+    let decoder = SimplePackingDecodeIteratorWrapper::SimplePacking(decoder);
     Ok(decoder)
 }
 


### PR DESCRIPTION
This PR fixes #32 by adding support for "nbit =0" cases to the complex packing decoder (and JPEG 2000 code stream format decoder), which was added to the simple packing decoder in response to #15.