### PR TITLE
Fix a panic with 'attempt to multiply with overflow' in decoding complex packing data

### DIFF
--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -101,13 +101,6 @@ test_operation_with_data_without_nan_values_and_byte_order_options! {
         utils::testdata::flat_binary::jma_meps_le()?
     ),
     (
-        decoding_complex_packing_with_3_byte_spatial_differencing_extra_descriptors_starting_from_0x80,
-        utils::testdata::grib2::noaa_gdas_0_10()?,
-        "0.0",
-        "-l",
-        utils::testdata::flat_binary::noaa_gdas_0_le()?
-    ),
-    (
         decoding_complex_packing_where_nbit_is_zero,
         utils::testdata::grib2::noaa_gdas_46()?,
         "0.0",
@@ -270,6 +263,16 @@ test_operation_with_data_without_nan_values_compared_using_simple_packing! {
         1,
         8,
         utils::testdata::flat_binary::noaa_gdas_1_le()?
+    ),
+    (
+        decoding_complex_packing_with_3_byte_spatial_differencing_extra_descriptors_starting_from_0x80,
+        utils::testdata::grib2::noaa_gdas_0_10()?,
+        "0.0",
+        "-l",
+        f32::from_be_bytes([0x49, 0x67, 0xe7, 0xdf]),
+        1,
+        1,
+        utils::testdata::flat_binary::noaa_gdas_0_le()?
     ),
     (
         decoding_complex_packing_with_zero_width_groups_as_little_endian,

--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -100,13 +100,13 @@ test_operation_with_data_without_nan_values_and_byte_order_options! {
         "-l",
         utils::testdata::flat_binary::jma_meps_le()?
     ),
-    // (
-    //     decoding_complex_packing_with_num_descriptor_octet_being_3_as_little_endian,
-    //     utils::testdata::grib2::noaa_gdas_0_10()?,
-    //     "0.0",
-    //     "-l",
-    //     utils::testdata::flat_binary::noaa_gdas_0_le()?
-    // ),
+    (
+        decoding_complex_packing_with_3_byte_spatial_differencing_extra_descriptors_starting_from_0x80,
+        utils::testdata::grib2::noaa_gdas_0_10()?,
+        "0.0",
+        "-l",
+        utils::testdata::flat_binary::noaa_gdas_0_le()?
+    ),
     (
         decoding_complex_packing_where_nbit_is_zero,
         utils::testdata::grib2::noaa_gdas_46()?,

--- a/cli/tests/cli/utils/testdata.rs
+++ b/cli/tests/cli/utils/testdata.rs
@@ -128,9 +128,9 @@ pub(crate) mod flat_binary {
         unxz_as_bytes(testdata_dir().join("gen").join("tornado-wgrib2-le.bin.xz"))
     }
 
-    // pub(crate) fn noaa_gdas_0_le() -> Result<Vec<u8>, io::Error> {
-    //     unxz_as_bytes(testdata_dir().join("gen").join("gdas-0-wgrib2-le.bin.xz"))
-    // }
+    pub(crate) fn noaa_gdas_0_le() -> Result<Vec<u8>, io::Error> {
+        unxz_as_bytes(testdata_dir().join("gen").join("gdas-0-wgrib2-le.bin.xz"))
+    }
 
     pub(crate) fn noaa_gdas_1_le() -> Result<Vec<u8>, io::Error> {
         unxz_as_bytes(testdata_dir().join("gen").join("gdas-1-wgrib2-le.bin.xz"))


### PR DESCRIPTION
This PR is a follow-up to #33 to fix a panic with 'attempt to multiply with overflow' in decoding complex packing data.

The panic was caused by reading a 3-byte parameter starting with `0x80` as a positive value instead of a negative value. For example, `0x80_cc_cc` was read as `52428` instead of `-52428`.

Closes #34.