### PR TITLE
Add support for computation of latitudes and longitudes of grid points (for the lat/lon grid (Template 3.0))

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@ use crate::codetables::{
 };
 use crate::datatypes::*;
 use crate::error::*;
+use crate::grid::GridPointIterator;
 use crate::parser::Grib2SubmessageIndexStream;
 use crate::reader::{Grib2Read, Grib2SectionStream, SeekableGrib2Reader, SECT8_ES_SIZE};
 
@@ -405,6 +406,20 @@ Data Representation:                    {}
             self.5.describe().unwrap_or_default(),
             self.repr_def().num_points(),
         )
+    }
+
+    pub fn latlons(&self) -> Result<GridPointIterator, GribError> {
+        let grid_def = self.grid_def();
+        let num_defined = grid_def.num_points() as usize;
+        let latlons = GridDefinitionTemplateValues::try_from(grid_def)?.latlons()?;
+        let (num_decoded, _) = latlons.size_hint();
+        if num_defined == num_decoded {
+            Ok(latlons)
+        } else {
+            Err(GribError::InvalidValueError(format!(
+                "number of grid points does not match: {num_defined} (defined) vs {num_decoded} (decoded)"
+            )))
+        }
     }
 }
 

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -5,7 +5,7 @@ use std::slice::Iter;
 use crate::codetables::SUPPORTED_PROD_DEF_TEMPLATE_NUMBERS;
 use crate::datatypes::*;
 use crate::error::*;
-use crate::grid::LatLonGridDefinition;
+use crate::grid::{GridPointIterator, LatLonGridDefinition};
 use crate::utils::{read_as, GribInt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -165,6 +165,17 @@ impl GridDefinition {
 #[derive(Debug, PartialEq, Eq)]
 pub enum GridDefinitionTemplateValues {
     Template0(LatLonGridDefinition),
+}
+
+impl GridDefinitionTemplateValues {
+    pub fn latlons(&self) -> Result<GridPointIterator, GribError> {
+        let iter = match self {
+            Self::Template0(def) => GridPointIterator::LatLon(def.latlons()?),
+        };
+        // note that consistency between `iter.size_hint()` and
+        // `GridDefinition::num_points()` is not checked
+        Ok(iter)
+    }
 }
 
 impl TryFrom<&GridDefinition> for GridDefinitionTemplateValues {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum GribError {
     ParseError(ParseError),
     DecodeError(DecodeError),
     InvalidValueError(String),
+    NotSupported(String),
 }
 
 impl Error for GribError {
@@ -37,6 +38,7 @@ impl Display for GribError {
             Self::ParseError(e) => write!(f, "{e}"),
             Self::DecodeError(e) => write!(f, "{e:#?}"),
             Self::InvalidValueError(s) => write!(f, "invalid value ({s})"),
+            Self::NotSupported(s) => write!(f, "not supported ({s})"),
         }
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,3 +1,67 @@
+use crate::error::GribError;
+
+pub(crate) struct LatLonGridDefinition {
+    ni: u32,
+    nj: u32,
+    first_point_lat: i32,
+    first_point_lon: i32,
+    last_point_lat: i32,
+    last_point_lon: i32,
+    scanning_mode: ScanningMode,
+}
+
+impl LatLonGridDefinition {
+    pub(crate) fn new(
+        ni: u32,
+        nj: u32,
+        first_point_lat: i32,
+        first_point_lon: i32,
+        last_point_lat: i32,
+        last_point_lon: i32,
+        scanning_mode: ScanningMode,
+    ) -> Self {
+        Self {
+            ni,
+            nj,
+            first_point_lat,
+            first_point_lon,
+            last_point_lat,
+            last_point_lon,
+            scanning_mode,
+        }
+    }
+
+    pub(crate) fn iter(&self) -> Result<LatLonGridIterator, GribError> {
+        if !self.is_consistent() {
+            return Err(GribError::InvalidValueError("Latitude and longitude for first/last grid points are not consistent with scanning mode".to_owned()));
+        }
+
+        let lat_diff = self.last_point_lat - self.first_point_lat;
+        let lon_diff = self.last_point_lon - self.first_point_lon;
+        let (num_div_lat, num_div_lon) = ((self.nj - 1) as i32, (self.ni - 1) as i32);
+        let lat_delta = lat_diff as f32 / num_div_lat as f32;
+        let lat = (0..=num_div_lat)
+            .into_iter()
+            .map(|x| (self.first_point_lat as f32 + x as f32 * lat_delta) / 1_000_000 as f32)
+            .collect();
+        let lon_delta = lon_diff as f32 / num_div_lon as f32;
+        let lon = (0..=num_div_lon)
+            .into_iter()
+            .map(|x| (self.first_point_lon as f32 + x as f32 * lon_delta) / 1_000_000 as f32)
+            .collect();
+
+        let iter = LatLonGridIterator::new(lat, lon, self.scanning_mode);
+        Ok(iter)
+    }
+
+    fn is_consistent(&self) -> bool {
+        let lat_diff = self.last_point_lat - self.first_point_lat;
+        let lon_diff = self.last_point_lon - self.first_point_lon;
+        !(((lat_diff > 0) ^ self.scanning_mode.scans_positively_for_j())
+            || ((lon_diff > 0) ^ self.scanning_mode.scans_positively_for_i()))
+    }
+}
+
 pub(crate) struct LatLonGridIterator {
     major: Vec<f32>,
     minor: Vec<f32>,
@@ -64,6 +128,7 @@ impl Iterator for LatLonGridIterator {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct ScanningMode(u8);
 
 impl ScanningMode {
@@ -91,6 +156,130 @@ impl ScanningMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_lat_lon_grid_definition_and_iteration() {
+        let grid = LatLonGridDefinition::new(
+            3,
+            2,
+            36_000_000,
+            135_000_000,
+            35_000_000,
+            137_000_000,
+            ScanningMode(0b00000000),
+        );
+        let actual = grid.iter().unwrap().collect::<Vec<_>>();
+        let expected = vec![
+            (36., 135.),
+            (36., 136.),
+            (36., 137.),
+            (35., 135.),
+            (35., 136.),
+            (35., 137.),
+        ];
+        assert_eq!(actual, expected)
+    }
+
+    macro_rules! test_consistencies_between_lat_lon_and_scanning_mode {
+        ($((
+            $name:ident,
+            $first_point_lat:expr,
+            $first_point_lon:expr,
+            $last_point_lat:expr,
+            $last_point_lon:expr,
+            $scanning_mode:expr,
+            $expected:expr
+        ),)*) => ($(
+            #[test]
+            fn $name() {
+                let grid = LatLonGridDefinition::new(
+                    1,
+                    1,
+                    $first_point_lat,
+                    $first_point_lon,
+                    $last_point_lat,
+                    $last_point_lon,
+                    ScanningMode($scanning_mode),
+                );
+                assert_eq!(grid.is_consistent(), $expected)
+            }
+        )*);
+    }
+
+    test_consistencies_between_lat_lon_and_scanning_mode! {
+        (
+            consistency_between_lat_decrease_and_scanning_mode_0b00000000,
+            37_000_000,
+            140_000_000,
+            36_000_000,
+            141_000_000,
+            0b00000000,
+            true
+        ),
+        (
+            consistency_between_lat_decrease_and_scanning_mode_0b01000000,
+            37_000_000,
+            140_000_000,
+            36_000_000,
+            141_000_000,
+            0b01000000,
+            false
+        ),
+        (
+            consistency_between_lat_increase_and_scanning_mode_0b00000000,
+            36_000_000,
+            140_000_000,
+            37_000_000,
+            141_000_000,
+            0b00000000,
+            false
+        ),
+        (
+            consistency_between_lat_increase_and_scanning_mode_0b01000000,
+            36_000_000,
+            140_000_000,
+            37_000_000,
+            141_000_000,
+            0b01000000,
+            true
+        ),
+        (
+            consistency_between_lon_increase_and_scanning_mode_0b00000000,
+            37_000_000,
+            140_000_000,
+            36_000_000,
+            141_000_000,
+            0b00000000,
+            true
+        ),
+        (
+            consistency_between_lon_increase_and_scanning_mode_0b10000000,
+            37_000_000,
+            140_000_000,
+            36_000_000,
+            141_000_000,
+            0b10000000,
+            false
+        ),
+        (
+            consistency_between_lon_decrease_and_scanning_mode_0b00000000,
+            37_000_000,
+            141_000_000,
+            36_000_000,
+            140_000_000,
+            0b00000000,
+            false
+        ),
+        (
+            consistency_between_lon_decrease_and_scanning_mode_0b10000000,
+            37_000_000,
+            141_000_000,
+            36_000_000,
+            140_000_000,
+            0b10000000,
+            true
+        ),
+    }
 
     macro_rules! test_lat_lon_grid_iter {
         ($(($name:ident, $scanning_mode:expr, $expected:expr),)*) => ($(

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,0 +1,152 @@
+pub(crate) struct LatLonGridIterator {
+    major: Vec<f32>,
+    minor: Vec<f32>,
+    scanning_mode: ScanningMode,
+    major_pos: usize,
+    minor_pos: usize,
+    increments: bool,
+}
+
+impl LatLonGridIterator {
+    pub(crate) fn new(major: Vec<f32>, minor: Vec<f32>, scanning_mode: ScanningMode) -> Self {
+        Self {
+            major,
+            minor,
+            scanning_mode,
+            minor_pos: 0,
+            major_pos: 0,
+            increments: true,
+        }
+    }
+}
+
+impl Iterator for LatLonGridIterator {
+    type Item = (f32, f32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.major_pos == self.major.len() {
+            return None;
+        }
+
+        let minor_pos = if self.increments {
+            self.minor_pos
+        } else {
+            self.minor.len() - self.minor_pos - 1
+        };
+        let minor = self.minor[minor_pos];
+        let major = self.major[self.major_pos];
+
+        self.minor_pos += 1;
+        if self.minor_pos == self.minor.len() {
+            self.major_pos += 1;
+            self.minor_pos = 0;
+            if self.scanning_mode.scans_alternating_rows() {
+                self.increments = !self.increments;
+            }
+        }
+
+        if self.scanning_mode.is_consecutive_for_i() {
+            Some((major, minor))
+        } else {
+            Some((minor, major))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.major.len() * self.minor.len();
+        (len, Some(len))
+    }
+}
+
+pub(crate) struct ScanningMode(u8);
+
+impl ScanningMode {
+    pub(crate) fn scans_positively_for_i(&self) -> bool {
+        self.0 & 0b10000000 == 0
+    }
+
+    pub(crate) fn scans_positively_for_j(&self) -> bool {
+        self.0 & 0b01000000 != 0
+    }
+
+    pub(crate) fn is_consecutive_for_i(&self) -> bool {
+        self.0 & 0b00100000 == 0
+    }
+
+    pub(crate) fn scans_alternating_rows(&self) -> bool {
+        self.0 & 0b00010000 != 0
+    }
+
+    pub(crate) fn has_unsupported_flags(&self) -> bool {
+        self.0 & 0b00001111 != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_lat_lon_grid_iter {
+        ($(($name:ident, $scanning_mode:expr, $expected:expr),)*) => ($(
+            #[test]
+            fn $name() {
+                let major = (0..3).into_iter().map(|i| i as f32).collect();
+                let minor = (10..12).into_iter().map(|i| i as f32).collect();
+                let scanning_mode = ScanningMode($scanning_mode);
+                let actual = LatLonGridIterator::new(major, minor, scanning_mode).collect::<Vec<_>>();
+                assert_eq!(actual, $expected);
+            }
+        )*);
+    }
+
+    test_lat_lon_grid_iter! {
+        (
+            lat_lon_grid_iter_with_scanning_mode_0b00000000,
+            0b00000000,
+            vec![
+                (0., 10.),
+                (0., 11.),
+                (1., 10.),
+                (1., 11.),
+                (2., 10.),
+                (2., 11.),
+            ]
+        ),
+        (
+            lat_lon_grid_iter_with_scanning_mode_0b00100000,
+            0b00100000,
+            vec![
+                (10., 0.),
+                (11., 0.),
+                (10., 1.),
+                (11., 1.),
+                (10., 2.),
+                (11., 2.),
+            ]
+        ),
+        (
+            lat_lon_grid_iter_with_scanning_mode_0b00010000,
+            0b00010000,
+            vec![
+                (0., 10.),
+                (0., 11.),
+                (1., 11.),
+                (1., 10.),
+                (2., 10.),
+                (2., 11.),
+            ]
+        ),
+        (
+            lat_lon_grid_iter_with_scanning_mode_0b00110000,
+            0b00110000,
+            vec![
+                (10., 0.),
+                (11., 0.),
+                (11., 1.),
+                (10., 1.),
+                (10., 2.),
+                (11., 2.),
+            ]
+        ),
+    }
+}

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -8,7 +8,13 @@ pub(crate) struct LatLonGridIterator {
 }
 
 impl LatLonGridIterator {
-    pub(crate) fn new(major: Vec<f32>, minor: Vec<f32>, scanning_mode: ScanningMode) -> Self {
+    pub(crate) fn new(lat: Vec<f32>, lon: Vec<f32>, scanning_mode: ScanningMode) -> Self {
+        let (major, minor) = if scanning_mode.is_consecutive_for_i() {
+            (lat, lon)
+        } else {
+            (lon, lat)
+        };
+
         Self {
             major,
             minor,
@@ -90,10 +96,10 @@ mod tests {
         ($(($name:ident, $scanning_mode:expr, $expected:expr),)*) => ($(
             #[test]
             fn $name() {
-                let major = (0..3).into_iter().map(|i| i as f32).collect();
-                let minor = (10..12).into_iter().map(|i| i as f32).collect();
+                let lat = (0..3).into_iter().map(|i| i as f32).collect();
+                let lon = (10..12).into_iter().map(|i| i as f32).collect();
                 let scanning_mode = ScanningMode($scanning_mode);
-                let actual = LatLonGridIterator::new(major, minor, scanning_mode).collect::<Vec<_>>();
+                let actual = LatLonGridIterator::new(lat, lon, scanning_mode).collect::<Vec<_>>();
                 assert_eq!(actual, $expected);
             }
         )*);
@@ -116,12 +122,12 @@ mod tests {
             lat_lon_grid_iter_with_scanning_mode_0b00100000,
             0b00100000,
             vec![
-                (10., 0.),
-                (11., 0.),
-                (10., 1.),
-                (11., 1.),
-                (10., 2.),
-                (11., 2.),
+                (0., 10.),
+                (1., 10.),
+                (2., 10.),
+                (0., 11.),
+                (1., 11.),
+                (2., 11.),
             ]
         ),
         (
@@ -140,12 +146,12 @@ mod tests {
             lat_lon_grid_iter_with_scanning_mode_0b00110000,
             0b00110000,
             vec![
-                (10., 0.),
-                (11., 0.),
-                (11., 1.),
-                (10., 1.),
-                (10., 2.),
-                (11., 2.),
+                (0., 10.),
+                (1., 10.),
+                (2., 10.),
+                (2., 11.),
+                (1., 11.),
+                (0., 11.),
             ]
         ),
     }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -69,13 +69,11 @@ impl LatLonGridDefinition {
         let (num_div_lat, num_div_lon) = ((self.nj - 1) as i32, (self.ni - 1) as i32);
         let lat_delta = lat_diff as f32 / num_div_lat as f32;
         let lat = (0..=num_div_lat)
-            .into_iter()
-            .map(|x| (self.first_point_lat as f32 + x as f32 * lat_delta) / 1_000_000 as f32)
+            .map(|x| (self.first_point_lat as f32 + x as f32 * lat_delta) / 1_000_000_f32)
             .collect();
         let lon_delta = lon_diff as f32 / num_div_lon as f32;
         let lon = (0..=num_div_lon)
-            .into_iter()
-            .map(|x| (self.first_point_lon as f32 + x as f32 * lon_delta) / 1_000_000 as f32)
+            .map(|x| (self.first_point_lon as f32 + x as f32 * lon_delta) / 1_000_000_f32)
             .collect();
 
         let iter = LatLonGridIterator::new(lat, lon, self.scanning_mode);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cookbook;
 pub mod datatypes;
 pub mod decoders;
 pub mod error;
+mod grid;
 pub mod parser;
 pub mod reader;
 mod utils;


### PR DESCRIPTION
This PR adds support for computation of latitudes and longitudes of grid points in the library. Among the various grids available in GRIB, this PR adds support for the latitude/longitude grid (Template 3.0), which I believe is the most commonly used.

With the addition of initial support for Section 3, initial support for all sections is now complete.

