### PR TITLE
CLI: make the "decode" subcommand print grid points' lat/lon values as well as data

### DIFF
--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -40,6 +40,11 @@ test_operation_with_no_options! {
     ),
     (
         decoding_multi_message_data,
+        utils::testdata::grib2::noaa_gdas_0_10()?,
+        "2.0"
+    ),
+    (
+        decoding_data_whose_grid_points_cannot_be_exported_as_latlons,
         utils::testdata::grib2::multi_message_data(3)?,
         "2.0"
     ),

--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -12,7 +12,10 @@ macro_rules! test_operation_with_no_options {
 
             let mut cmd = Command::cargo_bin(CMD_NAME)?;
             cmd.arg("decode").arg(input.path()).arg($message_index);
-            cmd.assert().success().stderr(predicate::str::is_empty());
+            cmd.assert()
+                .success()
+                .stdout(predicate::str::starts_with(" Latitude Longitude     Value\n"))
+                .stderr(predicate::str::is_empty());
 
             Ok(())
         }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -3,6 +3,7 @@ use crate::{
     utils::{read_as, GribInt},
 };
 
+#[derive(Clone)]
 pub enum GridPointIterator {
     LatLon(LatLonGridIterator),
 }
@@ -107,6 +108,7 @@ impl LatLonGridDefinition {
     }
 }
 
+#[derive(Clone)]
 pub struct LatLonGridIterator {
     major: Vec<f32>,
     minor: Vec<f32>,


### PR DESCRIPTION
This PR makes the "decode" subcommand print grid points' lat/lon values as well as data using a feature introduced at #39. In addition, improvements are made to the appearance of the text output.