### PR TITLE
Fix an issue that wrong offset values are stored in reading a message starting from a non-zero position

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -110,7 +110,7 @@ where
     }
 
     fn reset_pos(&mut self) -> Result<(), io::Error> {
-        let pos = self.reader.seek(SeekFrom::Current(0))?;
+        let pos = self.reader.stream_position()?;
         self.whole_size = pos as usize;
         Ok(())
     }


### PR DESCRIPTION
This PR fixes an issue that wrong offset values are stored in reading a message starting from a non-zero position.
Since incorrect offset values are stored, re-reading and decoding submessages using those offset values may lead to incorrect value output, crashes, etc.

Closes #38.