### PR TITLE
Make grid-related types and methods publicly accessible

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -412,7 +412,8 @@ Data Representation:                    {}
     /// points.
     ///
     /// The order of lat/lon data of grid points is the same as the order of the
-    /// grid point values, defined by the scanning mode in the data.
+    /// grid point values, defined by the scanning mode
+    /// ([`ScanningMode`](`crate::ScanningMode`)) in the data.
     ///
     /// # Examples
     ///

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -168,12 +168,15 @@ pub enum GridDefinitionTemplateValues {
 }
 
 impl GridDefinitionTemplateValues {
+    /// Returns an iterator over latitudes and longitudes of grid points.
+    ///
+    /// Note that this is a low-level API and it is not checked that the number
+    /// of iterator iterations is consistent with the number of grid points
+    /// defined in the data.
     pub fn latlons(&self) -> Result<GridPointIterator, GribError> {
         let iter = match self {
             Self::Template0(def) => GridPointIterator::LatLon(def.latlons()?),
         };
-        // note that consistency between `iter.size_hint()` and
-        // `GridDefinition::num_points()` is not checked
         Ok(iter)
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -56,7 +56,7 @@ impl LatLonGridDefinition {
         }
     }
 
-    pub(crate) fn latlons(&self) -> Result<LatLonGridIterator, GribError> {
+    pub fn latlons(&self) -> Result<LatLonGridIterator, GribError> {
         if self.scanning_mode.has_unsupported_flags() {
             let ScanningMode(mode) = self.scanning_mode;
             return Err(GribError::NotSupported(format!("scanning mode {mode}")));
@@ -179,19 +179,19 @@ impl Iterator for LatLonGridIterator {
 pub struct ScanningMode(pub u8);
 
 impl ScanningMode {
-    pub(crate) fn scans_positively_for_i(&self) -> bool {
+    pub fn scans_positively_for_i(&self) -> bool {
         self.0 & 0b10000000 == 0
     }
 
-    pub(crate) fn scans_positively_for_j(&self) -> bool {
+    pub fn scans_positively_for_j(&self) -> bool {
         self.0 & 0b01000000 != 0
     }
 
-    pub(crate) fn is_consecutive_for_i(&self) -> bool {
+    pub fn is_consecutive_for_i(&self) -> bool {
         self.0 & 0b00100000 == 0
     }
 
-    pub(crate) fn scans_alternating_rows(&self) -> bool {
+    pub fn scans_alternating_rows(&self) -> bool {
         self.0 & 0b00010000 != 0
     }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -56,6 +56,11 @@ impl LatLonGridDefinition {
         }
     }
 
+    /// Returns an iterator over latitudes and longitudes of grid points.
+    ///
+    /// Note that this is a low-level API and it is not checked that the number
+    /// of iterator iterations is consistent with the number of grid points
+    /// defined in the data.
     pub fn latlons(&self) -> Result<LatLonGridIterator, GribError> {
         if self.scanning_mode.has_unsupported_flags() {
             let ScanningMode(mode) = self.scanning_mode;
@@ -179,18 +184,61 @@ impl Iterator for LatLonGridIterator {
 pub struct ScanningMode(pub u8);
 
 impl ScanningMode {
+    /// Returns `true` if points of the first row or column scan in the `+i`
+    /// (`+x`) direction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grib::ScanningMode;
+    ///
+    /// let scanning_mode = ScanningMode(0b00000000);
+    /// assert_eq!(scanning_mode.scans_positively_for_i(), true);
+    /// ```
     pub fn scans_positively_for_i(&self) -> bool {
         self.0 & 0b10000000 == 0
     }
 
+    /// Returns `true` if points of the first row or column scan in the `+j`
+    /// (`+y`) direction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grib::ScanningMode;
+    ///
+    /// let scanning_mode = ScanningMode(0b00000000);
+    /// assert_eq!(scanning_mode.scans_positively_for_j(), false);
+    /// ```
     pub fn scans_positively_for_j(&self) -> bool {
         self.0 & 0b01000000 != 0
     }
 
+    /// Returns `true` if adjacent points in `i` (`x`) direction are
+    /// consecutive.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grib::ScanningMode;
+    ///
+    /// let scanning_mode = ScanningMode(0b00000000);
+    /// assert_eq!(scanning_mode.is_consecutive_for_i(), true);
+    /// ```
     pub fn is_consecutive_for_i(&self) -> bool {
         self.0 & 0b00100000 == 0
     }
 
+    /// Returns `true` if adjacent rows scans in the opposite direction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grib::ScanningMode;
+    ///
+    /// let scanning_mode = ScanningMode(0b00000000);
+    /// assert_eq!(scanning_mode.scans_alternating_rows(), false);
+    /// ```
     pub fn scans_alternating_rows(&self) -> bool {
         self.0 & 0b00010000 != 0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,7 @@ pub mod parser;
 pub mod reader;
 mod utils;
 
-pub use context::{from_reader, from_slice, Grib2};
+pub use crate::{
+    context::{from_reader, from_slice, Grib2},
+    grid::*,
+};


### PR DESCRIPTION
As a follow-up to #39 and #41, this PR makes grid-related types and methods publicly accessible, and also provide some documentation and examples for them.