### PR TITLE
Move all types except code tables directly under the crate root

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 #[cfg(unix)]
 use which::which;
 
-use grib::reader::SeekableGrib2Reader;
 use grib::Grib2;
+use grib::SeekableGrib2Reader;
 
 pub fn grib<P>(path: P) -> anyhow::Result<Grib2<SeekableGrib2Reader<BufReader<File>>>>
 where
@@ -60,7 +60,7 @@ fn start_pager() {
 fn start_pager() {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CliMessageIndex(pub(crate) grib::datatypes::MessageIndex);
+pub(crate) struct CliMessageIndex(pub(crate) grib::MessageIndex);
 
 impl std::str::FromStr for CliMessageIndex {
     type Err = anyhow::Error;

--- a/cli/src/commands/decode.rs
+++ b/cli/src/commands/decode.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::{arg, ArgMatches, Command};
 use console::Style;
-use grib::error::GribError;
+use grib::GribError;
 use std::fmt;
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -49,7 +49,7 @@ pub fn exec(args: &ArgMatches) -> Result<()> {
         .find(|(index, _)| *index == message_index)
         .ok_or_else(|| anyhow::anyhow!("no such index: {}.{}", message_index.0, message_index.1))?;
     let latlons = submessage.latlons();
-    let decoder = grib::decoders::Grib2SubmessageDecoder::from(submessage)?;
+    let decoder = grib::Grib2SubmessageDecoder::from(submessage)?;
     let values = decoder.dispatch()?;
 
     if args.contains_id("big-endian") {

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -7,8 +7,8 @@ use grib::codetables::{
     CodeTable0_0, CodeTable1_1, CodeTable1_2, CodeTable1_3, CodeTable1_4, CommonCodeTable00,
     CommonCodeTable11, Lookup,
 };
-use grib::context::SectionBody;
-use grib::datatypes::{Identification, Indicator};
+use grib::SectionBody;
+use grib::{Identification, Indicator};
 
 use crate::cli;
 

--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 use std::slice::Iter;
 
-use grib::context::{SectionInfo, SubMessageSection, SubmessageIterator, TemplateInfo};
+use grib::{SectionInfo, SubMessageSection, SubmessageIterator, TemplateInfo};
 
 use crate::cli;
 

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
 use grib::codetables::{CodeTable4_2, CodeTable4_3, Lookup};
-use grib::context::SubmessageIterator;
+use grib::SubmessageIterator;
 
 use crate::cli;
 

--- a/examples/decode_surface.rs
+++ b/examples/decode_surface.rs
@@ -42,7 +42,7 @@ where
     let latlons = submessage.latlons()?;
 
     // Prepare a decoder.
-    let decoder = grib::decoders::Grib2SubmessageDecoder::from(submessage)?;
+    let decoder = grib::Grib2SubmessageDecoder::from(submessage)?;
 
     // Actually dispatch a decoding process and get an iterator of decoded values.
     // There are various methods available for compressing GRIB2 data, but some are

--- a/examples/find_surfaces.rs
+++ b/examples/find_surfaces.rs
@@ -1,6 +1,6 @@
 use grib::codetables::grib2::*;
 use grib::codetables::*;
-use grib::datatypes::*;
+use grib::*;
 use std::env;
 use std::error::Error;
 use std::fs::File;

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -109,7 +109,7 @@
 //! ```rust
 //! use grib::codetables::grib2::*;
 //! use grib::codetables::*;
-//! use grib::datatypes::*;
+//! use grib::*;
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! use std::path::Path;
@@ -180,7 +180,7 @@
 //! ```rust
 //! use grib::codetables::grib2::*;
 //! use grib::codetables::*;
-//! use grib::datatypes::*;
+//! use grib::*;
 //! use std::fs::File;
 //! use std::io::{BufReader, Read, Write};
 //! use std::path::Path;
@@ -200,7 +200,7 @@
 //!         .unwrap();
 //!
 //!     let latlons = submessage.latlons().unwrap();
-//!     let decoder = grib::decoders::Grib2SubmessageDecoder::from(submessage).unwrap();
+//!     let decoder = grib::Grib2SubmessageDecoder::from(submessage).unwrap();
 //!     let values = decoder.dispatch().unwrap();
 //!
 //!     for ((lat, lon), value) in latlons.zip(values) {

--- a/src/decoders/common.rs
+++ b/src/decoders/common.rs
@@ -12,7 +12,7 @@ use num::ToPrimitive;
 ///
 /// # Examples
 /// ```
-/// use grib::decoders::Grib2SubmessageDecoder;
+/// use grib::Grib2SubmessageDecoder;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let f =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,12 @@
 pub mod codetables;
-pub mod context;
+mod context;
 pub mod cookbook;
-pub mod datatypes;
-pub mod decoders;
-pub mod error;
+mod datatypes;
+mod decoders;
+mod error;
 mod grid;
-pub mod parser;
-pub mod reader;
+mod parser;
+mod reader;
 mod utils;
 
-pub use crate::{
-    context::{from_reader, from_slice, Grib2},
-    grid::*,
-};
+pub use crate::{context::*, datatypes::*, decoders::*, error::*, grid::*, parser::*, reader::*};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
-use crate::context::SectionInfo;
-use crate::datatypes::Grib2SubmessageIndex;
-use crate::error::*;
+use crate::Grib2SubmessageIndex;
+use crate::SectionInfo;
+use crate::*;
 use std::iter::{Enumerate, Peekable};
 
 pub struct Submessage(
@@ -22,10 +22,10 @@ pub struct Submessage(
 /// beginning of the file.
 ///
 /// ```
-/// use grib::context::{SectionBody, SectionInfo};
-/// use grib::datatypes::Indicator;
-/// use grib::parser::Grib2SubmessageStream;
-/// use grib::reader::{Grib2SectionStream, SeekableGrib2Reader};
+/// use grib::Grib2SubmessageStream;
+/// use grib::Indicator;
+/// use grib::{Grib2SectionStream, SeekableGrib2Reader};
+/// use grib::{SectionBody, SectionInfo};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let f = std::fs::File::open(
@@ -84,8 +84,8 @@ where
 {
     /// # Example
     /// ```
-    /// use grib::parser::Grib2SubmessageStream;
-    /// use grib::reader::{Grib2SectionStream, SeekableGrib2Reader};
+    /// use grib::Grib2SubmessageStream;
+    /// use grib::{Grib2SectionStream, SeekableGrib2Reader};
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let f = std::fs::File::open(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,10 +2,10 @@ use std::convert::TryInto;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::result::Result;
 
-use crate::context::{SectionBody, SectionInfo};
-use crate::datatypes::*;
 use crate::error::*;
 use crate::utils::read_as;
+use crate::*;
+use crate::{SectionBody, SectionInfo};
 
 const SECT0_IS_MAGIC: &[u8] = b"GRIB";
 const SECT0_IS_MAGIC_SIZE: usize = SECT0_IS_MAGIC.len();
@@ -16,9 +16,9 @@ pub(crate) const SECT8_ES_SIZE: usize = SECT8_ES_MAGIC.len();
 
 /// # Example
 /// ```
-/// use grib::context::{SectionBody, SectionInfo};
-/// use grib::datatypes::Indicator;
-/// use grib::reader::{Grib2SectionStream, SeekableGrib2Reader};
+/// use grib::Indicator;
+/// use grib::{Grib2SectionStream, SeekableGrib2Reader};
+/// use grib::{SectionBody, SectionInfo};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let f = std::fs::File::open(
@@ -52,7 +52,7 @@ pub struct Grib2SectionStream<R> {
 impl<R> Grib2SectionStream<R> {
     /// # Example
     /// ```
-    /// use grib::reader::{Grib2SectionStream, SeekableGrib2Reader};
+    /// use grib::{Grib2SectionStream, SeekableGrib2Reader};
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let f = std::fs::File::open(


### PR DESCRIPTION
This PR moves all types except code tables directly under the crate root, without type name changes.
This makes incompatible changes to the API.

Due to my own unfamiliarity in the early stages of development, the library crate exposed the internal module hierarchy to the outside world as is.
However, this makes it difficult to refactor with internal hierarchical structure changes.
From the user's point of view, it is also difficult to grasp the full picture of what types exist in the API documentation.
This change solves these problems and will help future refactoring.

As for the code tables, I continue to keep the modules separate, as I plan to add various types (which should be machine-generated in the future), and putting them in the same level as the other types for data processing will bury the other types.