### PR TITLE
Clean up superfluous `use` statements

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,4 @@
-use std::env;
-use std::fs;
-use std::path::Path;
+use std::{env, fs, path::Path};
 
 fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,15 +1,12 @@
+use std::{fs::File, io::BufReader, path::Path};
+
+use grib::{Grib2, SeekableGrib2Reader};
 use once_cell::sync::Lazy;
 #[cfg(unix)]
 use pager::Pager;
 use regex::Regex;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
 #[cfg(unix)]
 use which::which;
-
-use grib::Grib2;
-use grib::SeekableGrib2Reader;
 
 pub fn grib<P>(path: P) -> anyhow::Result<Grib2<SeekableGrib2Reader<BufReader<File>>>>
 where

--- a/cli/src/commands/decode.rs
+++ b/cli/src/commands/decode.rs
@@ -1,11 +1,14 @@
+use std::{
+    fmt,
+    fs::File,
+    io::{BufWriter, Write},
+    path::PathBuf,
+};
+
 use anyhow::Result;
 use clap::{arg, ArgMatches, Command};
 use console::Style;
 use grib::GribError;
-use std::fmt;
-use std::fs::File;
-use std::io::{BufWriter, Write};
-use std::path::PathBuf;
 
 use crate::cli;
 

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -1,14 +1,17 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    path::PathBuf,
+};
+
 use chrono::{DateTime, Utc};
 use clap::{arg, ArgMatches, Command};
-use std::fmt::{self, Display, Formatter};
-use std::path::PathBuf;
-
-use grib::codetables::{
-    CodeTable0_0, CodeTable1_1, CodeTable1_2, CodeTable1_3, CodeTable1_4, CommonCodeTable00,
-    CommonCodeTable11, Lookup,
+use grib::{
+    codetables::{
+        CodeTable0_0, CodeTable1_1, CodeTable1_2, CodeTable1_3, CodeTable1_4, CommonCodeTable00,
+        CommonCodeTable11, Lookup,
+    },
+    Identification, Indicator, SectionBody,
 };
-use grib::SectionBody;
-use grib::{Identification, Indicator};
 
 use crate::cli;
 

--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -1,9 +1,11 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    path::PathBuf,
+    slice::Iter,
+};
+
 use clap::{arg, ArgAction, ArgMatches, Command};
 use console::Style;
-use std::fmt::{self, Display, Formatter};
-use std::path::PathBuf;
-use std::slice::Iter;
-
 use grib::{SectionInfo, SubMessageSection, SubmessageIterator, TemplateInfo};
 
 use crate::cli;

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -1,10 +1,14 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    path::PathBuf,
+};
+
 use clap::{arg, ArgAction, ArgMatches, Command};
 use console::Style;
-use std::fmt::{self, Display, Formatter};
-use std::path::PathBuf;
-
-use grib::codetables::{CodeTable4_2, CodeTable4_3, Lookup};
-use grib::SubmessageIterator;
+use grib::{
+    codetables::{CodeTable4_2, CodeTable4_3, Lookup},
+    SubmessageIterator,
+};
 
 use crate::cli;
 

--- a/cli/tests/cli/commands/common.rs
+++ b/cli/tests/cli/commands/common.rs
@@ -1,8 +1,10 @@
-use crate::{utils, CMD_NAME};
+use std::process::Command;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
 use tempfile::TempDir;
+
+use crate::{utils, CMD_NAME};
 
 macro_rules! test_subcommands_without_args {
     ($(($name:ident, $str:expr),)*) => ($(

--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -1,8 +1,10 @@
-use crate::{utils, CMD_NAME};
+use std::process::Command;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
 use tempfile::TempDir;
+
+use crate::{utils, CMD_NAME};
 
 macro_rules! test_operation_with_no_options {
     ($(($name:ident, $input:expr, $message_index:expr),)*) => ($(

--- a/cli/tests/cli/commands/info.rs
+++ b/cli/tests/cli/commands/info.rs
@@ -1,7 +1,9 @@
-use crate::{utils, CMD_NAME};
+use std::process::Command;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
+
+use crate::{utils, CMD_NAME};
 
 crate::commands::test_simple_display! {
     (

--- a/cli/tests/cli/commands/inspect.rs
+++ b/cli/tests/cli/commands/inspect.rs
@@ -1,7 +1,9 @@
-use crate::{utils, CMD_NAME};
+use std::process::Command;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
+
+use crate::{utils, CMD_NAME};
 
 crate::commands::test_simple_display! {
     (

--- a/cli/tests/cli/commands/list.rs
+++ b/cli/tests/cli/commands/list.rs
@@ -1,7 +1,9 @@
-use crate::{utils, CMD_NAME};
+use std::process::Command;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
+
+use crate::{utils, CMD_NAME};
 
 crate::commands::test_simple_display! {
     (

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -1,6 +1,7 @@
+use std::process::Command;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
 
 mod commands;
 mod utils;

--- a/cli/tests/cli/utils/mod.rs
+++ b/cli/tests/cli/utils/mod.rs
@@ -1,7 +1,10 @@
-use std::convert::TryInto;
-use std::fs::File;
-use std::io::{self, BufReader, Read, Write};
-use std::path::Path;
+use std::{
+    convert::TryInto,
+    fs::File,
+    io::{self, BufReader, Read, Write},
+    path::Path,
+};
+
 use tempfile::NamedTempFile;
 use xz2::bufread::XzDecoder;
 

--- a/cli/tests/cli/utils/testdata.rs
+++ b/cli/tests/cli/utils/testdata.rs
@@ -1,8 +1,12 @@
-use crate::utils::{cat_to_tempfile, unxz_as_bytes, unxz_to_tempfile};
-use std::fs::File;
-use std::io::{self, BufReader, Read, Write};
-use std::path::{Path, PathBuf};
+use std::{
+    fs::File,
+    io::{self, BufReader, Read, Write},
+    path::{Path, PathBuf},
+};
+
 use tempfile::NamedTempFile;
+
+use crate::utils::{cat_to_tempfile, unxz_as_bytes, unxz_to_tempfile};
 
 fn testdata_dir() -> PathBuf {
     Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).join("testdata")

--- a/examples/decode_surface.rs
+++ b/examples/decode_surface.rs
@@ -1,8 +1,4 @@
-use std::env;
-use std::error::Error;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
+use std::{env, error::Error, fs::File, io::BufReader, path::Path};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // This example shows how to decode values inside a surface in a GRIB2 message.

--- a/examples/find_surfaces.rs
+++ b/examples/find_surfaces.rs
@@ -1,11 +1,9 @@
-use grib::codetables::grib2::*;
-use grib::codetables::*;
-use grib::*;
-use std::env;
-use std::error::Error;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
+use std::{env, error::Error, fs::File, io::BufReader, path::Path};
+
+use grib::{
+    codetables::{grib2::*, *},
+    *,
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // This example shows how to find surfaces in a GRIB2 message.

--- a/examples/find_surfaces.rs
+++ b/examples/find_surfaces.rs
@@ -2,7 +2,7 @@ use std::{env, error::Error, fs::File, io::BufReader, path::Path};
 
 use grib::{
     codetables::{grib2::*, *},
-    *,
+    ForecastTime,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/list_surfaces.rs
+++ b/examples/list_surfaces.rs
@@ -1,9 +1,6 @@
+use std::{env, error::Error, fs::File, io::BufReader, path::Path};
+
 use grib::codetables::{CodeTable4_2, Lookup};
-use std::env;
-use std::error::Error;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // This example shows how to get information of element names, forecast time and

--- a/gen/src/cct_csv.rs
+++ b/gen/src/cct_csv.rs
@@ -1,9 +1,6 @@
+use std::{collections::BTreeMap, error::Error, fmt, fs::File, path::Path};
+
 use serde::Deserialize;
-use std::collections::BTreeMap;
-use std::error::Error;
-use std::fmt;
-use std::fs::File;
-use std::path::Path;
 
 use crate::*;
 

--- a/gen/src/grib2_codeflag_csv.rs
+++ b/gen/src/grib2_codeflag_csv.rs
@@ -1,10 +1,6 @@
+use std::{collections::BTreeMap, error::Error, fmt, fs::File, path::Path, str::FromStr};
+
 use serde::Deserialize;
-use std::collections::BTreeMap;
-use std::error::Error;
-use std::fmt;
-use std::fs::File;
-use std::path::Path;
-use std::str::FromStr;
 
 use crate::*;
 

--- a/gen/src/lib.rs
+++ b/gen/src/lib.rs
@@ -1,5 +1,4 @@
-use std::str::from_utf8;
-use std::str::FromStr;
+use std::str::{from_utf8, FromStr};
 
 pub mod cct_csv;
 pub mod grib2_codeflag_csv;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
 format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
 use_try_shorthand = true
 wrap_comments = true

--- a/src/codetables/grib2.rs
+++ b/src/codetables/grib2.rs
@@ -40,11 +40,11 @@ impl Table4_4 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use num_enum::TryFromPrimitiveError;
     use std::convert::TryFrom;
 
+    use num_enum::TryFromPrimitiveError;
+
+    use super::*;
     use crate::codetables::*;
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,17 +1,21 @@
-use std::cell::{RefCell, RefMut};
-use std::collections::HashSet;
-use std::fmt::{self, Display, Formatter};
-use std::io::{Cursor, Read, Seek};
-use std::result::Result;
-
-use crate::codetables::{
-    CodeTable3_1, CodeTable4_0, CodeTable4_1, CodeTable4_2, CodeTable4_3, CodeTable5_0, Lookup,
+use std::{
+    cell::{RefCell, RefMut},
+    collections::HashSet,
+    fmt::{self, Display, Formatter},
+    io::{Cursor, Read, Seek},
+    result::Result,
 };
-use crate::datatypes::*;
-use crate::error::*;
-use crate::grid::GridPointIterator;
-use crate::parser::Grib2SubmessageIndexStream;
-use crate::reader::{Grib2Read, Grib2SectionStream, SeekableGrib2Reader, SECT8_ES_SIZE};
+
+use crate::{
+    codetables::{
+        CodeTable3_1, CodeTable4_0, CodeTable4_1, CodeTable4_2, CodeTable4_3, CodeTable5_0, Lookup,
+    },
+    datatypes::*,
+    error::*,
+    grid::GridPointIterator,
+    parser::Grib2SubmessageIndexStream,
+    reader::{Grib2Read, Grib2SectionStream, SeekableGrib2Reader, SECT8_ES_SIZE},
+};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct SectionInfo {
@@ -482,10 +486,9 @@ impl<'a> SubMessageSection<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{fs::File, io::BufReader};
 
-    use std::fs::File;
-    use std::io::BufReader;
+    use super::*;
 
     macro_rules! sect_placeholder {
         ($num:expr) => {{

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -110,7 +110,7 @@
 //!
 //! use grib::{
 //!     codetables::{grib2::*, *},
-//!     *,
+//!     ForecastTime,
 //! };
 //!
 //! fn find_submessages<P>(path: P, forecast_time_hours: u32)
@@ -183,10 +183,7 @@
 //!     path::Path,
 //! };
 //!
-//! use grib::{
-//!     codetables::{grib2::*, *},
-//!     *,
-//! };
+//! use grib::codetables::{grib2::*, *};
 //!
 //! fn decode_surface<P>(path: P, message_index: (usize, usize))
 //! where

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -39,10 +39,9 @@
 //! grib-rs:
 //!
 //! ```rust
+//! use std::{fs::File, io::BufReader, path::Path};
+//!
 //! use grib::codetables::{CodeTable4_2, Lookup};
-//! use std::fs::File;
-//! use std::io::BufReader;
-//! use std::path::Path;
 //!
 //! fn list_submessages<P>(path: P)
 //! where
@@ -107,12 +106,12 @@
 //! grib-rs:
 //!
 //! ```rust
-//! use grib::codetables::grib2::*;
-//! use grib::codetables::*;
-//! use grib::*;
-//! use std::fs::File;
-//! use std::io::BufReader;
-//! use std::path::Path;
+//! use std::{fs::File, io::BufReader, path::Path};
+//!
+//! use grib::{
+//!     codetables::{grib2::*, *},
+//!     *,
+//! };
 //!
 //! fn find_submessages<P>(path: P, forecast_time_hours: u32)
 //! where
@@ -178,12 +177,16 @@
 //! grib-rs:
 //!
 //! ```rust
-//! use grib::codetables::grib2::*;
-//! use grib::codetables::*;
-//! use grib::*;
-//! use std::fs::File;
-//! use std::io::{BufReader, Read, Write};
-//! use std::path::Path;
+//! use std::{
+//!     fs::File,
+//!     io::{BufReader, Read, Write},
+//!     path::Path,
+//! };
+//!
+//! use grib::{
+//!     codetables::{grib2::*, *},
+//!     *,
+//! };
 //!
 //! fn decode_surface<P>(path: P, message_index: (usize, usize))
 //! where

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -1,8 +1,9 @@
-use std::convert::TryFrom;
-use std::fmt::{self, Display, Formatter};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Display, Formatter},
+};
 
-use crate::codetables::grib2::*;
-use crate::codetables::*;
+use crate::codetables::{grib2::*, *};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ForecastTime {

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -1,12 +1,14 @@
-use chrono::{DateTime, LocalResult, TimeZone, Utc};
-use std::convert::TryInto;
-use std::slice::Iter;
+use std::{convert::TryInto, slice::Iter};
 
-use crate::codetables::SUPPORTED_PROD_DEF_TEMPLATE_NUMBERS;
-use crate::datatypes::*;
-use crate::error::*;
-use crate::grid::{GridPointIterator, LatLonGridDefinition};
-use crate::utils::{read_as, GribInt};
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
+
+use crate::{
+    codetables::SUPPORTED_PROD_DEF_TEMPLATE_NUMBERS,
+    datatypes::*,
+    error::*,
+    grid::{GridPointIterator, LatLonGridDefinition},
+    utils::{read_as, GribInt},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Indicator {

--- a/src/decoders/common.rs
+++ b/src/decoders/common.rs
@@ -1,12 +1,17 @@
-use crate::context::{SectionBody, SubMessage};
-use crate::decoders::bitmap::{create_bitmap_for_nonnullable_data, BitmapDecodeIterator};
-use crate::decoders::complex::{self, ComplexPackingDecodeError};
-use crate::decoders::jpeg2000::{self, Jpeg2000CodeStreamDecodeError};
-use crate::decoders::run_length::{self, RunLengthEncodingDecodeError};
-use crate::decoders::simple::{self, SimplePackingDecodeError, SimplePackingDecodeIteratorWrapper};
-use crate::error::*;
-use crate::reader::Grib2Read;
 use num::ToPrimitive;
+
+use crate::{
+    context::{SectionBody, SubMessage},
+    decoders::{
+        bitmap::{create_bitmap_for_nonnullable_data, BitmapDecodeIterator},
+        complex::{self, ComplexPackingDecodeError},
+        jpeg2000::{self, Jpeg2000CodeStreamDecodeError},
+        run_length::{self, RunLengthEncodingDecodeError},
+        simple::{self, SimplePackingDecodeError, SimplePackingDecodeIteratorWrapper},
+    },
+    error::*,
+    reader::Grib2Read,
+};
 
 /// Decoder for grid point values of GRIB2 submessages.
 ///

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -1,12 +1,12 @@
-use num::ToPrimitive;
-use std::convert::TryInto;
-use std::iter;
+use std::{convert::TryInto, iter};
 
-use crate::decoders::common::*;
-use crate::decoders::param::SimplePackingParam;
-use crate::decoders::simple::*;
-use crate::error::*;
-use crate::utils::{read_as, GribInt, NBitwiseIterator};
+use num::ToPrimitive;
+
+use crate::{
+    decoders::{common::*, param::SimplePackingParam, simple::*},
+    error::*,
+    utils::{read_as, GribInt, NBitwiseIterator},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ComplexPackingDecodeError {

--- a/src/decoders/complex/section7.rs
+++ b/src/decoders/complex/section7.rs
@@ -1,6 +1,5 @@
-use crate::{decoders::DecodeError, error::GribError, utils::grib_int_from_bytes};
-
 use super::ComplexPackingDecodeError;
+use crate::{decoders::DecodeError, error::GribError, utils::grib_int_from_bytes};
 
 pub(crate) struct SpatialDifferencingExtraDescriptors<'a> {
     slice: &'a [u8],

--- a/src/decoders/jpeg2000/ext.rs
+++ b/src/decoders/jpeg2000/ext.rs
@@ -13,10 +13,13 @@ As soon as someone writes an efficient JPEG2000 decoder in pure Rust you should 
 You can use the Rust code in the directories `src` and `openjp2-sys/src` under the terms of either the MIT license (`LICENSE-MIT` file) or the Apache license (`LICENSE-APACHE` file). Please note that this will link statically to OpenJPEG, which has its own license which you can find at `openjpeg-sys/libopenjpeg/LICENSE` (you might have to check out the git submodule first).
 */
 
+use std::{
+    os::raw::c_void,
+    ptr::{self, NonNull},
+};
+
 use openjpeg_sys as opj;
 use opj::OPJ_CODEC_FORMAT;
-use std::os::raw::c_void;
-use std::ptr::{self, NonNull};
 
 use crate::decoders::jpeg2000::Jpeg2000CodeStreamDecodeError;
 

--- a/src/decoders/jpeg2000/mod.rs
+++ b/src/decoders/jpeg2000/mod.rs
@@ -1,11 +1,12 @@
-use openjpeg_sys as opj;
 use std::convert::TryInto;
 
-use crate::decoders::common::*;
-use crate::decoders::param::SimplePackingParam;
-use crate::decoders::simple::*;
-use crate::error::*;
-use crate::utils::read_as;
+use openjpeg_sys as opj;
+
+use crate::{
+    decoders::{common::*, param::SimplePackingParam, simple::*},
+    error::*,
+    utils::read_as,
+};
 
 mod ext;
 use ext::*;

--- a/src/decoders/run_length.rs
+++ b/src/decoders/run_length.rs
@@ -1,8 +1,10 @@
 use std::convert::TryInto;
 
-use crate::decoders::common::*;
-use crate::error::*;
-use crate::utils::{read_as, NBitwiseIterator};
+use crate::{
+    decoders::common::*,
+    error::*,
+    utils::{read_as, NBitwiseIterator},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RunLengthEncodingDecodeError {

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -1,10 +1,12 @@
-use num::ToPrimitive;
 use std::convert::TryInto;
 
-use crate::decoders::common::*;
-use crate::decoders::param::SimplePackingParam;
-use crate::error::*;
-use crate::utils::{read_as, NBitwiseIterator};
+use num::ToPrimitive;
+
+use crate::{
+    decoders::{common::*, param::SimplePackingParam},
+    error::*,
+    utils::{read_as, NBitwiseIterator},
+};
 
 pub(crate) enum SimplePackingDecodeIteratorWrapper<I> {
     FixedValue(FixedValueIterator),
@@ -141,11 +143,12 @@ impl Iterator for FixedValueIterator {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        fs::File,
+        io::{BufReader, Cursor, Read},
+    };
+
     use super::*;
-
-    use std::fs::File;
-    use std::io::{BufReader, Cursor, Read};
-
     use crate::context::from_reader;
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::io;
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+    io,
+};
 
 use crate::decoders::*;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,6 @@
-use crate::Grib2SubmessageIndex;
-use crate::SectionInfo;
-use crate::*;
 use std::iter::{Enumerate, Peekable};
+
+use crate::{Grib2SubmessageIndex, SectionInfo, *};
 
 pub struct Submessage(
     pub SectionInfo,
@@ -22,10 +21,10 @@ pub struct Submessage(
 /// beginning of the file.
 ///
 /// ```
-/// use grib::Grib2SubmessageStream;
-/// use grib::Indicator;
-/// use grib::{Grib2SectionStream, SeekableGrib2Reader};
-/// use grib::{SectionBody, SectionInfo};
+/// use grib::{
+///     Grib2SectionStream, Grib2SubmessageStream, Indicator, SectionBody, SectionInfo,
+///     SeekableGrib2Reader,
+/// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let f = std::fs::File::open(
@@ -84,8 +83,7 @@ where
 {
     /// # Example
     /// ```
-    /// use grib::Grib2SubmessageStream;
-    /// use grib::{Grib2SectionStream, SeekableGrib2Reader};
+    /// use grib::{Grib2SectionStream, Grib2SubmessageStream, SeekableGrib2Reader};
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let f = std::fs::File::open(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,7 +4,7 @@ use std::{
     result::Result,
 };
 
-use crate::{error::*, utils::read_as, SectionBody, SectionInfo, *};
+use crate::{datatypes::*, error::*, utils::read_as, SectionBody, SectionInfo};
 
 const SECT0_IS_MAGIC: &[u8] = b"GRIB";
 const SECT0_IS_MAGIC_SIZE: usize = SECT0_IS_MAGIC.len();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,11 +1,10 @@
-use std::convert::TryInto;
-use std::io::{self, Read, Seek, SeekFrom};
-use std::result::Result;
+use std::{
+    convert::TryInto,
+    io::{self, Read, Seek, SeekFrom},
+    result::Result,
+};
 
-use crate::error::*;
-use crate::utils::read_as;
-use crate::*;
-use crate::{SectionBody, SectionInfo};
+use crate::{error::*, utils::read_as, SectionBody, SectionInfo, *};
 
 const SECT0_IS_MAGIC: &[u8] = b"GRIB";
 const SECT0_IS_MAGIC_SIZE: usize = SECT0_IS_MAGIC.len();
@@ -16,9 +15,7 @@ pub(crate) const SECT8_ES_SIZE: usize = SECT8_ES_MAGIC.len();
 
 /// # Example
 /// ```
-/// use grib::Indicator;
-/// use grib::{Grib2SectionStream, SeekableGrib2Reader};
-/// use grib::{SectionBody, SectionInfo};
+/// use grib::{Grib2SectionStream, Indicator, SectionBody, SectionInfo, SeekableGrib2Reader};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let f = std::fs::File::open(
@@ -345,9 +342,9 @@ type SectHeader = (usize, u8);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::io::{Cursor, Write};
+
+    use super::*;
 
     #[test]
     fn read_one_grib2_message() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -120,9 +120,9 @@ impl<'a> Iterator for NBitwiseIterator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::convert::TryInto;
+
+    use super::*;
 
     #[test]
     fn into_grib_i8() {


### PR DESCRIPTION
This PR cleans up superfluous `use` statements, mostly using rustfmt options.
The rules are described as settings for rustfmt, so they will apply to future coding.