### PR TITLE
Re-export `Name` and `Num` in `codetables` directly under the crate root

### DIFF
--- a/examples/find_surfaces.rs
+++ b/examples/find_surfaces.rs
@@ -1,9 +1,6 @@
 use std::{env, error::Error, fs::File, io::BufReader, path::Path};
 
-use grib::{
-    codetables::{grib2::*, *},
-    ForecastTime,
-};
+use grib::{codetables::grib2::*, ForecastTime, Name};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // This example shows how to find surfaces in a GRIB2 message.

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -108,10 +108,7 @@
 //! ```rust
 //! use std::{fs::File, io::BufReader, path::Path};
 //!
-//! use grib::{
-//!     codetables::{grib2::*, *},
-//!     ForecastTime,
-//! };
+//! use grib::{codetables::grib2::*, ForecastTime, Name};
 //!
 //! fn find_submessages<P>(path: P, forecast_time_hours: u32)
 //! where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,13 @@ mod parser;
 mod reader;
 mod utils;
 
-pub use crate::{context::*, datatypes::*, decoders::*, error::*, grid::*, parser::*, reader::*};
+pub use crate::{
+    codetables::Code::{self, Name, Num},
+    context::*,
+    datatypes::*,
+    decoders::*,
+    error::*,
+    grid::*,
+    parser::*,
+    reader::*,
+};


### PR DESCRIPTION
This PR re-exports `Name` and `Num` in `codetables` directly under the crate root for a better coding experience.
This is a follow-up to #44.