### PR TITLE
Include example code in README.md to show the usage of the API

### DIFF
--- a/examples/find_surfaces.rs
+++ b/examples/find_surfaces.rs
@@ -29,14 +29,14 @@ where
 
     for (index, submessage) in grib2.iter() {
         let ft = submessage.prod_def().forecast_time();
-        if let Some(ForecastTime {
-            unit: Name(Table4_4::Hour),
-            value: hours,
-        }) = ft
-        {
-            if hours == forecast_time_hours {
-                println!("{}.{}: {hours}", index.0, index.1);
-            }
+        if matches!(
+            ft,
+            Some(ForecastTime {
+                unit: Name(Table4_4::Hour),
+                value: hours,
+            }) if hours == forecast_time_hours
+        ) {
+            println!("{}.{}\n{}", index.0, index.1, submessage.describe());
         }
     }
 


### PR DESCRIPTION
This PR adds example code in README.md to show the usage of the API.

Since grib-rs is a library crate, it would be better if possible users could see in the README what the coding experience is like.