### PR TITLE
Replace the word "surfaces" with "layers" for submessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ A world where everyone can read weather data easily although its interpretation 
 * Rust library `grib`
   * Ability to read and check the basic structure of GRIB2
   * Ability to access data inside the GRIB2 message:
-    * List of surfaces
-    * Some parameters of each surface, which are important for most users
-    * Underlying sections which make up surfaces and the entire data
+    * List of layers
+    * Some parameters of each layer, which are important for most users
+    * Underlying sections which make up layers and the entire data
   * Support for some code tables defined by WMO
   * Decoding feature supporting following templates:
     * Template 5.0/7.0 (simple packing)
@@ -41,7 +41,7 @@ A world where everyone can read weather data easily although its interpretation 
     * decode: data export as text and flat binary files
     * info: display of identification information
     * inspect: display of information mainly for development purpose such as template numbers
-    * list: display of parameters for each surface inside
+    * list: display of parameters for each layer inside
 
 ## Planned features
 
@@ -101,7 +101,7 @@ Commands:
   decode       Export decoded data
   info         Show identification information
   inspect      Inspect and describes the data structure
-  list         List surfaces contained in the data
+  list         List layers contained in the data
   help         Print this message or the help of the given subcommand(s)
 
 Options:

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -14,7 +14,7 @@ use crate::cli;
 
 pub fn cli() -> Command {
     Command::new("list")
-        .about("List surfaces contained in the data")
+        .about("List layers contained in the data")
         .arg(arg!(-d --dump "Show details of each data").action(ArgAction::SetTrue))
         .arg(arg!(<FILE> "Target file").value_parser(clap::value_parser!(PathBuf)))
 }

--- a/examples/decode_layer.rs
+++ b/examples/decode_layer.rs
@@ -1,23 +1,23 @@
 use std::{env, error::Error, fs::File, io::BufReader, path::Path};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // This example shows how to decode values inside a surface in a GRIB2 message.
+    // This example shows how to decode values inside a layer in a GRIB2 message.
     // The example also shows how to obtain the latitude-longitude locations of grid
     // points, which are usually used in conjunction with the grid point values.
 
     // Take the first argument as an input file path and the second argument as a
-    // surface index.
+    // layer index.
     let mut args = env::args().skip(1);
     if let (Some(file_path), Some(index), Some(subindex)) = (args.next(), args.next(), args.next())
     {
         let index: (usize, usize) = (index.parse()?, subindex.parse()?);
-        decode_surface(file_path, index)
+        decode_layer(file_path, index)
     } else {
-        panic!("Usage: decode_surface <path> <index>");
+        panic!("Usage: decode_layer <path> <index>");
     }
 }
 
-fn decode_surface<P>(path: P, message_index: (usize, usize)) -> Result<(), Box<dyn Error>>
+fn decode_layer<P>(path: P, message_index: (usize, usize)) -> Result<(), Box<dyn Error>>
 where
     P: AsRef<Path>,
 {

--- a/examples/find_layers.rs
+++ b/examples/find_layers.rs
@@ -3,20 +3,20 @@ use std::{env, error::Error, fs::File, io::BufReader, path::Path};
 use grib::{codetables::grib2::*, ForecastTime, Name};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // This example shows how to find surfaces in a GRIB2 message.
+    // This example shows how to find layers in a GRIB2 message.
 
     // Take the first argument as an input file path and the second argument as
     // forecast time in hours.
     let mut args = env::args().skip(1);
     if let (Some(file_path), Some(forecast_time)) = (args.next(), args.next()) {
         let forecast_time = forecast_time.parse::<u32>()?;
-        find_surfaces(file_path, forecast_time)
+        find_layers(file_path, forecast_time)
     } else {
-        panic!("Usage: find_surfaces <path> <forecast_time>");
+        panic!("Usage: find_layers <path> <forecast_time>");
     }
 }
 
-fn find_surfaces<P>(path: P, forecast_time_hours: u32) -> Result<(), Box<dyn Error>>
+fn find_layers<P>(path: P, forecast_time_hours: u32) -> Result<(), Box<dyn Error>>
 where
     P: AsRef<Path>,
 {

--- a/examples/list_layers.rs
+++ b/examples/list_layers.rs
@@ -4,18 +4,18 @@ use grib::codetables::{CodeTable4_2, Lookup};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // This example shows how to get information of element names, forecast time and
-    // elevation levels for all surfaces in a GRIB2 message.
+    // elevation levels for all layers in a GRIB2 message.
 
     // Take the first argument as an input file path.
     let mut args = env::args().skip(1);
     if let Some(file_path) = args.next() {
-        list_surfaces(file_path)
+        list_layers(file_path)
     } else {
-        panic!("Usage: list_surfaces <path>");
+        panic!("Usage: list_layers <path>");
     }
 }
 
-fn list_surfaces<P>(path: P) -> Result<(), Box<dyn Error>>
+fn list_layers<P>(path: P) -> Result<(), Box<dyn Error>>
 where
     P: AsRef<Path>,
 {
@@ -26,7 +26,7 @@ where
     // Read with the reader.
     let grib2 = grib::from_reader(f)?;
 
-    // Iterate over surfaces.
+    // Iterate over layers.
     for (_index, submessage) in grib2.iter() {
         // In GRIB data, attribute information such as elements are represented as
         // numeric values. To convert those numeric values to strings, we use
@@ -65,7 +65,7 @@ where
         // `forecast_time()` returns `ForecastTime` wrapped by `Option`.
         let forecast_time = submessage.prod_def().forecast_time().unwrap();
 
-        // `fixed_surfaces()` returns a tuple of two surfaces wrapped by `Option`.
+        // `fixed_layers()` returns a tuple of two layers wrapped by `Option`.
         let (first, _second) = submessage.prod_def().fixed_surfaces().unwrap();
         let elevation_level = first.value();
 

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -182,7 +182,7 @@
 //!
 //! use grib::codetables::{grib2::*, *};
 //!
-//! fn decode_surface<P>(path: P, message_index: (usize, usize))
+//! fn decode_layer<P>(path: P, message_index: (usize, usize))
 //! where
 //!     P: AsRef<Path>,
 //! {
@@ -217,7 +217,7 @@
 //!     f.read_to_end(&mut buf).unwrap();
 //!     out.write_all(&buf).unwrap();
 //!
-//!     decode_surface(&out.path(), (0, 0));
+//!     decode_layer(&out.path(), (0, 0));
 //! }
 //! ```
 //!


### PR DESCRIPTION
This PR replaces the word "surfaces" with "layers" to describe submessages.

The word "surface" has been used in README.md and elsewhere as a plain term to describe the concept of a submessage, but this is not appropriate, since a single submessage can have multiple surfaces.