### PR TITLE
Fix an issue that `size_hint()` results do not change after consuming iterator items

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -278,7 +278,7 @@ impl<'a, R> Iterator for SubmessageIterator<'a, R> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.context.submessages.len();
+        let size = self.context.submessages.len() - self.pos;
         (size, Some(size))
     }
 

--- a/src/decoders/bitmap.rs
+++ b/src/decoders/bitmap.rs
@@ -55,7 +55,8 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
+        let size = self.len - self.offset;
+        (size, Some(size))
     }
 }
 
@@ -118,5 +119,18 @@ mod test {
             .iter()
             .zip(expected.iter())
             .all(|(a, b)| (a.is_nan() && b.is_nan()) || (a == b));
+    }
+
+    #[test]
+    fn bitmap_iterator_size_hint() {
+        let bitmap = vec![0b01001100u8, 0b01110000, 0b11110000];
+        let values = (0..10).map(|n| n as f32).collect::<Vec<_>>();
+        let values = values.into_iter();
+
+        let mut iter = BitmapDecodeIterator::new(bitmap.iter(), values, 24).unwrap();
+
+        assert_eq!(iter.size_hint(), (24, Some(24)));
+        let _ = iter.next();
+        assert_eq!(iter.size_hint(), (23, Some(23)));
     }
 }

--- a/src/decoders/bitmap.rs
+++ b/src/decoders/bitmap.rs
@@ -34,7 +34,7 @@ where
 {
     type Item = f32;
 
-    fn next(&mut self) -> Option<f32> {
+    fn next(&mut self) -> Option<Self::Item> {
         let offset = self.offset;
         if offset >= self.len {
             return None;

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -147,7 +147,7 @@ where
 {
     type Item = Vec<i32>;
 
-    fn next(&mut self) -> Option<Vec<i32>> {
+    fn next(&mut self) -> Option<Self::Item> {
         match (
             self.ref_iter.next(),
             self.width_iter.next(),
@@ -205,7 +205,7 @@ impl<I> SpatialDiff2ndOrderDecodeIterator<I> {
 impl<I: Iterator<Item = i32>> Iterator for SpatialDiff2ndOrderDecodeIterator<I> {
     type Item = i32;
 
-    fn next(&mut self) -> Option<i32> {
+    fn next(&mut self) -> Option<Self::Item> {
         let count = self.count;
         self.count += 1;
         match (count, self.iter.next()) {

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -91,7 +91,7 @@ impl<I> SimplePackingDecodeIterator<I> {
 impl<I: Iterator<Item = N>, N: ToPrimitive> Iterator for SimplePackingDecodeIterator<I> {
     type Item = f32;
 
-    fn next(&mut self) -> Option<f32> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.iter.next() {
             Some(encoded) => {
                 let encoded = encoded.to_f32().unwrap();

--- a/src/decoders/simple.rs
+++ b/src/decoders/simple.rs
@@ -137,7 +137,8 @@ impl Iterator for FixedValueIterator {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.length, Some(self.length))
+        let size = self.length - self.pos;
+        (size, Some(size))
     }
 }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -209,7 +209,7 @@ impl Iterator for LatLonGridIterator {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.major.len() * self.minor.len();
+        let len = (self.major.len() - self.major_pos) * self.minor.len() - self.minor_pos;
         (len, Some(len))
     }
 }
@@ -469,5 +469,17 @@ mod tests {
                 (0., 11.),
             ]
         ),
+    }
+
+    #[test]
+    fn lat_lon_grid_iterator_size_hint() {
+        let lat = (0..3).into_iter().map(|i| i as f32).collect();
+        let lon = (10..12).into_iter().map(|i| i as f32).collect();
+        let scanning_mode = ScanningMode(0b00000000);
+        let mut iter = LatLonGridIterator::new(lat, lon, scanning_mode);
+
+        assert_eq!(iter.size_hint(), (6, Some(6)));
+        let _ = iter.next();
+        assert_eq!(iter.size_hint(), (5, Some(5)));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -120,7 +120,7 @@ where
 {
     type Item = Result<(usize, usize, Submessage), ParseError>;
 
-    fn next(&mut self) -> Option<Result<(usize, usize, Submessage), ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         let mut sect4 = Default::default();
         let mut sect5 = Default::default();
         let mut sect6 = Default::default();
@@ -235,7 +235,7 @@ where
 {
     type Item = Result<Grib2SubmessageIndex, ParseError>;
 
-    fn next(&mut self) -> Option<Result<Grib2SubmessageIndex, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         let mut sect4 = Default::default();
         let mut sect5 = Default::default();
         let mut sect6 = Default::default();
@@ -493,7 +493,7 @@ where
 {
     type Item = Result<(usize, usize, usize, SectionInfo), ParseError>;
 
-    fn next(&mut self) -> Option<Result<(usize, usize, usize, SectionInfo), ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.state {
             Grib2SubmessageValidatorState::EndOfStream => None,
             Grib2SubmessageValidatorState::StartOfMessage => self.ensure_next_is_sect0(),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -159,7 +159,7 @@ where
 {
     type Item = Result<SectionInfo, ParseError>;
 
-    fn next(&mut self) -> Option<Result<SectionInfo, ParseError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.rest_size {
             0 => self.next_sect0(),
             SECT8_ES_SIZE => self.next_sect8(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -84,7 +84,7 @@ impl<'a> NBitwiseIterator<'a> {
 impl<'a> Iterator for NBitwiseIterator<'a> {
     type Item = u32;
 
-    fn next(&mut self) -> Option<u32> {
+    fn next(&mut self) -> Option<Self::Item> {
         let new_offset = self.offset + self.size;
         let (new_pos, new_offset) = (self.pos + new_offset / 8, new_offset % 8);
 


### PR DESCRIPTION
This PR fixes an issue that `size_hint()` results do not change after consuming iterator items.

The implementation of `size_hint()` should return the bounds on the _remaining_ length of the iterator.

Closes #50.