### PR TITLE
Suggest `git submodule update --init` in build failure

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,10 @@
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-};
+use std::{env, fs, path::Path};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
-    if let Err(e) = check_nonemptiness(&PathBuf::from("def/CCT"))
-        .and(check_nonemptiness(&PathBuf::from("def/GRIB2")))
+    if let Err(e) =
+        check_nonemptiness(Path::new("def/CCT")).and(check_nonemptiness(Path::new("def/GRIB2")))
     {
         return Err(format!("{}; run `git submodule update --init`", e).into());
     }
@@ -48,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn check_nonemptiness(dir: &PathBuf) -> Result<(), String> {
+fn check_nonemptiness(dir: &Path) -> Result<(), String> {
     dir.read_dir()
         .map_err(|_| format!("{} is not a directory", dir.to_string_lossy()))
         .and_then(|mut iter| {

--- a/build.rs
+++ b/build.rs
@@ -3,23 +3,23 @@ use std::{
     path::{Path, PathBuf},
 };
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
     if let Err(e) = check_nonemptiness(&PathBuf::from("def/CCT"))
         .and(check_nonemptiness(&PathBuf::from("def/GRIB2")))
     {
-        panic!("error: {e}; run `git submodule update --init`")
+        return Err(format!("error: {}; run `git submodule update --init`", e).into());
     }
 
     let input_file_names = ["def/CCT/C00.csv", "def/CCT/C11.csv"];
     let mut db = grib_build::cct_csv::CodeDB::new();
     let output_path = Path::new(&out_dir).join("cct.rs");
     for path in &input_file_names {
-        db.load(path).unwrap();
+        db.load(path)?;
         println!("cargo:rerun-if-changed={path}");
     }
-    fs::write(output_path, format!("{db}")).unwrap();
+    fs::write(output_path, format!("{db}"))?;
 
     let input_file_names = [
         "def/GRIB2/GRIB2_CodeFlag_0_0_CodeTable_en.csv",
@@ -39,12 +39,13 @@ fn main() {
     let mut db = grib_build::grib2_codeflag_csv::CodeDB::new();
     let output_path = Path::new(&out_dir).join("grib2_codeflag.rs");
     for path in &input_file_names {
-        db.load(path).unwrap();
+        db.load(path)?;
         println!("cargo:rerun-if-changed={path}");
     }
-    fs::write(output_path, format!("{db}")).unwrap();
+    fs::write(output_path, format!("{db}"))?;
 
     println!("cargo:rerun-if-changed=build.rs");
+    Ok(())
 }
 
 fn check_nonemptiness(dir: &PathBuf) -> Result<(), String> {

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Err(e) = check_nonemptiness(&PathBuf::from("def/CCT"))
         .and(check_nonemptiness(&PathBuf::from("def/GRIB2")))
     {
-        return Err(format!("error: {}; run `git submodule update --init`", e).into());
+        return Err(format!("{}; run `git submodule update --init`", e).into());
     }
 
     let input_file_names = ["def/CCT/C00.csv", "def/CCT/C11.csv"];


### PR DESCRIPTION
This PR improves an error message from `cargo build` to suggest `git submodule update --init`.

Current:

    Caused by:
      process didn't exit successfully: `/path/to/grib-rs/target/.../build-script-build` (exit status: 101)
      --- stderr
      thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', build.rs:10:23
      note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

After improvement:

    Caused by:
      process didn't exit successfully: `/path/to/grib-rs/target/.../build-script-build` (exit status: 1)
      --- stderr
      Error: "def/CCT is empty; run `git submodule update --init`"

### Motivation

A senior member of the company I am working for asked me when he had an error trying to build grib-rs.
I could instantly imagine that the cause was the absence of submodules, but the error message certainly seemed confusing to users.