### PR TITLE
NDFD GRIB data support part 4: correctly handle cases where nbit is 0 in the complex packing decoder

### DIFF
--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -219,13 +219,13 @@ test_operation_with_data_with_nan_values_as_little_endian! {
         "-l",
         utils::testdata::flat_binary::noaa_ndfd_critfireo_0_le()?
     ),
-    // (
-    //     decoding_complex_packing_without_spatial_differencing_as_little_endian_when_nbit_is_zero,
-    //     utils::testdata::grib2::noaa_ndfd_critfireo()?,
-    //     "1.0",
-    //     "-l",
-    //     utils::testdata::flat_binary::noaa_ndfd_critfireo_1_le()?
-    // ),
+    (
+        decoding_complex_packing_without_spatial_differencing_as_little_endian_when_nbit_is_zero,
+        utils::testdata::grib2::noaa_ndfd_critfireo()?,
+        "1.0",
+        "-l",
+        utils::testdata::flat_binary::noaa_ndfd_critfireo_1_le()?
+    ),
     (
         decoding_complex_packing_with_missing_value_management_as_little_endian,
         utils::testdata::grib2::noaa_ndfd_minrh()?,

--- a/cli/tests/cli/utils/testdata.rs
+++ b/cli/tests/cli/utils/testdata.rs
@@ -174,7 +174,6 @@ pub(crate) mod flat_binary {
         unxz_as_bytes(testdata_dir().join("gen").join("ds.critfireo.bin.0.xz"))
     }
 
-    #[allow(dead_code)]
     pub(crate) fn noaa_ndfd_critfireo_1_le() -> Result<Vec<u8>, io::Error> {
         unxz_as_bytes(testdata_dir().join("gen").join("ds.critfireo.bin.1.xz"))
     }

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -30,9 +30,11 @@ pub(crate) fn decode_without_spdiff(
     let complex_param = ComplexPackingParam::from_buf(&sect5_data[16..42]);
 
     if simple_param.nbit == 0 {
-        return Err(GribError::DecodeError(
-            DecodeError::ComplexPackingDecodeError(ComplexPackingDecodeError::NotSupported),
+        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
+            simple_param.ref_val,
+            target.num_points_encoded,
         ));
+        return Ok(decoder);
     };
 
     if complex_param.group_splitting_method_used != 1

--- a/src/decoders/complex.rs
+++ b/src/decoders/complex.rs
@@ -10,7 +10,7 @@ use crate::{
         simple::*,
     },
     error::*,
-    utils::{read_as, GribInt, NBitwiseIterator},
+    utils::{read_as, BitStream, GribInt, NBitwiseIterator},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,14 +28,6 @@ pub(crate) fn decode_without_spdiff(
     let sect5_data = &target.sect5_payload;
     let simple_param = SimplePackingParam::from_buf(&sect5_data[6..15]);
     let complex_param = ComplexPackingParam::from_buf(&sect5_data[16..42]);
-
-    if simple_param.nbit == 0 {
-        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
-            simple_param.ref_val,
-            target.num_points_encoded,
-        ));
-        return Ok(decoder);
-    };
 
     if complex_param.group_splitting_method_used != 1
         || complex_param.missing_value_management_used > 2
@@ -61,23 +53,26 @@ pub(crate) fn decode_without_spdiff(
     let group_lens_end_octet = group_widths_end_octet
         + get_octet_length(complex_param.group_len_nbit, complex_param.ngroup);
 
-    let group_refs_iter = NBitwiseIterator::new(
+    let group_refs_iter = BitStream::new(
         &sect7_data[params_end_octet..group_refs_end_octet],
         usize::from(simple_param.nbit),
+        complex_param.ngroup as usize,
     );
     let group_refs_iter = group_refs_iter.take(complex_param.ngroup as usize);
 
-    let group_widths_iter = NBitwiseIterator::new(
+    let group_widths_iter = BitStream::new(
         &sect7_data[group_refs_end_octet..group_widths_end_octet],
         usize::from(complex_param.group_width_nbit),
+        complex_param.ngroup as usize,
     );
     let group_widths_iter = group_widths_iter
         .take(complex_param.ngroup as usize)
         .map(move |v| u32::from(complex_param.group_width_ref) + v);
 
-    let group_lens_iter = NBitwiseIterator::new(
+    let group_lens_iter = BitStream::new(
         &sect7_data[group_widths_end_octet..group_lens_end_octet],
         usize::from(complex_param.group_len_nbit),
+        (complex_param.ngroup - 1) as usize,
     );
     let group_lens_iter = group_lens_iter
         .take((complex_param.ngroup - 1) as usize)
@@ -111,14 +106,6 @@ pub(crate) fn decode(
     let spdiff_level = read_as!(u8, sect5_data, 42);
     let spdiff_param_octet = read_as!(u8, sect5_data, 43);
 
-    if simple_param.nbit == 0 {
-        let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
-            simple_param.ref_val,
-            target.num_points_encoded,
-        ));
-        return Ok(decoder);
-    };
-
     if complex_param.group_splitting_method_used != 1
         || complex_param.missing_value_management_used > 2
     {
@@ -148,23 +135,26 @@ pub(crate) fn decode(
     let group_lens_end_octet = group_widths_end_octet
         + get_octet_length(complex_param.group_len_nbit, complex_param.ngroup);
 
-    let group_refs_iter = NBitwiseIterator::new(
+    let group_refs_iter = BitStream::new(
         &sect7_data[params_end_octet..group_refs_end_octet],
         usize::from(simple_param.nbit),
+        complex_param.ngroup as usize,
     );
     let group_refs_iter = group_refs_iter.take(complex_param.ngroup as usize);
 
-    let group_widths_iter = NBitwiseIterator::new(
+    let group_widths_iter = BitStream::new(
         &sect7_data[group_refs_end_octet..group_widths_end_octet],
         usize::from(complex_param.group_width_nbit),
+        complex_param.ngroup as usize,
     );
     let group_widths_iter = group_widths_iter
         .take(complex_param.ngroup as usize)
         .map(move |v| u32::from(complex_param.group_width_ref) + v);
 
-    let group_lens_iter = NBitwiseIterator::new(
+    let group_lens_iter = BitStream::new(
         &sect7_data[group_widths_end_octet..group_lens_end_octet],
         usize::from(complex_param.group_len_nbit),
+        (complex_param.ngroup - 1) as usize,
     );
     let group_lens_iter = group_lens_iter
         .take((complex_param.ngroup - 1) as usize)


### PR DESCRIPTION
This PR adds support for Code Table 5.5 (missing value management for complex packing).

The logic for decoding complex packing when nbit is 0 was incorrect and wrong values were output.
The reason was that I wrote the process based on an incorrect understanding.
This time I read the source code of wgrib2, understood it again, and rewrote the process.

This is the 4th step of NDFD GRIB data support discussed in #59.