### PR TITLE
NDFD GRIB data support part 8: add support for Template 3.30 (Lambert conformal)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+          - os: ubuntu-latest
+            features: --features gridpoints-proj
+          - os: windows-latest
+          - os: macOS-latest
+          - os: macOS-latest
+            features: --features gridpoints-proj
 
     runs-on: ${{ matrix.os }}
 
@@ -42,9 +49,9 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
     - name: Build
-      run: cargo build --verbose --workspace
+      run: cargo build --verbose --workspace ${{ matrix.features }}
     - name: Run tests
-      run: cargo test --verbose --workspace
+      run: cargo test --verbose --workspace ${{ matrix.features }}
 
   build_wasm:
     name: Building library for wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
         env:
           RUSTFLAGS: -Z sanitizer=address
           RUSTDOCFLAGS: -Z sanitizer=address
-        run: cargo test --target x86_64-unknown-linux-gnu --workspace
+        run: cargo test --target x86_64-unknown-linux-gnu --workspace --features gridpoints-proj

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ chrono = "0.4.23" # `TimeZone::with_ymd_and_hms` needed
 num = "0.4"
 num_enum = "0.7"
 png = "0.17"
-proj = "0.27"
+proj = { version = "0.27", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 openjpeg-sys = "1.0.5" # avoiding 1.0.2/1.0.4
@@ -43,6 +43,9 @@ xz2 = "0.1"
 
 [build-dependencies]
 grib-build = { path = "gen", version = "0.4.2" }
+
+[features]
+proj = ["dep:proj"]
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ chrono = "0.4.23" # `TimeZone::with_ymd_and_hms` needed
 num = "0.4"
 num_enum = "0.7"
 png = "0.17"
+proj = "0.27"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 openjpeg-sys = "1.0.5" # avoiding 1.0.2/1.0.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ xz2 = "0.1"
 grib-build = { path = "gen", version = "0.4.2" }
 
 [features]
-proj = ["dep:proj"]
+gridpoints-proj = ["dep:proj"]
 
 [profile.release]
 strip = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = "1.13"
 regex = "1.6"
 
 [target.'cfg(unix)'.dependencies]
-grib = { path = "..", version = "=0.8.0", features = ["proj"] }
+grib = { path = "..", version = "=0.8.0", features = ["gridpoints-proj"] }
 pager = "0.16"
 which = "4"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,13 +23,16 @@ chrono = "0.4.23"
 clap = "4.1"
 clap_complete = "4"
 console = "0.15"
-grib = { path = "..", version = "=0.8.0" }
 once_cell = "1.13"
 regex = "1.6"
 
 [target.'cfg(unix)'.dependencies]
+grib = { path = "..", version = "=0.8.0", features = ["proj"] }
 pager = "0.16"
 which = "4"
+
+[target.'cfg(not(unix))'.dependencies]
+grib = { path = "..", version = "=0.8.0" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -230,7 +230,7 @@ impl TryFrom<&GridDefinition> for GridDefinitionTemplateValues {
             30 => {
                 let buf = &value.payload;
                 Ok(GridDefinitionTemplateValues::Template30(
-                    LambertGridDefinition::from_buf(&buf[25..]),
+                    LambertGridDefinition::from_buf(&buf[9..]),
                 ))
             }
             _ => Err(GribError::NotSupported(format!("template {num}"))),

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -209,7 +209,15 @@ impl GridDefinitionTemplateValues {
     pub fn latlons(&self) -> Result<GridPointIterator, GribError> {
         let iter = match self {
             Self::Template0(def) => GridPointIterator::LatLon(def.latlons()?),
+            #[cfg(feature = "proj")]
             Self::Template30(def) => GridPointIterator::Lambert(def.latlons()?),
+            #[cfg(not(feature = "proj"))]
+            Self::Template30(_) => {
+                return Err(GribError::NotSupported(
+                    "lat/lon computation support for the template is dropped in this build"
+                        .to_owned(),
+                ))
+            }
         };
         Ok(iter)
     }

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -209,9 +209,9 @@ impl GridDefinitionTemplateValues {
     pub fn latlons(&self) -> Result<GridPointIterator, GribError> {
         let iter = match self {
             Self::Template0(def) => GridPointIterator::LatLon(def.latlons()?),
-            #[cfg(feature = "proj")]
+            #[cfg(feature = "gridpoints-proj")]
             Self::Template30(def) => GridPointIterator::Lambert(def.latlons()?),
-            #[cfg(not(feature = "proj"))]
+            #[cfg(not(feature = "gridpoints-proj"))]
             Self::Template30(_) => {
                 return Err(GribError::NotSupported(
                     "lat/lon computation support for the template is dropped in this build"

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -529,15 +529,15 @@ mod tests {
         .unwrap();
 
         let actual = GridDefinitionTemplateValues::try_from(&data).unwrap();
-        let expected = GridDefinitionTemplateValues::Template0(LatLonGridDefinition::new(
-            256,
-            336,
-            47958333,
-            118062500,
-            20041667,
-            149937500,
-            crate::grid::ScanningMode(0b00000000),
-        ));
+        let expected = GridDefinitionTemplateValues::Template0(LatLonGridDefinition {
+            ni: 256,
+            nj: 336,
+            first_point_lat: 47958333,
+            first_point_lon: 118062500,
+            last_point_lat: 20041667,
+            last_point_lon: 149937500,
+            scanning_mode: crate::grid::ScanningMode(0b00000000),
+        });
         assert_eq!(actual, expected);
     }
 

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -209,11 +209,7 @@ impl GridDefinitionTemplateValues {
     pub fn latlons(&self) -> Result<GridPointIterator, GribError> {
         let iter = match self {
             Self::Template0(def) => GridPointIterator::LatLon(def.latlons()?),
-            Self::Template30(_def) => {
-                return Err(GribError::NotSupported(format!(
-                    "lat/lon calculation is not supported for this template"
-                )))
-            }
+            Self::Template30(def) => GridPointIterator::Lambert(def.latlons()?),
         };
         Ok(iter)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum GribError {
     DecodeError(DecodeError),
     InvalidValueError(String),
     NotSupported(String),
+    Unknown(String),
 }
 
 impl Error for GribError {
@@ -41,6 +42,7 @@ impl Display for GribError {
             Self::DecodeError(e) => write!(f, "{e:#?}"),
             Self::InvalidValueError(s) => write!(f, "invalid value ({s})"),
             Self::NotSupported(s) => write!(f, "not supported ({s})"),
+            Self::Unknown(s) => write!(f, "unknown error: {s}"),
         }
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -43,26 +43,6 @@ pub struct LatLonGridDefinition {
 }
 
 impl LatLonGridDefinition {
-    pub(crate) fn new(
-        ni: u32,
-        nj: u32,
-        first_point_lat: i32,
-        first_point_lon: i32,
-        last_point_lat: i32,
-        last_point_lon: i32,
-        scanning_mode: ScanningMode,
-    ) -> Self {
-        Self {
-            ni,
-            nj,
-            first_point_lat,
-            first_point_lon,
-            last_point_lat,
-            last_point_lon,
-            scanning_mode,
-        }
-    }
-
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number
@@ -164,15 +144,15 @@ impl LatLonGridDefinition {
         let last_point_lat = read_as!(u32, buf, 25).as_grib_int();
         let last_point_lon = read_as!(u32, buf, 29).as_grib_int();
         let scanning_mode = read_as!(u8, buf, 41);
-        Self::new(
+        Self {
             ni,
             nj,
             first_point_lat,
             first_point_lon,
             last_point_lat,
             last_point_lon,
-            ScanningMode(scanning_mode),
-        )
+            scanning_mode: ScanningMode(scanning_mode),
+        }
     }
 }
 
@@ -192,35 +172,6 @@ pub struct LambertGridDefinition {
 }
 
 impl LambertGridDefinition {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        ni: u32,
-        nj: u32,
-        first_point_lat: i32,
-        first_point_lon: i32,
-        lad: i32,
-        lov: i32,
-        dx: u32,
-        dy: u32,
-        scanning_mode: ScanningMode,
-        latin1: i32,
-        latin2: i32,
-    ) -> Self {
-        Self {
-            ni,
-            nj,
-            first_point_lat,
-            first_point_lon,
-            lad,
-            lov,
-            dx,
-            dy,
-            scanning_mode,
-            latin1,
-            latin2,
-        }
-    }
-
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number
@@ -274,7 +225,7 @@ impl LambertGridDefinition {
         let scanning_mode = read_as!(u8, buf, 34);
         let latin1 = read_as!(u32, buf, 35).as_grib_int();
         let latin2 = read_as!(u32, buf, 39).as_grib_int();
-        Self::new(
+        Self {
             ni,
             nj,
             first_point_lat,
@@ -283,10 +234,10 @@ impl LambertGridDefinition {
             lov,
             dx,
             dy,
-            ScanningMode(scanning_mode),
+            scanning_mode: ScanningMode(scanning_mode),
             latin1,
             latin2,
-        )
+        }
     }
 }
 
@@ -467,15 +418,15 @@ mod tests {
 
     #[test]
     fn test_lat_lon_grid_definition_and_iteration() {
-        let grid = LatLonGridDefinition::new(
-            3,
-            2,
-            36_000_000,
-            135_000_000,
-            35_000_000,
-            137_000_000,
-            ScanningMode(0b00000000),
-        );
+        let grid = LatLonGridDefinition {
+            ni: 3,
+            nj: 2,
+            first_point_lat: 36_000_000,
+            first_point_lon: 135_000_000,
+            last_point_lat: 35_000_000,
+            last_point_lon: 137_000_000,
+            scanning_mode: ScanningMode(0b00000000),
+        };
         let actual = grid.latlons().unwrap().collect::<Vec<_>>();
         let expected = vec![
             (36., 135.),
@@ -500,15 +451,15 @@ mod tests {
         ),)*) => ($(
             #[test]
             fn $name() {
-                let grid = LatLonGridDefinition::new(
-                    1,
-                    1,
-                    $first_point_lat,
-                    $first_point_lon,
-                    $last_point_lat,
-                    $last_point_lon,
-                    ScanningMode($scanning_mode),
-                );
+                let grid = LatLonGridDefinition {
+                    ni: 1,
+                    nj: 1,
+                    first_point_lat: $first_point_lat,
+                    first_point_lon: $first_point_lon,
+                    last_point_lat: $last_point_lat,
+                    last_point_lon: $last_point_lon,
+                    scanning_mode: ScanningMode($scanning_mode),
+                };
                 assert_eq!(grid.is_consistent(), $expected)
             }
         )*);
@@ -677,19 +628,19 @@ mod tests {
         f.read_to_end(&mut buf)?;
 
         let actual = LambertGridDefinition::from_buf(&buf[0x93..]);
-        let expected = LambertGridDefinition::new(
-            2145,
-            1377,
-            20190000,
-            238449996,
-            25000000,
-            265000000,
-            2539703,
-            2539703,
-            ScanningMode(0b01010000),
-            25000000,
-            25000000,
-        );
+        let expected = LambertGridDefinition {
+            ni: 2145,
+            nj: 1377,
+            first_point_lat: 20190000,
+            first_point_lon: 238449996,
+            lad: 25000000,
+            lov: 265000000,
+            dx: 2539703,
+            dy: 2539703,
+            scanning_mode: ScanningMode(0b01010000),
+            latin1: 25000000,
+            latin2: 25000000,
+        };
         assert_eq!(actual, expected);
 
         Ok(())

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "proj")]
+#[cfg(feature = "gridpoints-proj")]
 use proj::Proj;
 
 pub use self::earth::EarthShapeDefinition;
@@ -235,7 +235,7 @@ impl LambertGridDefinition {
     /// Note that this is a low-level API and it is not checked that the number
     /// of iterator iterations is consistent with the number of grid points
     /// defined in the data.
-    #[cfg(feature = "proj")]
+    #[cfg(feature = "gridpoints-proj")]
     pub fn latlons(&self) -> Result<std::vec::IntoIter<(f32, f32)>, GribError> {
         let lad = self.lad as f64 * 1e-6;
         let lov = self.lov as f64 * 1e-6;
@@ -754,7 +754,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "proj")]
+    #[cfg(feature = "gridpoints-proj")]
     #[test]
     fn lambert_grid_latlon_computation() -> Result<(), Box<dyn std::error::Error>> {
         let grid_def = LambertGridDefinition {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -478,6 +478,19 @@ mod tests {
 
     use super::*;
 
+    macro_rules! assert_almost_eq {
+        ($a1:expr, $a2:expr, $d:expr) => {
+            if !($a1 - $a2 < $d || $a2 - $a1 < $d) {
+                panic!();
+            }
+        };
+    }
+
+    fn assert_coord_almost_eq((x1, y1): (f32, f32), (x2, y2): (f32, f32), delta: f32) {
+        assert_almost_eq!(x1, x2, delta);
+        assert_almost_eq!(y1, y2, delta);
+    }
+
     #[test]
     fn test_lat_lon_grid_definition_and_iteration() {
         let grid = LatLonGridDefinition {
@@ -704,6 +717,39 @@ mod tests {
             latin2: 25000000,
         };
         assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn lambert_grid_latlon_computation() -> Result<(), Box<dyn std::error::Error>> {
+        let grid_def = LambertGridDefinition {
+            ni: 2145,
+            nj: 1377,
+            first_point_lat: 20190000,
+            first_point_lon: 238449996,
+            lad: 25000000,
+            lov: 265000000,
+            dx: 2539703,
+            dy: 2539703,
+            scanning_mode: ScanningMode(0b01010000),
+            latin1: 25000000,
+            latin2: 25000000,
+        };
+        let latlons = grid_def.latlons()?.collect::<Vec<_>>();
+        let delta = 1e-10;
+        assert_coord_almost_eq(latlons[0], (20.19, -121.550004), delta);
+        assert_coord_almost_eq(latlons[1], (20.19442682, -121.52621665), delta);
+        assert_coord_almost_eq(
+            latlons[latlons.len() - 2],
+            (50.10756403, -60.91298217),
+            delta,
+        );
+        assert_coord_almost_eq(
+            latlons[latlons.len() - 1],
+            (50.1024611, -60.88202274),
+            delta,
+        );
 
         Ok(())
     }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "proj")]
 use proj::Proj;
 
 pub use self::earth::EarthShapeDefinition;
@@ -234,6 +235,7 @@ impl LambertGridDefinition {
     /// Note that this is a low-level API and it is not checked that the number
     /// of iterator iterations is consistent with the number of grid points
     /// defined in the data.
+    #[cfg(feature = "proj")]
     pub fn latlons(&self) -> Result<std::vec::IntoIter<(f32, f32)>, GribError> {
         let lad = self.lad as f64 * 1e-6;
         let lov = self.lov as f64 * 1e-6;
@@ -752,6 +754,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "proj")]
     #[test]
     fn lambert_grid_latlon_computation() -> Result<(), Box<dyn std::error::Error>> {
         let grid_def = LambertGridDefinition {


### PR DESCRIPTION
This PR adds support for Template 3.30 (Lambert conformal) using `proj` crate.

As part of Template 3.30 support, this PR introduces a feature named `gridpoints-proj`.
This feature has two roles:

- first, to allow users to choose to do their own geographic calculations;
- second, to make it easier to build this crate, even for targets that have difficulty building `proj` crate that wraps PROJ written in C++.