### PR TITLE
Example GRIB2 viewer web app

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy the latest documentation to GitHub Pages
+name: Deploy the latest documentation and WASM app to GitHub Pages
 on:
   push:
     branches: [ master ]
@@ -24,14 +24,36 @@ jobs:
           submodules: recursive
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
       - name: Build documentation
         run: cargo doc --no-deps --release
+      - name: Stage documentation
+        run: mv target/doc dist
+
+      - name: Install trunk
+        run: wget -qO- https://github.com/thedodd/trunk/releases/download/v0.16.0/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+      - name: Build WASM
+        run: ../trunk build --public-url /grib-rs/viewer/ --release
+        working-directory: ./web
+      - name: Stage WASM
+        run: mv web/dist dist/viewer
+
+      - name: Fix file permissions
+        shell: sh
+        run: |
+          chmod -c -R +rX dist |
+          while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./target/doc
+          path: ./dist
 
   deploy:
     environment:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 exclude = ["/.github", "/testdata"]
 
 [workspace]
-members = ["gen", "cli"]
+members = ["gen", "cli", "web"]
 
 [workspace.package]
 version = "0.9.2"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This is a GRIB format parser library written in [Rust](https://www.rust-lang.org
 
 GRIB is a concise data format commonly used in meteorology to store historical and forecast weather data. It is intended to be a container of a collection of records of 2D data. GRIB files are huge and binary and should be processed efficiently. Also, since GRIB is designed to support various grid types and data compression using parameters defined in external code tables and templates, some popular existing softwares cannot handle some GRIB data.
 
+## Example web application
+
+Example GRIB2 viewer web app using the crate is available [here](https://noritada.github.io/grib-rs/viewer/).
+
+After loaded, the app works completely on your web browser and will not send the data you drop anywhere.
+
 ## Vision
 
 A world where everyone can read weather data easily although its interpretation needs some specific knowledge and experience.

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "grib-web"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = [
+    "DataTransfer",
+    "DomTokenList",
+    "Element",
+    "FileList",
+    "DragEvent",
+] }
+yew = { version = "0.20", features = ["csr"] }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,4 +18,4 @@ web-sys = { version = "0.3", features = [
     "FileList",
     "DragEvent",
 ] }
-yew = { version = "0.20", features = ["csr"] }
+yew = { version = "0.21", features = ["csr"] }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 gloo-file = { version = "0.3", features = ["futures"] }
-grib = { path = "..", version = "0.9.1" }
+grib = { path = "..", version = "0.9.2" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -6,8 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+gloo-file = { version = "0.3", features = ["futures"] }
+grib = { path = "..", version = "0.9.1" }
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [
+    "Blob",
     "DataTransfer",
     "DomTokenList",
     "Element",

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,8 @@
                 width: 100%;
                 box-sizing: border-box;
                 padding: 12px;
+                display: flex;
+                flex-direction: column;
             }
 
             .invisible {
@@ -31,6 +33,7 @@
                 width: 100%;
                 box-sizing: border-box;
                 padding: 5%;
+                z-index: 2;
                 background-color: #fff;
             }
 
@@ -48,6 +51,31 @@
 
             #drop-zone.dragover #drop-zone-content {
                 border-color: #000;
+                background-color: #f9f9f9;
+            }
+
+            #submessage_list {
+                flex: 1;
+                overflow: auto;
+            }
+
+            #submessage_list table {
+                border-collapse: collapse;
+                width: 100%;
+            }
+
+            #submessage_list thead th {
+                position: sticky;
+                top: 0;
+                z-index: 1;
+                background-color: #ccc;
+            }
+
+            tr:nth-child(odd) {
+                background-color: #eee;
+            }
+
+            tr:nth-child(even) {
                 background-color: #f9f9f9;
             }
         </style>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>GRIB2 Data Viewer</title>
+        <style>
+            body {
+                position: relative;
+                margin: 0;
+                padding: 0;
+                height: 100vh;
+                font-family: Arial, sans-serif;
+                text-align: center;
+            }
+
+            #main {
+                position: absolute;
+                height: 100%;
+                width: 100%;
+                box-sizing: border-box;
+                padding: 12px;
+            }
+
+            .invisible {
+                display: none;
+            }
+
+            #drop-zone {
+                position: absolute;
+                height: 100%;
+                width: 100%;
+                box-sizing: border-box;
+                padding: 5%;
+                background-color: #fff;
+            }
+
+            #drop-zone-content {
+                height: 100%;
+                box-sizing: border-box;
+                border: 10px dashed #ccc;
+                font-size: 60px;
+                line-height: 1.5;
+                color: #666;
+                border-radius: 30px;
+                transition: all 0.3s ease-in-out;
+                pointer-events: none;
+            }
+
+            #drop-zone.dragover #drop-zone-content {
+                border-color: #000;
+                background-color: #f9f9f9;
+            }
+        </style>
+    </head>
+    <body></body>
+</html>

--- a/web/src/drop_area.rs
+++ b/web/src/drop_area.rs
@@ -1,0 +1,106 @@
+use wasm_bindgen::JsCast;
+use web_sys::Element;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct FileDropAreaProps {
+    pub first_time: bool,
+    pub on_drop: Callback<web_sys::File>,
+}
+
+#[function_component(FileDropArea)]
+pub(crate) fn file_drop_area(
+    FileDropAreaProps {
+        first_time,
+        on_drop,
+    }: &FileDropAreaProps,
+) -> Html {
+    let on_drag_over = {
+        Callback::from(move |e: DragEvent| {
+            e.prevent_default();
+
+            if let Some(target) = e.target() {
+                let element = target.unchecked_into::<Element>();
+                element
+                    .class_list()
+                    .add_1("dragover")
+                    .expect("adding class 'dragover' failed")
+            }
+        })
+    };
+    let first_time_ = *first_time;
+    let on_drag_leave = {
+        Callback::from(move |e: DragEvent| {
+            e.prevent_default();
+
+            if let Some(target) = e.target() {
+                let element = target.unchecked_into::<Element>();
+                element
+                    .class_list()
+                    .remove_1("dragover")
+                    .expect("removing class 'dragover' failed")
+            }
+
+            if !first_time_ {
+                hide_drop_zone();
+            }
+        })
+    };
+    let on_file_drop = {
+        let on_drop = on_drop.clone();
+        Callback::from(move |e: DragEvent| {
+            e.prevent_default();
+
+            if let Some(target) = e.target() {
+                let element = target.unchecked_into::<Element>();
+                element
+                    .class_list()
+                    .remove_1("dragover")
+                    .expect("removing class 'dragover' failed")
+            }
+
+            hide_drop_zone();
+
+            let item = e
+                .data_transfer()
+                .and_then(|transfer| transfer.files())
+                .and_then(|files| files.item(0));
+            if let Some(item) = item {
+                on_drop.emit(item)
+            }
+        })
+    };
+
+    html! {
+        <div id={ "drop-zone" } ondragover={on_drag_over} ondragleave={on_drag_leave} ondrop={on_file_drop}>
+            <div id="drop-zone-content">
+                <h1>{ "GRIB2 Data Viewer" }</h1>
+                { "Drag and drop file here" }
+            </div>
+        </div>
+    }
+}
+
+pub(crate) fn display_drop_zone() {
+    if let Some(classes) = get_drop_zone_classes() {
+        classes
+            .remove_1("invisible")
+            .expect("removing class 'invisible' failed")
+    }
+}
+
+pub(crate) fn hide_drop_zone() {
+    if let Some(classes) = get_drop_zone_classes() {
+        classes
+            .add_1("invisible")
+            .expect("adding class 'invisible' failed")
+    }
+}
+
+fn get_drop_zone_classes() -> Option<web_sys::DomTokenList> {
+    let window = web_sys::window()?;
+    let document = window.document()?;
+    let element = document.get_element_by_id("drop-zone")?;
+    let class_list = element.class_list();
+    Some(class_list)
+}

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -101,23 +101,25 @@ fn app() -> Html {
         html! {
             <>
                 <div>{format!("{} submessage(s)", len)}</div>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>{"#"}</th>
-                            <th>{"parameter"}</th>
-                            <th>{"generating process"}</th>
-                            <th>{"forecast time"}</th>
-                            <th>{"1st fixed surface"}</th>
-                            <th>{"2nd fixed surface"}</th>
-                            <th>{"#points (nan)"}</th>
-                            <th>{"#points (total)"}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {submessages_html}
-                    </tbody>
-                </table>
+                <div id="submessage_list">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>{"#"}</th>
+                                <th>{"parameter"}</th>
+                                <th>{"generating process"}</th>
+                                <th>{"forecast time"}</th>
+                                <th>{"1st fixed surface"}</th>
+                                <th>{"2nd fixed surface"}</th>
+                                <th>{"#points (nan)"}</th>
+                                <th>{"#points (total)"}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {submessages_html}
+                        </tbody>
+                    </table>
+                </div>
             </>
         }
     } else {
@@ -129,7 +131,7 @@ fn app() -> Html {
             <div id="main" ondragover={ on_drag_over }>
                 <h1>{ "GRIB2 Data Viewer" }</h1>
                 <div>{ file_name }</div>
-                <div>{ listing }</div>
+                { listing }
             </div>
             <FileDropArea first_time={*first_time} on_drop={on_file_drop} />
         </>

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -37,21 +37,18 @@ fn app() -> Html {
     {
         let grib_context = grib_context.clone();
         let file = dropped_file.clone();
-        use_effect_with_deps(
-            move |_| {
-                if let Some(file) = file.as_ref() {
-                    let blob = Blob::from(file.deref().clone());
-                    wasm_bindgen_futures::spawn_local(async move {
-                        let result = read_as_bytes(&blob).await;
-                        if let Ok(bytes_) = result {
-                            let grib = grib::from_reader(std::io::Cursor::new(bytes_));
-                            grib_context.set(grib.ok())
-                        }
-                    });
-                }
-            },
-            dropped_file,
-        );
+        use_effect_with(dropped_file, move |_| {
+            if let Some(file) = file.as_ref() {
+                let blob = Blob::from(file.deref().clone());
+                wasm_bindgen_futures::spawn_local(async move {
+                    let result = read_as_bytes(&blob).await;
+                    if let Ok(bytes_) = result {
+                        let grib = grib::from_reader(std::io::Cursor::new(bytes_));
+                        grib_context.set(grib.ok())
+                    }
+                });
+            }
+        });
     }
 
     let listing = if let Some(context) = grib_context.as_ref() {

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,3 +1,7 @@
+use std::ops::Deref;
+
+use gloo_file::{futures::read_as_bytes, Blob};
+use grib::codetables::{CodeTable4_2, CodeTable4_3, Lookup};
 use yew::prelude::*;
 mod drop_area;
 use drop_area::FileDropArea;
@@ -6,6 +10,7 @@ use drop_area::FileDropArea;
 fn app() -> Html {
     let first_time = use_state(|| true);
     let dropped_file = use_state(|| None);
+    let grib_context = use_state(|| None);
 
     let first_time_ = first_time.clone();
     let on_file_drop = {
@@ -29,11 +34,102 @@ fn app() -> Html {
         })
     };
 
+    {
+        let grib_context = grib_context.clone();
+        let file = dropped_file.clone();
+        use_effect_with_deps(
+            move |_| {
+                if let Some(file) = file.as_ref() {
+                    let blob = Blob::from(file.deref().clone());
+                    wasm_bindgen_futures::spawn_local(async move {
+                        let result = read_as_bytes(&blob).await;
+                        if let Ok(bytes_) = result {
+                            let grib = grib::from_reader(std::io::Cursor::new(bytes_));
+                            grib_context.set(grib.ok())
+                        }
+                    });
+                }
+            },
+            dropped_file,
+        );
+    }
+
+    let listing = if let Some(context) = grib_context.as_ref() {
+        let submessages = context.submessages();
+        let (len, _) = submessages.size_hint();
+        let submessages_html = submessages
+            .map(|(i, submessage)| {
+                let id = format!("{}.{}", i.0, i.1);
+                let prod_def = submessage.prod_def();
+                let category = prod_def
+                    .parameter_category()
+                    .zip(prod_def.parameter_number())
+                    .map(|(c, n)| {
+                        CodeTable4_2::new(submessage.indicator().discipline, c)
+                            .lookup(usize::from(n))
+                            .to_string()
+                    })
+                    .unwrap_or_default();
+                let generating_process = prod_def
+                    .generating_process()
+                    .map(|v| CodeTable4_3.lookup(usize::from(v)).to_string())
+                    .unwrap_or_default();
+                let forecast_time = prod_def
+                    .forecast_time()
+                    .map(|ft| ft.to_string())
+                    .unwrap_or_default();
+                let surfaces = prod_def
+                    .fixed_surfaces()
+                    .map(|(first, second)| (first.value().to_string(), second.value().to_string()))
+                    .unwrap_or((String::new(), String::new()));
+                let num_grid_points = submessage.grid_def().num_points();
+                let num_points_represented = submessage.repr_def().num_points();
+                html! {
+                    <tr>
+                        <td>{id}</td>
+                        <td>{category}</td>
+                        <td>{generating_process}</td>
+                        <td>{forecast_time}</td>
+                        <td>{surfaces.0}</td>
+                        <td>{surfaces.1}</td>
+                        <td>{num_grid_points - num_points_represented}</td>
+                        <td>{num_grid_points}</td>
+                    </tr>
+                }
+            })
+            .collect::<Html>();
+        html! {
+            <>
+                <div>{format!("{} submessage(s)", len)}</div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>{"#"}</th>
+                            <th>{"parameter"}</th>
+                            <th>{"generating process"}</th>
+                            <th>{"forecast time"}</th>
+                            <th>{"1st fixed surface"}</th>
+                            <th>{"2nd fixed surface"}</th>
+                            <th>{"#points (nan)"}</th>
+                            <th>{"#points (total)"}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {submessages_html}
+                    </tbody>
+                </table>
+            </>
+        }
+    } else {
+        html! {}
+    };
+
     html! {
         <>
             <div id="main" ondragover={ on_drag_over }>
                 <h1>{ "GRIB2 Data Viewer" }</h1>
                 <div>{ file_name }</div>
+                <div>{ listing }</div>
             </div>
             <FileDropArea first_time={*first_time} on_drop={on_file_drop} />
         </>

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,0 +1,45 @@
+use yew::prelude::*;
+mod drop_area;
+use drop_area::FileDropArea;
+
+#[function_component(App)]
+fn app() -> Html {
+    let first_time = use_state(|| true);
+    let dropped_file = use_state(|| None);
+
+    let first_time_ = first_time.clone();
+    let on_file_drop = {
+        let dropped_file = dropped_file.clone();
+        Callback::from(move |file: web_sys::File| {
+            dropped_file.set(Some(file));
+            first_time_.set(false);
+        })
+    };
+
+    let file_name = if let Some(file) = dropped_file.as_ref() {
+        file.name()
+    } else {
+        String::new()
+    };
+
+    let on_drag_over = {
+        Callback::from(move |e: DragEvent| {
+            e.prevent_default();
+            drop_area::display_drop_zone();
+        })
+    };
+
+    html! {
+        <>
+            <div id="main" ondragover={ on_drag_over }>
+                <h1>{ "GRIB2 Data Viewer" }</h1>
+                <div>{ file_name }</div>
+            </div>
+            <FileDropArea first_time={*first_time} on_drop={on_file_drop} />
+        </>
+    }
+}
+
+fn main() {
+    yew::Renderer::<App>::new().render();
+}


### PR DESCRIPTION
This PR makes an example GRIB2 viewer web app available on GitHub Pages.
It will be available on https://noritada.github.io/grib-rs/viewer/.

The web app still only has the ability to list submessages in GRIB2.
The ability to display grid point values within submessages will be available in the near future.