### PR TITLE
Add functionality to access the grid shape without iteration

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -458,6 +458,42 @@ Data Representation:                    {}
         )
     }
 
+    /// Returns the shape of the grid, i.e. a tuple of the number of grids in
+    /// the i and j directions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::{
+    ///     fs::File,
+    ///     io::{BufReader, Read},
+    /// };
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let mut buf = Vec::new();
+    ///
+    ///     let f = File::open("testdata/gdas.t12z.pgrb2.0p25.f000.0-10.xz")?;
+    ///     let f = BufReader::new(f);
+    ///     let mut f = xz2::bufread::XzDecoder::new(f);
+    ///     f.read_to_end(&mut buf)?;
+    ///
+    ///     let f = std::io::Cursor::new(buf);
+    ///     let grib2 = grib::from_reader(f)?;
+    ///
+    ///     let mut iter = grib2.iter();
+    ///     let (_, message) = iter.next().ok_or_else(|| "first message is not found")?;
+    ///
+    ///     let shape = message.grid_shape()?;
+    ///     assert_eq!(shape, (1440, 721));
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn grid_shape(&self) -> Result<(usize, usize), GribError> {
+        let grid_def = self.grid_def();
+        let shape = GridDefinitionTemplateValues::try_from(grid_def)?.grid_shape();
+        Ok(shape)
+    }
+
     /// Computes and returns an iterator over `(i, j)` of grid points.
     ///
     /// The order of items is the same as the order of the grid point values,

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -190,6 +190,16 @@ pub enum GridDefinitionTemplateValues {
 }
 
 impl GridDefinitionTemplateValues {
+    /// Returns the shape of the grid, i.e. a tuple of the number of grids in
+    /// the i and j directions.
+    pub fn grid_shape(&self) -> (usize, usize) {
+        match self {
+            Self::Template0(def) => def.grid_shape(),
+            Self::Template20(def) => def.grid_shape(),
+            Self::Template30(def) => def.grid_shape(),
+        }
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -21,6 +21,41 @@ pub struct LambertGridDefinition {
 }
 
 impl LambertGridDefinition {
+    /// Returns the shape of the grid, i.e. a tuple of the number of grids in
+    /// the i and j directions.
+    ///
+    /// Examples
+    ///
+    /// ```
+    /// let def = grib::LambertGridDefinition {
+    ///     earth_shape: grib::EarthShapeDefinition {
+    ///         shape_of_the_earth: 1,
+    ///         scale_factor_of_radius_of_spherical_earth: 0,
+    ///         scaled_value_of_radius_of_spherical_earth: 6371200,
+    ///         scale_factor_of_earth_major_axis: 0,
+    ///         scaled_value_of_earth_major_axis: 0,
+    ///         scale_factor_of_earth_minor_axis: 0,
+    ///         scaled_value_of_earth_minor_axis: 0,
+    ///     },
+    ///     ni: 2,
+    ///     nj: 3,
+    ///     first_point_lat: 0,
+    ///     first_point_lon: 0,
+    ///     lad: 0,
+    ///     lov: 0,
+    ///     dx: 1000,
+    ///     dy: 1000,
+    ///     scanning_mode: grib::ScanningMode(0b01000000),
+    ///     latin1: 0,
+    ///     latin2: 0,
+    /// };
+    /// let shape = def.grid_shape();
+    /// assert_eq!(shape, (2, 3));
+    /// ```
+    pub fn grid_shape(&self) -> (usize, usize) {
+        (self.ni as usize, self.nj as usize)
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number

--- a/src/grid/latlon.rs
+++ b/src/grid/latlon.rs
@@ -16,6 +16,28 @@ pub struct LatLonGridDefinition {
 }
 
 impl LatLonGridDefinition {
+    /// Returns the shape of the grid, i.e. a tuple of the number of grids in
+    /// the i and j directions.
+    ///
+    /// Examples
+    ///
+    /// ```
+    /// let def = grib::LatLonGridDefinition {
+    ///     ni: 2,
+    ///     nj: 3,
+    ///     first_point_lat: 0,
+    ///     first_point_lon: 0,
+    ///     last_point_lat: 2_000_000,
+    ///     last_point_lon: 1_000_000,
+    ///     scanning_mode: grib::ScanningMode(0b01000000),
+    /// };
+    /// let shape = def.grid_shape();
+    /// assert_eq!(shape, (2, 3));
+    /// ```
+    pub fn grid_shape(&self) -> (usize, usize) {
+        (self.ni as usize, self.nj as usize)
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -21,6 +21,40 @@ pub struct PolarStereographicGridDefinition {
 }
 
 impl PolarStereographicGridDefinition {
+    /// Returns the shape of the grid, i.e. a tuple of the number of grids in
+    /// the i and j directions.
+    ///
+    /// Examples
+    ///
+    /// ```
+    /// let def = grib::PolarStereographicGridDefinition {
+    ///     earth_shape: grib::EarthShapeDefinition {
+    ///         shape_of_the_earth: 6,
+    ///         scale_factor_of_radius_of_spherical_earth: 0xff,
+    ///         scaled_value_of_radius_of_spherical_earth: 0xffffffff,
+    ///         scale_factor_of_earth_major_axis: 0xff,
+    ///         scaled_value_of_earth_major_axis: 0xffffffff,
+    ///         scale_factor_of_earth_minor_axis: 0xff,
+    ///         scaled_value_of_earth_minor_axis: 0xffffffff,
+    ///     },
+    ///     ni: 2,
+    ///     nj: 3,
+    ///     first_point_lat: 0,
+    ///     first_point_lon: 0,
+    ///     lad: 0,
+    ///     lov: 0,
+    ///     dx: 1000,
+    ///     dy: 1000,
+    ///     projection_centre: grib::ProjectionCentreFlag(0b00000000),
+    ///     scanning_mode: grib::ScanningMode(0b01000000),
+    /// };
+    /// let shape = def.grid_shape();
+    /// assert_eq!(shape, (2, 3));
+    /// ```
+    pub fn grid_shape(&self) -> (usize, usize) {
+        (self.ni as usize, self.nj as usize)
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number


### PR DESCRIPTION
This PR adds functionality to access the grid shape without iteration.

The shape of the grid is included in the parameters of the grid definition and is therefore accessible to the user if he/she makes the effort, but currently that access is not as easy as it could be.

This feature may be useful when plotting grid point values on canvas, since it allows the distribution of grid points to be known before the actual decoding of the grid point values.