### PR TITLE
Web app: add functionality to display grid point values in a GRIB2 submessage

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -17,5 +17,8 @@ web-sys = { version = "0.3", features = [
     "Element",
     "FileList",
     "DragEvent",
+    "HtmlCanvasElement",
+    "CanvasRenderingContext2d",
+    "ImageData",
 ] }
 yew = { version = "0.21", features = ["csr"] }

--- a/web/index.html
+++ b/web/index.html
@@ -125,6 +125,7 @@
             #grid-canvas {
                 height: 100%;
                 width: 80%;
+                image-rendering: pixelated;
             }
         </style>
     </head>

--- a/web/index.html
+++ b/web/index.html
@@ -33,7 +33,7 @@
                 width: 100%;
                 box-sizing: border-box;
                 padding: 5%;
-                z-index: 2;
+                z-index: 3;
                 background-color: #fff;
             }
 
@@ -103,6 +103,23 @@
 
             tr:nth-child(even) {
                 background-color: #f9f9f9;
+            }
+
+            #submessage-modal {
+                position: absolute;
+                height: 100%;
+                width: 100%;
+                box-sizing: border-box;
+                padding: 5%;
+                z-index: 2;
+                backdrop-filter: blur(3px);
+                background-color: #fff8;
+            }
+
+            #submessage-details {
+                height: 100%;
+                width: 100%;
+                background-color: #eee;
             }
         </style>
     </head>

--- a/web/index.html
+++ b/web/index.html
@@ -121,6 +121,11 @@
                 width: 100%;
                 background-color: #eee;
             }
+
+            #grid-canvas {
+                height: 100%;
+                width: 80%;
+            }
         </style>
     </head>
     <body></body>

--- a/web/src/drop_area.rs
+++ b/web/src/drop_area.rs
@@ -2,6 +2,10 @@ use wasm_bindgen::JsCast;
 use web_sys::Element;
 use yew::prelude::*;
 
+use crate::utils;
+
+const DROP_ZONE_ID: &str = "drop-zone";
+
 #[derive(Properties, PartialEq)]
 pub struct FileDropAreaProps {
     pub first_time: bool,
@@ -83,7 +87,7 @@ pub(crate) fn file_drop_area(
 }
 
 pub(crate) fn display_drop_zone() {
-    if let Some(classes) = get_drop_zone_classes() {
+    if let Some(classes) = utils::get_classes(DROP_ZONE_ID) {
         classes
             .remove_1("invisible")
             .expect("removing class 'invisible' failed")
@@ -91,17 +95,9 @@ pub(crate) fn display_drop_zone() {
 }
 
 pub(crate) fn hide_drop_zone() {
-    if let Some(classes) = get_drop_zone_classes() {
+    if let Some(classes) = utils::get_classes(DROP_ZONE_ID) {
         classes
             .add_1("invisible")
             .expect("adding class 'invisible' failed")
     }
-}
-
-fn get_drop_zone_classes() -> Option<web_sys::DomTokenList> {
-    let window = web_sys::window()?;
-    let document = window.document()?;
-    let element = document.get_element_by_id("drop-zone")?;
-    let class_list = element.class_list();
-    Some(class_list)
 }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -57,7 +57,8 @@ fn app() -> Html {
                     let result = read_as_bytes(&blob).await;
                     if let Ok(bytes_) = result {
                         let grib = grib::from_reader(std::io::Cursor::new(bytes_));
-                        grib_context.set(grib.ok())
+                        grib_context.set(grib.ok());
+                        submessage_modal::hide_submessage_modal();
                     }
                 });
             }
@@ -180,12 +181,16 @@ fn app() -> Html {
 
     html! {
         <>
-            <div id="main" ondragover={ on_drag_over }>
+            <div id="main" ondragover={ on_drag_over.clone() }>
                 <h1>{ "GRIB2 Data Viewer" }</h1>
                 <div>{ file_name }</div>
                 { listing }
             </div>
-            <SubmessageModal image_data={image_data} on_click={on_click_submessage_modal} />
+            <SubmessageModal
+                image_data={image_data}
+                on_click={on_click_submessage_modal}
+                on_drag_over={on_drag_over}
+            />
             <FileDropArea first_time={*first_time} on_drop={on_file_drop} />
         </>
     }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -2,11 +2,13 @@ use std::ops::Deref;
 
 use gloo_file::{futures::read_as_bytes, Blob};
 use grib::codetables::{CodeTable4_2, CodeTable4_3, Lookup};
+use web_sys::ImageData;
 use yew::prelude::*;
 mod drop_area;
 use drop_area::FileDropArea;
 mod submessage_modal;
 use submessage_modal::SubmessageModal;
+mod palette;
 mod utils;
 
 #[function_component(App)]
@@ -14,6 +16,7 @@ fn app() -> Html {
     let first_time = use_state(|| true);
     let dropped_file = use_state(|| None);
     let grib_context = use_state(|| None);
+    let image_data = use_state(|| None);
 
     let first_time_ = first_time.clone();
     let on_file_drop = {
@@ -65,7 +68,8 @@ fn app() -> Html {
         let submessages = context.submessages();
         let (len, _) = submessages.size_hint();
         let submessages_html = submessages
-            .map(|(i, submessage)| {
+            .enumerate()
+            .map(|(index, (i, submessage))| {
                 let id = format!("{}.{}", i.0, i.1);
                 let prod_def = submessage.prod_def();
                 let category = prod_def
@@ -92,9 +96,40 @@ fn app() -> Html {
                 let num_grid_points = submessage.grid_def().num_points();
                 let num_points_represented = submessage.repr_def().num_points();
 
+                let grib_context_ = grib_context.clone();
+                let image_data_ = image_data.clone();
                 let on_click_submessage_row = {
                     Callback::from(move |e: MouseEvent| {
                         e.prevent_default();
+                        if let Some(grib) = grib_context_.as_ref() {
+                            let image_data = if let Some((_i, submessage)) =
+                                grib.submessages().nth(index)
+                            {
+                                if let Ok((w, h)) = submessage.grid_shape() {
+                                    let decoder =
+                                        grib::Grib2SubmessageDecoder::from(submessage).unwrap(); // FIXME
+                                    let values = decoder.dispatch().unwrap(); // FIXME
+                                    let pixel_bytes = values
+                                        .map(|value| palette::jma_amedas_temperature(value))
+                                        .flatten()
+                                        .collect::<Vec<_>>();
+                                    let pixel_bytes: &[u8] = &pixel_bytes;
+                                    let pixel_bytes = wasm_bindgen::Clamped(pixel_bytes);
+                                    let image_data = ImageData::new_with_u8_clamped_array_and_sh(
+                                        pixel_bytes,
+                                        w as u32,
+                                        h as u32,
+                                    )
+                                    .unwrap(); // FIXME
+                                    Some(image_data)
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None // is not expected to happen
+                            };
+                            image_data_.set(image_data);
+                        }
                         submessage_modal::display_submessage_modal();
                     })
                 };
@@ -141,6 +176,8 @@ fn app() -> Html {
         html! {}
     };
 
+    let image_data = image_data.as_ref().map(|i| i.clone());
+
     html! {
         <>
             <div id="main" ondragover={ on_drag_over }>
@@ -148,7 +185,7 @@ fn app() -> Html {
                 <div>{ file_name }</div>
                 { listing }
             </div>
-            <SubmessageModal on_click={on_click_submessage_modal} />
+            <SubmessageModal image_data={image_data} on_click={on_click_submessage_modal} />
             <FileDropArea first_time={*first_time} on_drop={on_file_drop} />
         </>
     }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -111,8 +111,7 @@ fn app() -> Html {
                                         grib::Grib2SubmessageDecoder::from(submessage).unwrap(); // FIXME
                                     let values = decoder.dispatch().unwrap(); // FIXME
                                     let pixel_bytes = values
-                                        .map(|value| palette::jma_amedas_temperature(value))
-                                        .flatten()
+                                        .flat_map(palette::jma_amedas_temperature)
                                         .collect::<Vec<_>>();
                                     let pixel_bytes: &[u8] = &pixel_bytes;
                                     let pixel_bytes = wasm_bindgen::Clamped(pixel_bytes);

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -5,6 +5,9 @@ use grib::codetables::{CodeTable4_2, CodeTable4_3, Lookup};
 use yew::prelude::*;
 mod drop_area;
 use drop_area::FileDropArea;
+mod submessage_modal;
+use submessage_modal::SubmessageModal;
+mod utils;
 
 #[function_component(App)]
 fn app() -> Html {
@@ -25,6 +28,13 @@ fn app() -> Html {
         file.name()
     } else {
         String::new()
+    };
+
+    let on_click_submessage_modal = {
+        Callback::from(move |e: MouseEvent| {
+            e.prevent_default();
+            submessage_modal::hide_submessage_modal();
+        })
     };
 
     let on_drag_over = {
@@ -81,8 +91,16 @@ fn app() -> Html {
                     .unwrap_or((String::new(), String::new()));
                 let num_grid_points = submessage.grid_def().num_points();
                 let num_points_represented = submessage.repr_def().num_points();
+
+                let on_click_submessage_row = {
+                    Callback::from(move |e: MouseEvent| {
+                        e.prevent_default();
+                        submessage_modal::display_submessage_modal();
+                    })
+                };
+
                 html! {
-                    <tr>
+                    <tr onclick={on_click_submessage_row}>
                         <td>{id}</td>
                         <td>{category}</td>
                         <td>{generating_process}</td>
@@ -130,6 +148,7 @@ fn app() -> Html {
                 <div>{ file_name }</div>
                 { listing }
             </div>
+            <SubmessageModal on_click={on_click_submessage_modal} />
             <FileDropArea first_time={*first_time} on_drop={on_file_drop} />
         </>
     }

--- a/web/src/palette.rs
+++ b/web/src/palette.rs
@@ -1,0 +1,18 @@
+pub(crate) fn jma_amedas_temperature(degrees_celsius: f32) -> [u8; 4] {
+    match degrees_celsius {
+        v if v > degrees_celsius_to_kelvin(35.) => [180, 0, 104, 255],
+        v if v > degrees_celsius_to_kelvin(30.) => [255, 40, 0, 255],
+        v if v > degrees_celsius_to_kelvin(25.) => [255, 153, 0, 255],
+        v if v > degrees_celsius_to_kelvin(20.) => [250, 245, 0, 255],
+        v if v > degrees_celsius_to_kelvin(15.) => [255, 255, 150, 255],
+        v if v > degrees_celsius_to_kelvin(10.) => [255, 255, 240, 255],
+        v if v > degrees_celsius_to_kelvin(5.) => [185, 235, 255, 255],
+        v if v > degrees_celsius_to_kelvin(0.) => [0, 150, 255, 255],
+        v if v > degrees_celsius_to_kelvin(-5.) => [0, 65, 255, 255],
+        _ => [0, 32, 128, 255],
+    }
+}
+
+fn degrees_celsius_to_kelvin(value: f32) -> f32 {
+    value + 273.15
+}

--- a/web/src/submessage_modal.rs
+++ b/web/src/submessage_modal.rs
@@ -32,7 +32,7 @@ pub(crate) fn submessage_modal(
     if let Some((context, width, height)) = context_.as_ref() {
         if let Some(image_data) = image_data {
             context.clear_rect(0., 0., *width as f64, *height as f64);
-            let _ = context.put_image_data(&image_data, 0., 0.);
+            let _ = context.put_image_data(image_data, 0., 0.);
         }
     }
 

--- a/web/src/submessage_modal.rs
+++ b/web/src/submessage_modal.rs
@@ -27,8 +27,9 @@ pub(crate) fn submessage_modal(
         });
     }
 
-    if let Some(context) = context_.as_ref() {
+    if let Some((context, width, height)) = context_.as_ref() {
         if let Some(image_data) = image_data {
+            context.clear_rect(0., 0., *width as f64, *height as f64);
             let _ = context.put_image_data(&image_data, 0., 0.);
         }
     }
@@ -58,15 +59,16 @@ pub(crate) fn hide_submessage_modal() {
     }
 }
 
-fn get_canvas_context() -> Option<CanvasRenderingContext2d> {
+fn get_canvas_context() -> Option<(CanvasRenderingContext2d, u32, u32)> {
     let window = web_sys::window()?;
     let document = window.document()?;
     let canvas = document.get_element_by_id("grid-canvas")?;
     let canvas: web_sys::HtmlCanvasElement =
         canvas.dyn_into::<web_sys::HtmlCanvasElement>().ok()?;
-    canvas
+    let context = canvas
         .get_context("2d")
         .ok()??
         .dyn_into::<CanvasRenderingContext2d>()
-        .ok()
+        .ok()?;
+    Some((context, canvas.width(), canvas.height()))
 }

--- a/web/src/submessage_modal.rs
+++ b/web/src/submessage_modal.rs
@@ -8,6 +8,7 @@ const SUBMESSAGE_MODAL_ID: &str = "submessage-modal";
 pub struct SubmessageModalProps {
     pub image_data: Option<ImageData>,
     pub on_click: Callback<MouseEvent>,
+    pub on_drag_over: Callback<DragEvent>,
 }
 
 #[function_component(SubmessageModal)]
@@ -15,6 +16,7 @@ pub(crate) fn submessage_modal(
     SubmessageModalProps {
         image_data,
         on_click,
+        on_drag_over,
     }: &SubmessageModalProps,
 ) -> Html {
     let context = use_state(|| None);
@@ -35,7 +37,7 @@ pub(crate) fn submessage_modal(
     }
 
     html! {
-        <div id={SUBMESSAGE_MODAL_ID} class="invisible" onclick={on_click}>
+        <div id={SUBMESSAGE_MODAL_ID} class="invisible" onclick={on_click} ondragover={on_drag_over}>
             <div id="submessage-details">
                 <canvas id="grid-canvas"></canvas>
             </div>

--- a/web/src/submessage_modal.rs
+++ b/web/src/submessage_modal.rs
@@ -1,0 +1,33 @@
+use yew::prelude::*;
+
+const SUBMESSAGE_MODAL_ID: &str = "submessage-modal";
+
+#[derive(Properties, PartialEq)]
+pub struct SubmessageModalProps {
+    pub on_click: Callback<MouseEvent>,
+}
+
+#[function_component(SubmessageModal)]
+pub(crate) fn submessage_modal(SubmessageModalProps { on_click }: &SubmessageModalProps) -> Html {
+    html! {
+        <div id={SUBMESSAGE_MODAL_ID} class="invisible" onclick={on_click}>
+            <div id="submessage-details"></div>
+        </div>
+    }
+}
+
+pub(crate) fn display_submessage_modal() {
+    if let Some(classes) = crate::utils::get_classes(SUBMESSAGE_MODAL_ID) {
+        classes
+            .remove_1("invisible")
+            .expect("removing class 'invisible' failed")
+    }
+}
+
+pub(crate) fn hide_submessage_modal() {
+    if let Some(classes) = crate::utils::get_classes(SUBMESSAGE_MODAL_ID) {
+        classes
+            .add_1("invisible")
+            .expect("adding class 'invisible' failed")
+    }
+}

--- a/web/src/submessage_modal.rs
+++ b/web/src/submessage_modal.rs
@@ -1,17 +1,43 @@
+use wasm_bindgen::prelude::*;
+use web_sys::{CanvasRenderingContext2d, ImageData};
 use yew::prelude::*;
 
 const SUBMESSAGE_MODAL_ID: &str = "submessage-modal";
 
 #[derive(Properties, PartialEq)]
 pub struct SubmessageModalProps {
+    pub image_data: Option<ImageData>,
     pub on_click: Callback<MouseEvent>,
 }
 
 #[function_component(SubmessageModal)]
-pub(crate) fn submessage_modal(SubmessageModalProps { on_click }: &SubmessageModalProps) -> Html {
+pub(crate) fn submessage_modal(
+    SubmessageModalProps {
+        image_data,
+        on_click,
+    }: &SubmessageModalProps,
+) -> Html {
+    let context = use_state(|| None);
+    let context_ = context.clone();
+
+    {
+        let context_ = context.clone();
+        use_effect_with(context, move |_| {
+            context_.set(get_canvas_context());
+        });
+    }
+
+    if let Some(context) = context_.as_ref() {
+        if let Some(image_data) = image_data {
+            let _ = context.put_image_data(&image_data, 0., 0.);
+        }
+    }
+
     html! {
         <div id={SUBMESSAGE_MODAL_ID} class="invisible" onclick={on_click}>
-            <div id="submessage-details"></div>
+            <div id="submessage-details">
+                <canvas id="grid-canvas"></canvas>
+            </div>
         </div>
     }
 }
@@ -30,4 +56,17 @@ pub(crate) fn hide_submessage_modal() {
             .add_1("invisible")
             .expect("adding class 'invisible' failed")
     }
+}
+
+fn get_canvas_context() -> Option<CanvasRenderingContext2d> {
+    let window = web_sys::window()?;
+    let document = window.document()?;
+    let canvas = document.get_element_by_id("grid-canvas")?;
+    let canvas: web_sys::HtmlCanvasElement =
+        canvas.dyn_into::<web_sys::HtmlCanvasElement>().ok()?;
+    canvas
+        .get_context("2d")
+        .ok()??
+        .dyn_into::<CanvasRenderingContext2d>()
+        .ok()
 }

--- a/web/src/utils.rs
+++ b/web/src/utils.rs
@@ -1,0 +1,7 @@
+pub(crate) fn get_classes(element_id: &str) -> Option<web_sys::DomTokenList> {
+    let window = web_sys::window()?;
+    let document = window.document()?;
+    let element = document.get_element_by_id(element_id)?;
+    let class_list = element.class_list();
+    Some(class_list)
+}


### PR DESCRIPTION
This PR adds functionality to the web app to display grid point values in a GRIB2 submessage.

At this time, there are several issues with this display feature:

- Color map selection support
- Display of color map legend and unit
- Proper support for scanning modes
- Fix for an issue that noise sometimes appears in the display
- Improvements of UX when there is a wait for display
- Error messages for submessages whose Section 3 and/or Section 5 is supported

These issues will be addressed in due course.