### PR TITLE
Strictly return an error for quasi-regular latitude/longitude grids

### DIFF
--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -245,6 +245,11 @@ impl TryFrom<&GridDefinition> for GridDefinitionTemplateValues {
         match num {
             0 => {
                 let buf = &value.payload;
+                if buf.len() > 67 {
+                    return Err(GribError::NotSupported(format!(
+                        "template {num} with list of number of points"
+                    )));
+                }
                 Ok(GridDefinitionTemplateValues::Template0(
                     LatLonGridDefinition::from_buf(&buf[25..]),
                 ))


### PR DESCRIPTION
This PR makes the lib crate return an error for quasi-regular latitude/longitude grids.

Quasi-regular latitude/longitude grids should be supported but are not yet supported.