### PR TITLE
Add a feature to return the short name defined for the grid, based on ecCodes `gridType` strings

### DIFF
--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -69,7 +69,7 @@ impl<'i, R> Display for ListView<'i, R> {
         match self.mode {
             ListViewMode::OneLine => {
                 let header = format!(
-                    "{:>8} │ {:<31} {:<18} {:>14} {:>33} {:>33} │ {:>21} {:<21}\n",
+                    "{:>8} │ {:<31} {:<18} {:>14} {:>33} {:>33} │ {:>21} {:<21}",
                     "id",
                     "Parameter",
                     "Generating process",
@@ -80,7 +80,7 @@ impl<'i, R> Display for ListView<'i, R> {
                     "grid type",
                 );
                 let style = Style::new().bold();
-                write!(f, "{}", style.apply_to(header))?;
+                writeln!(f, "{}", style.apply_to(header.trim_end()))?;
 
                 for (i, submessage) in entries {
                     let id = format!("{}.{}", i.0, i.1);

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fmt::{self, Display, Formatter},
     path::PathBuf,
 };
@@ -68,14 +69,15 @@ impl<'i, R> Display for ListView<'i, R> {
         match self.mode {
             ListViewMode::OneLine => {
                 let header = format!(
-                    "{:>8} │ {:<31} {:<18} {:>14} {:>33} {:>33} │ {:>21}\n",
+                    "{:>8} │ {:<31} {:<18} {:>14} {:>33} {:>33} │ {:>21} {:<21}\n",
                     "id",
                     "Parameter",
                     "Generating process",
                     "Forecast time",
                     "1st fixed surface",
                     "2nd fixed surface",
-                    "#points (nan/total)"
+                    "#points (nan/total)",
+                    "grid type",
                 );
                 let style = Style::new().bold();
                 write!(f, "{}", style.apply_to(header))?;
@@ -104,11 +106,17 @@ impl<'i, R> Display for ListView<'i, R> {
                         .fixed_surfaces()
                         .map(|(first, second)| (format_surface(&first), format_surface(&second)))
                         .unwrap_or((String::new(), String::new()));
-                    let num_grid_points = submessage.grid_def().num_points();
+                    let grid_def = submessage.grid_def();
+                    let num_grid_points = grid_def.num_points();
                     let num_points_represented = submessage.repr_def().num_points();
+                    let grid_type = grib::GridDefinitionTemplateValues::try_from(grid_def)
+                        .map(|def| Cow::from(def.grid_type()))
+                        .unwrap_or_else(|_| {
+                            Cow::from(format!("unknown (template {})", grid_def.grid_tmpl_num()))
+                        });
                     writeln!(
                         f,
-                        "{:>8} │ {:<31} {:<18} {:>14} {:>33} {:>33} │ {:>10}/{:>10}",
+                        "{:>8} │ {:<31} {:<18} {:>14} {:>33} {:>33} │ {:>10}/{:>10} {:<21}",
                         id,
                         category,
                         generating_process,
@@ -116,7 +124,8 @@ impl<'i, R> Display for ListView<'i, R> {
                         surfaces.0,
                         surfaces.1,
                         num_grid_points - num_points_represented,
-                        num_grid_points
+                        num_grid_points,
+                        grid_type,
                     )?;
                 }
             }

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -110,7 +110,7 @@ impl<'i, R> Display for ListView<'i, R> {
                     let num_grid_points = grid_def.num_points();
                     let num_points_represented = submessage.repr_def().num_points();
                     let grid_type = grib::GridDefinitionTemplateValues::try_from(grid_def)
-                        .map(|def| Cow::from(def.grid_type()))
+                        .map(|def| Cow::from(def.short_name()))
                         .unwrap_or_else(|_| {
                             Cow::from(format!("unknown (template {})", grid_def.grid_tmpl_num()))
                         });

--- a/cli/tests/cli/commands/list.rs
+++ b/cli/tests/cli/commands/list.rs
@@ -11,7 +11,7 @@ crate::commands::test_simple_display! {
         "list",
         utils::testdata::grib2::jma_tornado_nowcast()?,
         Vec::<&str>::new(),
-        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type            
+        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type
      0.0 │ code '0' is not implemented     Analysis                    0 [m]                               NaN                               NaN │          0/     86016 regular_ll           
      0.1 │ code '0' is not implemented     Forecast                   10 [m]                               NaN                               NaN │          0/     86016 regular_ll           
      0.2 │ code '0' is not implemented     Forecast                   20 [m]                               NaN                               NaN │          0/     86016 regular_ll           
@@ -26,7 +26,7 @@ crate::commands::test_simple_display! {
         "list",
         utils::testdata::grib2::jma_msmguid()?,
         Vec::<&str>::new(),
-        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type            
+        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type
      0.0 │ code '192' is not implemented   Forecast                    0 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
      0.1 │ Total precipitation rate        Forecast                    0 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
      0.2 │ code '192' is not implemented   Forecast                    3 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
@@ -79,7 +79,7 @@ crate::commands::test_simple_display! {
         "list",
         utils::testdata::grib2::multi_message_data(3)?,
         Vec::<&str>::new(),
-        r#"      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type            
+        r#"      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type
      0.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120 unknown (template 101)
      1.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120 unknown (template 101)
      2.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120 unknown (template 101)

--- a/cli/tests/cli/commands/list.rs
+++ b/cli/tests/cli/commands/list.rs
@@ -11,14 +11,14 @@ crate::commands::test_simple_display! {
         "list",
         utils::testdata::grib2::jma_tornado_nowcast()?,
         Vec::<&str>::new(),
-        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total)
-     0.0 │ code '0' is not implemented     Analysis                    0 [m]                               NaN                               NaN │          0/     86016
-     0.1 │ code '0' is not implemented     Forecast                   10 [m]                               NaN                               NaN │          0/     86016
-     0.2 │ code '0' is not implemented     Forecast                   20 [m]                               NaN                               NaN │          0/     86016
-     0.3 │ code '0' is not implemented     Forecast                   30 [m]                               NaN                               NaN │          0/     86016
-     0.4 │ code '0' is not implemented     Forecast                   40 [m]                               NaN                               NaN │          0/     86016
-     0.5 │ code '0' is not implemented     Forecast                   50 [m]                               NaN                               NaN │          0/     86016
-     0.6 │ code '0' is not implemented     Forecast                   60 [m]                               NaN                               NaN │          0/     86016
+        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type            
+     0.0 │ code '0' is not implemented     Analysis                    0 [m]                               NaN                               NaN │          0/     86016 regular_ll           
+     0.1 │ code '0' is not implemented     Forecast                   10 [m]                               NaN                               NaN │          0/     86016 regular_ll           
+     0.2 │ code '0' is not implemented     Forecast                   20 [m]                               NaN                               NaN │          0/     86016 regular_ll           
+     0.3 │ code '0' is not implemented     Forecast                   30 [m]                               NaN                               NaN │          0/     86016 regular_ll           
+     0.4 │ code '0' is not implemented     Forecast                   40 [m]                               NaN                               NaN │          0/     86016 regular_ll           
+     0.5 │ code '0' is not implemented     Forecast                   50 [m]                               NaN                               NaN │          0/     86016 regular_ll           
+     0.6 │ code '0' is not implemented     Forecast                   60 [m]                               NaN                               NaN │          0/     86016 regular_ll           
 "
     ),
     (
@@ -26,52 +26,52 @@ crate::commands::test_simple_display! {
         "list",
         utils::testdata::grib2::jma_msmguid()?,
         Vec::<&str>::new(),
-        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total)
-     0.0 │ code '192' is not implemented   Forecast                    0 [h]                               NaN                               NaN │     106575/    268800
-     0.1 │ Total precipitation rate        Forecast                    0 [h]                               NaN                               NaN │     106575/    268800
-     0.2 │ code '192' is not implemented   Forecast                    3 [h]                               NaN                               NaN │     106575/    268800
-     0.3 │ Total precipitation rate        Forecast                    3 [h]                               NaN                               NaN │     106575/    268800
-     0.4 │ code '192' is not implemented   Forecast                    6 [h]                               NaN                               NaN │     106575/    268800
-     0.5 │ Total precipitation rate        Forecast                    6 [h]                               NaN                               NaN │     106575/    268800
-     0.6 │ Total precipitation rate        Forecast                    3 [h]                               NaN                               NaN │     106575/    268800
-     0.7 │ code '192' is not implemented   Forecast                    9 [h]                               NaN                               NaN │     106575/    268800
-     0.8 │ Total precipitation rate        Forecast                    9 [h]                               NaN                               NaN │     106575/    268800
-     0.9 │ code '192' is not implemented   Forecast                   12 [h]                               NaN                               NaN │     106575/    268800
-    0.10 │ Total precipitation rate        Forecast                   12 [h]                               NaN                               NaN │     106575/    268800
-    0.11 │ Total precipitation rate        Forecast                    9 [h]                               NaN                               NaN │     106575/    268800
-    0.12 │ code '192' is not implemented   Forecast                   15 [h]                               NaN                               NaN │     106575/    268800
-    0.13 │ Total precipitation rate        Forecast                   15 [h]                               NaN                               NaN │     106575/    268800
-    0.14 │ code '192' is not implemented   Forecast                   18 [h]                               NaN                               NaN │     106575/    268800
-    0.15 │ Total precipitation rate        Forecast                   18 [h]                               NaN                               NaN │     106575/    268800
-    0.16 │ Total precipitation rate        Forecast                   15 [h]                               NaN                               NaN │     106575/    268800
-    0.17 │ code '192' is not implemented   Forecast                   21 [h]                               NaN                               NaN │     106575/    268800
-    0.18 │ Total precipitation rate        Forecast                   21 [h]                               NaN                               NaN │     106575/    268800
-    0.19 │ code '192' is not implemented   Forecast                   24 [h]                               NaN                               NaN │     106575/    268800
-    0.20 │ Total precipitation rate        Forecast                   24 [h]                               NaN                               NaN │     106575/    268800
-    0.21 │ Total precipitation rate        Forecast                   21 [h]                               NaN                               NaN │     106575/    268800
-    0.22 │ code '192' is not implemented   Forecast                   27 [h]                               NaN                               NaN │     106575/    268800
-    0.23 │ Total precipitation rate        Forecast                   27 [h]                               NaN                               NaN │     106575/    268800
-    0.24 │ code '192' is not implemented   Forecast                   30 [h]                               NaN                               NaN │     106575/    268800
-    0.25 │ Total precipitation rate        Forecast                   30 [h]                               NaN                               NaN │     106575/    268800
-    0.26 │ Total precipitation rate        Forecast                   27 [h]                               NaN                               NaN │     106575/    268800
-    0.27 │ code '192' is not implemented   Forecast                   33 [h]                               NaN                               NaN │     106575/    268800
-    0.28 │ Total precipitation rate        Forecast                   33 [h]                               NaN                               NaN │     106575/    268800
-    0.29 │ code '192' is not implemented   Forecast                   36 [h]                               NaN                               NaN │     106575/    268800
-    0.30 │ Total precipitation rate        Forecast                   36 [h]                               NaN                               NaN │     106575/    268800
-    0.31 │ Total precipitation rate        Forecast                   33 [h]                               NaN                               NaN │     106575/    268800
-    0.32 │ Thunderstorm probability        Forecast                    0 [h]                               NaN                               NaN │      14446/     17061
-    0.33 │ Thunderstorm probability        Forecast                    3 [h]                               NaN                               NaN │      14446/     17061
-    0.34 │ Thunderstorm probability        Forecast                    6 [h]                               NaN                               NaN │      14446/     17061
-    0.35 │ Thunderstorm probability        Forecast                    9 [h]                               NaN                               NaN │      14446/     17061
-    0.36 │ Thunderstorm probability        Forecast                   12 [h]                               NaN                               NaN │      14446/     17061
-    0.37 │ Thunderstorm probability        Forecast                   15 [h]                               NaN                               NaN │      14446/     17061
-    0.38 │ Thunderstorm probability        Forecast                   18 [h]                               NaN                               NaN │      14446/     17061
-    0.39 │ Thunderstorm probability        Forecast                   21 [h]                               NaN                               NaN │      14446/     17061
-    0.40 │ Thunderstorm probability        Forecast                   24 [h]                               NaN                               NaN │      14446/     17061
-    0.41 │ Thunderstorm probability        Forecast                   27 [h]                               NaN                               NaN │      14446/     17061
-    0.42 │ Thunderstorm probability        Forecast                   30 [h]                               NaN                               NaN │      14446/     17061
-    0.43 │ Thunderstorm probability        Forecast                   33 [h]                               NaN                               NaN │      14446/     17061
-    0.44 │ Thunderstorm probability        Forecast                   36 [h]                               NaN                               NaN │      14446/     17061
+        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type            
+     0.0 │ code '192' is not implemented   Forecast                    0 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.1 │ Total precipitation rate        Forecast                    0 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.2 │ code '192' is not implemented   Forecast                    3 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.3 │ Total precipitation rate        Forecast                    3 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.4 │ code '192' is not implemented   Forecast                    6 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.5 │ Total precipitation rate        Forecast                    6 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.6 │ Total precipitation rate        Forecast                    3 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.7 │ code '192' is not implemented   Forecast                    9 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.8 │ Total precipitation rate        Forecast                    9 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+     0.9 │ code '192' is not implemented   Forecast                   12 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.10 │ Total precipitation rate        Forecast                   12 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.11 │ Total precipitation rate        Forecast                    9 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.12 │ code '192' is not implemented   Forecast                   15 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.13 │ Total precipitation rate        Forecast                   15 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.14 │ code '192' is not implemented   Forecast                   18 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.15 │ Total precipitation rate        Forecast                   18 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.16 │ Total precipitation rate        Forecast                   15 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.17 │ code '192' is not implemented   Forecast                   21 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.18 │ Total precipitation rate        Forecast                   21 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.19 │ code '192' is not implemented   Forecast                   24 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.20 │ Total precipitation rate        Forecast                   24 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.21 │ Total precipitation rate        Forecast                   21 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.22 │ code '192' is not implemented   Forecast                   27 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.23 │ Total precipitation rate        Forecast                   27 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.24 │ code '192' is not implemented   Forecast                   30 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.25 │ Total precipitation rate        Forecast                   30 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.26 │ Total precipitation rate        Forecast                   27 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.27 │ code '192' is not implemented   Forecast                   33 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.28 │ Total precipitation rate        Forecast                   33 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.29 │ code '192' is not implemented   Forecast                   36 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.30 │ Total precipitation rate        Forecast                   36 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.31 │ Total precipitation rate        Forecast                   33 [h]                               NaN                               NaN │     106575/    268800 regular_ll           
+    0.32 │ Thunderstorm probability        Forecast                    0 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.33 │ Thunderstorm probability        Forecast                    3 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.34 │ Thunderstorm probability        Forecast                    6 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.35 │ Thunderstorm probability        Forecast                    9 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.36 │ Thunderstorm probability        Forecast                   12 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.37 │ Thunderstorm probability        Forecast                   15 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.38 │ Thunderstorm probability        Forecast                   18 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.39 │ Thunderstorm probability        Forecast                   21 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.40 │ Thunderstorm probability        Forecast                   24 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.41 │ Thunderstorm probability        Forecast                   27 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.42 │ Thunderstorm probability        Forecast                   30 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.43 │ Thunderstorm probability        Forecast                   33 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
+    0.44 │ Thunderstorm probability        Forecast                   36 [h]                               NaN                               NaN │      14446/     17061 regular_ll           
 "
     ),
     (
@@ -79,11 +79,11 @@ crate::commands::test_simple_display! {
         "list",
         utils::testdata::grib2::multi_message_data(3)?,
         Vec::<&str>::new(),
-        "      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total)
-     0.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120
-     1.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120
-     2.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120
-"
+        r#"      id │ Parameter                       Generating process  Forecast time                 1st fixed surface                 2nd fixed surface │   #points (nan/total) grid type            
+     0.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120 unknown (template 101)
+     1.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120 unknown (template 101)
+     2.0 │ Total precipitation rate        Forecast                    0 [m]                                 0                               NaN │          0/   2949120 unknown (template 101)
+"#
     ),
     (
         displaying_grib2_with_multiple_submessages_with_opt_d,

--- a/demo/index.html
+++ b/demo/index.html
@@ -80,7 +80,9 @@
             #submessage_list th:nth-child(2),
             #submessage_list td:nth-child(2),
             #submessage_list th:nth-child(3),
-            #submessage_list td:nth-child(3) {
+            #submessage_list td:nth-child(3),
+            #submessage_list th:nth-child(9),
+            #submessage_list td:nth-child(9) {
                 text-align: left;
             }
 

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use gloo_file::{futures::read_as_bytes, Blob};
-use grib::codetables::{CodeTable4_2, CodeTable4_3, Lookup};
+use grib::codetables::{CodeTable3_1, CodeTable4_2, CodeTable4_3, Lookup};
 use web_sys::ImageData;
 use yew::prelude::*;
 mod drop_area;
@@ -96,6 +96,8 @@ fn app() -> Html {
                     .unwrap_or((String::new(), String::new()));
                 let num_grid_points = submessage.grid_def().num_points();
                 let num_points_represented = submessage.repr_def().num_points();
+                let grid_type_id = submessage.grid_def().grid_tmpl_num();
+                let grid_type = CodeTable3_1.lookup(usize::from(grid_type_id)).to_string();
 
                 let grib_context_ = grib_context.clone();
                 let image_data_ = image_data.clone();
@@ -144,6 +146,7 @@ fn app() -> Html {
                         <td>{surfaces.1}</td>
                         <td>{num_grid_points - num_points_represented}</td>
                         <td>{num_grid_points}</td>
+                        <td>{grid_type}</td>
                     </tr>
                 }
             })
@@ -163,6 +166,7 @@ fn app() -> Html {
                                 <th>{"2nd fixed surface"}</th>
                                 <th>{"#points (nan)"}</th>
                                 <th>{"#points (total)"}</th>
+                                <th>{"grid type"}</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -98,7 +98,7 @@ fn app() -> Html {
                 let num_grid_points = grid_def.num_points();
                 let num_points_represented = submessage.repr_def().num_points();
                 let grid_type = grib::GridDefinitionTemplateValues::try_from(grid_def)
-                    .map(|def| Cow::from(def.grid_type()))
+                    .map(|def| Cow::from(def.short_name()))
                     .unwrap_or_else(|_| {
                         Cow::from(format!("unknown (template {})", grid_def.grid_tmpl_num()))
                     });

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -200,6 +200,22 @@ impl GridDefinitionTemplateValues {
         }
     }
 
+    /// Returns the grid type.
+    ///
+    /// The grid types are denoted as short strings based on `gridType` used in
+    /// ecCodes.
+    ///
+    /// This is provided primarily for debugging and simple notation purposes.
+    /// It is better to use enum variants instead of the string notation to
+    /// determine the grid type.
+    pub fn grid_type(&self) -> &'static str {
+        match self {
+            Self::Template0(def) => def.grid_type(),
+            Self::Template20(def) => def.grid_type(),
+            Self::Template30(def) => def.grid_type(),
+        }
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -208,11 +208,11 @@ impl GridDefinitionTemplateValues {
     /// This is provided primarily for debugging and simple notation purposes.
     /// It is better to use enum variants instead of the string notation to
     /// determine the grid type.
-    pub fn grid_type(&self) -> &'static str {
+    pub fn short_name(&self) -> &'static str {
         match self {
-            Self::Template0(def) => def.grid_type(),
-            Self::Template20(def) => def.grid_type(),
-            Self::Template30(def) => def.grid_type(),
+            Self::Template0(def) => def.short_name(),
+            Self::Template20(def) => def.short_name(),
+            Self::Template30(def) => def.short_name(),
         }
     }
 

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -57,7 +57,7 @@ impl LambertGridDefinition {
     }
 
     /// Returns the grid type.
-    pub fn grid_type(&self) -> &'static str {
+    pub fn short_name(&self) -> &'static str {
         "lambert"
     }
 

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -56,6 +56,11 @@ impl LambertGridDefinition {
         (self.ni as usize, self.nj as usize)
     }
 
+    /// Returns the grid type.
+    pub fn grid_type(&self) -> &'static str {
+        "lambert"
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number

--- a/src/grid/latlon.rs
+++ b/src/grid/latlon.rs
@@ -39,7 +39,7 @@ impl LatLonGridDefinition {
     }
 
     /// Returns the grid type.
-    pub fn grid_type(&self) -> &'static str {
+    pub fn short_name(&self) -> &'static str {
         "regular_ll"
     }
 

--- a/src/grid/latlon.rs
+++ b/src/grid/latlon.rs
@@ -38,6 +38,11 @@ impl LatLonGridDefinition {
         (self.ni as usize, self.nj as usize)
     }
 
+    /// Returns the grid type.
+    pub fn grid_type(&self) -> &'static str {
+        "regular_ll"
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -56,7 +56,7 @@ impl PolarStereographicGridDefinition {
     }
 
     /// Returns the grid type.
-    pub fn grid_type(&self) -> &'static str {
+    pub fn short_name(&self) -> &'static str {
         "polar_stereographic"
     }
 

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -55,6 +55,11 @@ impl PolarStereographicGridDefinition {
         (self.ni as usize, self.nj as usize)
     }
 
+    /// Returns the grid type.
+    pub fn grid_type(&self) -> &'static str {
+        "polar_stereographic"
+    }
+
     /// Returns an iterator over `(i, j)` of grid points.
     ///
     /// Note that this is a low-level API and it is not checked that the number


### PR DESCRIPTION
This PR adds a feature to return the short name defined for the grid.
Short names are based on ecCodes `gridType` strings, such as `"regular_ll"` and `"lambert"`.

This PR also changes CLI and demo web app to show that grid type string in the submessage list view.