### PR TITLE
Strict checking of type of original field values in complex packing

### DIFF
--- a/src/decoder/complex.rs
+++ b/src/decoder/complex.rs
@@ -34,9 +34,7 @@ pub(crate) fn decode_7_2(
     GribError,
 > {
     let sect5_data = &target.sect5_payload;
-    let simple_param = SimplePackingParam::from_buf(&sect5_data[6..15]);
-    let value_type = read_as!(u8, sect5_data, 15);
-    check_original_field_value_type_support(value_type)?;
+    let simple_param = SimplePackingParam::from_buf(&sect5_data[6..16])?;
     let complex_param = ComplexPackingParam::from_buf(&sect5_data[16..42]);
 
     if complex_param.group_splitting_method_used != 1
@@ -62,9 +60,7 @@ pub(crate) fn decode_7_3(
     GribError,
 > {
     let sect5_data = &target.sect5_payload;
-    let simple_param = SimplePackingParam::from_buf(&sect5_data[6..15]);
-    let value_type = read_as!(u8, sect5_data, 15);
-    check_original_field_value_type_support(value_type)?;
+    let simple_param = SimplePackingParam::from_buf(&sect5_data[6..16])?;
     let complex_param = ComplexPackingParam::from_buf(&sect5_data[16..42]);
     let spdiff_order = read_as!(u8, sect5_data, 42);
     let spdiff_order = Table5_6::try_from(spdiff_order).map_err(|e| {

--- a/src/decoder/complex.rs
+++ b/src/decoder/complex.rs
@@ -35,6 +35,8 @@ pub(crate) fn decode_7_2(
 > {
     let sect5_data = &target.sect5_payload;
     let simple_param = SimplePackingParam::from_buf(&sect5_data[6..15]);
+    let value_type = read_as!(u8, sect5_data, 15);
+    check_original_field_value_type_support(value_type)?;
     let complex_param = ComplexPackingParam::from_buf(&sect5_data[16..42]);
 
     if complex_param.group_splitting_method_used != 1
@@ -61,6 +63,8 @@ pub(crate) fn decode_7_3(
 > {
     let sect5_data = &target.sect5_payload;
     let simple_param = SimplePackingParam::from_buf(&sect5_data[6..15]);
+    let value_type = read_as!(u8, sect5_data, 15);
+    check_original_field_value_type_support(value_type)?;
     let complex_param = ComplexPackingParam::from_buf(&sect5_data[16..42]);
     let spdiff_order = read_as!(u8, sect5_data, 42);
     let spdiff_order = Table5_6::try_from(spdiff_order).map_err(|e| {

--- a/src/decoder/jpeg2000.rs
+++ b/src/decoder/jpeg2000.rs
@@ -6,7 +6,6 @@ use crate::{
         Grib2SubmessageDecoder,
     },
     error::*,
-    helpers::read_as,
 };
 
 mod ext;
@@ -25,9 +24,7 @@ pub(crate) fn decode(
     target: &Grib2SubmessageDecoder,
 ) -> Result<SimplePackingDecodeIteratorWrapper<impl Iterator<Item = i32>>, GribError> {
     let sect5_data = &target.sect5_payload;
-    let simple_param = SimplePackingParam::from_buf(&sect5_data[6..15]);
-    let value_type = read_as!(u8, sect5_data, 15);
-    check_original_field_value_type_support(value_type)?;
+    let simple_param = SimplePackingParam::from_buf(&sect5_data[6..16])?;
 
     if simple_param.nbit == 0 {
         eprintln!(

--- a/src/decoder/jpeg2000.rs
+++ b/src/decoder/jpeg2000.rs
@@ -27,6 +27,7 @@ pub(crate) fn decode(
     let sect5_data = &target.sect5_payload;
     let simple_param = SimplePackingParam::from_buf(&sect5_data[6..15]);
     let value_type = read_as!(u8, sect5_data, 15);
+    check_original_field_value_type_support(value_type)?;
 
     if simple_param.nbit == 0 {
         eprintln!(
@@ -39,14 +40,6 @@ pub(crate) fn decode(
         ));
         return Ok(decoder);
     };
-
-    if value_type != 0 {
-        return Err(GribError::DecodeError(
-            DecodeError::SimplePackingDecodeError(
-                SimplePackingDecodeError::OriginalFieldValueTypeNotSupported,
-            ),
-        ));
-    }
 
     let stream = Stream::from_bytes(&target.sect7_payload)
         .map_err(|e| GribError::DecodeError(DecodeError::Jpeg2000CodeStreamDecodeError(e)))?;

--- a/src/decoder/png.rs
+++ b/src/decoder/png.rs
@@ -1,10 +1,7 @@
 use crate::{
     decoder::{
-        param::SimplePackingParam,
-        simple::{check_original_field_value_type_support, SimplePackingDecodeIterator},
-        stream::NBitwiseIterator,
+        param::SimplePackingParam, simple::SimplePackingDecodeIterator, stream::NBitwiseIterator,
     },
-    helpers::read_as,
     DecodeError, Grib2SubmessageDecoder, GribError,
 };
 
@@ -18,9 +15,7 @@ pub(crate) fn decode(
     target: &Grib2SubmessageDecoder,
 ) -> Result<SimplePackingDecodeIterator<impl Iterator<Item = u32> + '_>, GribError> {
     let sect5_data = &target.sect5_payload;
-    let param = SimplePackingParam::from_buf(&sect5_data[6..15]);
-    let value_type = read_as!(u8, sect5_data, 15);
-    check_original_field_value_type_support(value_type)?;
+    let param = SimplePackingParam::from_buf(&sect5_data[6..16])?;
 
     let buf = read_image_buffer(&target.sect7_payload).map_err(|e| {
         GribError::DecodeError(DecodeError::PngDecodeError(PngDecodeError::PngError(

--- a/src/decoder/png.rs
+++ b/src/decoder/png.rs
@@ -1,7 +1,7 @@
 use crate::{
     decoder::{
         param::SimplePackingParam,
-        simple::{SimplePackingDecodeError, SimplePackingDecodeIterator},
+        simple::{check_original_field_value_type_support, SimplePackingDecodeIterator},
         stream::NBitwiseIterator,
     },
     helpers::read_as,
@@ -20,14 +20,7 @@ pub(crate) fn decode(
     let sect5_data = &target.sect5_payload;
     let param = SimplePackingParam::from_buf(&sect5_data[6..15]);
     let value_type = read_as!(u8, sect5_data, 15);
-
-    if value_type != 0 {
-        return Err(GribError::DecodeError(
-            DecodeError::SimplePackingDecodeError(
-                SimplePackingDecodeError::OriginalFieldValueTypeNotSupported,
-            ),
-        ));
-    }
+    check_original_field_value_type_support(value_type)?;
 
     let buf = read_image_buffer(&target.sect7_payload).map_err(|e| {
         GribError::DecodeError(DecodeError::PngDecodeError(PngDecodeError::PngError(

--- a/src/decoder/simple.rs
+++ b/src/decoder/simple.rs
@@ -52,14 +52,7 @@ pub(crate) fn decode(
     let sect5_data = &target.sect5_payload;
     let param = SimplePackingParam::from_buf(&sect5_data[6..15]);
     let value_type = read_as!(u8, sect5_data, 15);
-
-    if value_type != 0 {
-        return Err(GribError::DecodeError(
-            DecodeError::SimplePackingDecodeError(
-                SimplePackingDecodeError::OriginalFieldValueTypeNotSupported,
-            ),
-        ));
-    }
+    check_original_field_value_type_support(value_type)?;
 
     let decoder = if param.nbit == 0 {
         SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
@@ -106,6 +99,18 @@ impl<I: Iterator<Item = N>, N: ToPrimitive> Iterator for SimplePackingDecodeIter
             }
             _ => None,
         }
+    }
+}
+
+pub(crate) fn check_original_field_value_type_support(code: u8) -> Result<(), GribError> {
+    if code == 0 {
+        Ok(())
+    } else {
+        Err(GribError::DecodeError(
+            DecodeError::SimplePackingDecodeError(
+                SimplePackingDecodeError::OriginalFieldValueTypeNotSupported,
+            ),
+        ))
     }
 }
 


### PR DESCRIPTION
This PR provides strict checking of type of original field values in complex packing.

Current implementation assumes that original field values are floating-point.
Almost all decoders check the value type, but the check was missing in the complex packing decoders.