### PR TITLE
Fix decoders handling cases where nbit is 0

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -12,10 +12,7 @@ use crate::{
         complex::ComplexPackingDecodeError,
         png::PngDecodeError,
         run_length::RunLengthEncodingDecodeError,
-        simple::{
-            SimplePackingDecodeError, SimplePackingDecodeIterator,
-            SimplePackingDecodeIteratorWrapper,
-        },
+        simple::{SimplePackingDecodeError, SimplePackingDecodeIteratorWrapper},
     },
     error::*,
     reader::Grib2Read,
@@ -186,7 +183,7 @@ enum Grib2SubmessageDecoderIteratorWrapper<T0, T2, T3, T40, T41> {
     Template40(PhantomData<T40>),
     #[cfg(not(target_arch = "wasm32"))]
     Template40(SimplePackingDecodeIteratorWrapper<T40>),
-    Template41(SimplePackingDecodeIterator<T41>),
+    Template41(SimplePackingDecodeIteratorWrapper<T41>),
     Template200(std::vec::IntoIter<f32>),
 }
 

--- a/src/decoder/jpeg2000.rs
+++ b/src/decoder/jpeg2000.rs
@@ -32,7 +32,7 @@ pub(crate) fn decode(
             Please report your data and help us develop the library."
         );
         let decoder = SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
-            simple_param.ref_val,
+            simple_param.zero_bit_reference_value(),
             target.num_points_encoded,
         ));
         return Ok(decoder);

--- a/src/decoder/param.rs
+++ b/src/decoder/param.rs
@@ -33,6 +33,10 @@ impl SimplePackingParam {
             nbit,
         })
     }
+
+    pub(crate) fn zero_bit_reference_value(&self) -> f32 {
+        self.ref_val * 10_f32.powi(-i32::from(self.dig))
+    }
 }
 
 pub(crate) struct ComplexPackingParam {

--- a/src/decoder/simple.rs
+++ b/src/decoder/simple.rs
@@ -53,7 +53,7 @@ pub(crate) fn decode(
 
     let decoder = if param.nbit == 0 {
         SimplePackingDecodeIteratorWrapper::FixedValue(FixedValueIterator::new(
-            param.ref_val,
+            param.zero_bit_reference_value(),
             target.num_points_encoded,
         ))
     } else {


### PR DESCRIPTION
This PR makes decoders correctly handle cases where nbit is 0.

Following two possible issues will be corrected by this PR:

- Simple packing and JPEG 2000 code stream format decoders have returned $R$ for all points when nbit was 0,
  although they should return $R * 10^{-D}$.
  I noticed this problem when I was reading the source code of wgrib2.
  Although I have went through every one of data files I had on hand,
  I have not encountered any data files where the problem actually occurs,
  since every message has had $D$ value of 0 when nbit is 0.

- PNG format decoder may possibly have crashed when nbit was 0.
  I have not encountered any data files where the problem actually occurs,
  since I only have PNG-format encoded data files whose nbit is 16.