### PR TITLE
Submessage filtering improvement part 1:  `Parameter` struct and NCEP code mock-ups

### DIFF
--- a/src/codetables.rs
+++ b/src/codetables.rs
@@ -1,5 +1,7 @@
 mod core;
 pub use self::core::Code::{self, Name, Num};
+mod external;
+pub use external::*;
 pub mod grib2;
 mod old;
 pub use old::*;

--- a/src/codetables/external.rs
+++ b/src/codetables/external.rs
@@ -1,0 +1,24 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use crate::Parameter;
+
+#[derive(Debug, Eq, PartialEq, Clone, TryFromPrimitive, IntoPrimitive)]
+#[repr(u32)]
+/// Parameter code used in NCEP.
+pub enum NCEP {
+    /// Pressure.
+    PRES = 0x_00_03_00,
+    /// Pressure reduced to MSL.
+    PRMSL = 0x_00_03_01,
+    /// Geopotential Height.
+    HGT = 0x_00_03_05,
+}
+
+impl TryFrom<Parameter> for NCEP {
+    type Error = &'static str;
+
+    fn try_from(value: Parameter) -> Result<Self, Self::Error> {
+        let code = value.as_u32();
+        Self::try_from_primitive(code).map_err(|_| "code not found")
+    }
+}

--- a/src/codetables/old.rs
+++ b/src/codetables/old.rs
@@ -2,6 +2,15 @@ use std::fmt::{self, Display, Formatter};
 
 pub struct LookupResult(Result<&'static &'static str, ConversionError>);
 
+impl LookupResult {
+    /// Returns WMO description of the code.
+    pub fn description(&self) -> Option<String> {
+        let Self(result) = self;
+        let s = result.as_ref().ok()?.to_string();
+        Some(s)
+    }
+}
+
 impl Display for LookupResult {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let s = match &self.0 {

--- a/src/context.rs
+++ b/src/context.rs
@@ -368,6 +368,8 @@ impl<'a, R> SubMessage<'a, R> {
     ///     io::{BufReader, Read},
     /// };
     ///
+    /// use grib::codetables::NCEP;
+    ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let mut buf = Vec::new();
     ///
@@ -394,10 +396,12 @@ impl<'a, R> SubMessage<'a, R> {
     ///             num: 1
     ///         })
     ///     );
+    ///     let param = param.unwrap();
     ///     assert_eq!(
-    ///         param.unwrap().description(),
+    ///         param.description(),
     ///         Some("Pressure reduced to MSL".to_owned())
     ///     );
+    ///     assert_eq!(NCEP::try_from(param), Ok(NCEP::PRMSL));
     ///     Ok(())
     /// }
     /// ```

--- a/src/context.rs
+++ b/src/context.rs
@@ -354,6 +354,50 @@ pub struct SubMessage<'a, R>(
 );
 
 impl<'a, R> SubMessage<'a, R> {
+    /// Looks up the product codes of the submessage and returns its WMO
+    /// description.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::{
+    ///     fs::File,
+    ///     io::{BufReader, Read},
+    /// };
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let mut buf = Vec::new();
+    ///
+    ///     let f = File::open("testdata/gdas.t12z.pgrb2.0p25.f000.0-10.xz")?;
+    ///     let f = BufReader::new(f);
+    ///     let mut f = xz2::bufread::XzDecoder::new(f);
+    ///     f.read_to_end(&mut buf)?;
+    ///
+    ///     let f = std::io::Cursor::new(buf);
+    ///     let grib2 = grib::from_reader(f)?;
+    ///
+    ///     let mut iter = grib2.iter();
+    ///     let (_, message) = iter.next().ok_or_else(|| "first message is not found")?;
+    ///
+    ///     let desc = message.product_description();
+    ///     assert_eq!(desc, Some("Pressure reduced to MSL".to_owned()));
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn product_description(&self) -> Option<String> {
+        let prod_def = self.prod_def();
+        let category = prod_def.parameter_category();
+        let number = prod_def.parameter_number();
+        category
+            .zip(number)
+            .map(|(c, n)| {
+                CodeTable4_2::new(self.indicator().discipline, c)
+                    .lookup(usize::from(n))
+                    .description()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn indicator(&self) -> &Indicator {
         // panics should not happen if data is correct
         match self.0.body.body.as_ref().unwrap() {

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -2,6 +2,51 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::codetables::{grib2::*, *};
 
+/// Parameter of the product.
+///
+/// In the context of GRIB products, parameters refer to weather elements such
+/// as air temperature, air pressure, and humidity, and other physical
+/// quantities.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Parameter {
+    /// Discipline of processed data in the GRIB message.
+    pub discipline: u8,
+    /// GRIB master tables version number.
+    pub centre: u16,
+    /// Parameter category by product discipline.
+    pub master_ver: u8,
+    /// GRIB local tables version number.
+    pub local_ver: u8,
+    /// Identification of originating/generating centre.
+    pub category: u8,
+    /// Parameter number by product discipline and parameter category.
+    pub num: u8,
+}
+
+impl Parameter {
+    /// Looks up the parameter's WMO description.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Extracted from the first submessage of JMA MSM GRIB2 data.
+    /// let param = grib::Parameter {
+    ///     discipline: 0,
+    ///     centre: 34,
+    ///     master_ver: 2,
+    ///     local_ver: 1,
+    ///     category: 3,
+    ///     num: 5,
+    /// };
+    /// assert_eq!(param.description(), Some("Geopotential height".to_owned()))
+    /// ```
+    pub fn description(&self) -> Option<String> {
+        CodeTable4_2::new(self.discipline, self.category)
+            .lookup(usize::from(self.num))
+            .description()
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct ForecastTime {
     pub unit: Code<grib2::Table4_4, u8>,

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -7,6 +7,26 @@ use crate::codetables::{grib2::*, *};
 /// In the context of GRIB products, parameters refer to weather elements such
 /// as air temperature, air pressure, and humidity, and other physical
 /// quantities.
+///
+/// [`NCEP`] would help you to test whether the parameter is what you want to
+/// use.
+///
+/// # Examples
+///
+/// ```
+/// use grib::codetables::NCEP;
+///
+/// // Extracted from the first submessage of JMA MSM GRIB2 data.
+/// let param = grib::Parameter {
+///     discipline: 0,
+///     centre: 34,
+///     master_ver: 2,
+///     local_ver: 1,
+///     category: 3,
+///     num: 5,
+/// };
+/// assert_eq!(NCEP::try_from(param), Ok(NCEP::HGT));
+/// ```
 #[derive(Debug, PartialEq, Eq)]
 pub struct Parameter {
     /// Discipline of processed data in the GRIB message.
@@ -44,6 +64,10 @@ impl Parameter {
         CodeTable4_2::new(self.discipline, self.category)
             .lookup(usize::from(self.num))
             .description()
+    }
+
+    pub(crate) fn as_u32(&self) -> u32 {
+        (u32::from(self.discipline) << 16) + (u32::from(self.category) << 8) + u32::from(self.num)
     }
 }
 


### PR DESCRIPTION
This PR provides new `Parameter` struct and some NCEP codes defined as enum variants.

This PR allows users to obtain a `Parameter` struct from a submessage.
This struct provides functions concerning parameters (weather elements and other physical quantities),
such as parameter matching using NCEP codes and text representation.

NCEP codes are implemented as enum variants so that users can take full advantage of Rust's static typing,
e.g., with the assistance of IDE for NCEP code typing.

This PR provides only a limited number of NCEP codes.
Most of the remaining NCEP codes will be provided in subsequent PRs.