### PR TITLE
Submessage filtering improvement part 2: more user-friendly API to check the identity of numerical parameters and named codes

### DIFF
--- a/src/codetables/external.rs
+++ b/src/codetables/external.rs
@@ -14,10 +14,10 @@ pub enum NCEP {
     HGT = 0x_00_03_05,
 }
 
-impl TryFrom<Parameter> for NCEP {
+impl TryFrom<&Parameter> for NCEP {
     type Error = &'static str;
 
-    fn try_from(value: Parameter) -> Result<Self, Self::Error> {
+    fn try_from(value: &Parameter) -> Result<Self, Self::Error> {
         let code = value.as_u32();
         Self::try_from_primitive(code).map_err(|_| "code not found")
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -401,7 +401,7 @@ impl<'a, R> SubMessage<'a, R> {
     ///         param.description(),
     ///         Some("Pressure reduced to MSL".to_owned())
     ///     );
-    ///     assert_eq!(NCEP::try_from(param), Ok(NCEP::PRMSL));
+    ///     assert!(param.is_identical_to(NCEP::PRMSL));
     ///     Ok(())
     /// }
     /// ```

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -8,25 +8,10 @@ use crate::codetables::{grib2::*, *};
 /// as air temperature, air pressure, and humidity, and other physical
 /// quantities.
 ///
-/// [`NCEP`] would help you to test whether the parameter is what you want to
-/// use.
+/// With [`is_identical_to`], users can check if the parameter is identical to a
+/// third-party code, such as [`NCEP`].
 ///
-/// # Examples
-///
-/// ```
-/// use grib::codetables::NCEP;
-///
-/// // Extracted from the first submessage of JMA MSM GRIB2 data.
-/// let param = grib::Parameter {
-///     discipline: 0,
-///     centre: 34,
-///     master_ver: 2,
-///     local_ver: 1,
-///     category: 3,
-///     num: 5,
-/// };
-/// assert_eq!(NCEP::try_from(param), Ok(NCEP::HGT));
-/// ```
+/// [`is_identical_to`]: Parameter::is_identical_to
 #[derive(Debug, PartialEq, Eq)]
 pub struct Parameter {
     /// Discipline of processed data in the GRIB message.
@@ -64,6 +49,34 @@ impl Parameter {
         CodeTable4_2::new(self.discipline, self.category)
             .lookup(usize::from(self.num))
             .description()
+    }
+
+    /// Checks if the parameter is identical to a third-party `code`, such as
+    /// [`NCEP`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grib::codetables::NCEP;
+    ///
+    /// // Extracted from the first submessage of JMA MSM GRIB2 data.
+    /// let param = grib::Parameter {
+    ///     discipline: 0,
+    ///     centre: 34,
+    ///     master_ver: 2,
+    ///     local_ver: 1,
+    ///     category: 3,
+    ///     num: 5,
+    /// };
+    /// assert!(param.is_identical_to(NCEP::HGT));
+    /// ```
+    pub fn is_identical_to<'a, T>(&'a self, code: T) -> bool
+    where
+        T: TryFrom<&'a Self>,
+        T: PartialEq,
+    {
+        let self_ = T::try_from(self);
+        self_.is_ok_and(|v| v == code)
     }
 
     pub(crate) fn as_u32(&self) -> u32 {


### PR DESCRIPTION
This PR provides a more user-friendly API to check the identity of numerical parameters and named codes.

With this API, users are now able to check the identity like this:

```rust
param.is_identical_to(NCEP::HGT)
```

So, submessage filtering can be done like this:

```rust
grib2.iter().find(|submessage| {
    submessage.parameter().is_some_and(|param| param.is_identical_to(NCEP::HGT))
});
```