### PR TITLE
Submessage filtering improvement part 4: make minor improvements to the proc macro for code generation

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -26,6 +26,7 @@ pub fn parameter_codes(args: TokenStream, input: TokenStream) -> TokenStream {
             .into_compile_error()
             .into();
     }
+    let attrs = input.attrs;
     let vis = input.vis;
     let ident = input.ident;
 
@@ -33,6 +34,7 @@ pub fn parameter_codes(args: TokenStream, input: TokenStream) -> TokenStream {
         use std::cell::LazyCell;
         use std::collections::HashMap;
 
+        #(#attrs)*
         #vis enum #ident {
             #entries
         }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
-    parse_macro_input, DeriveInput, Lit, Result, Token,
+    parse_macro_input, ItemEnum, Lit, Result, Token,
 };
 
 #[proc_macro_attribute]
@@ -20,8 +20,8 @@ pub fn parameter_codes(args: TokenStream, input: TokenStream) -> TokenStream {
             .into();
     };
 
-    let input = parse_macro_input!(input as DeriveInput);
-    if !is_empty_enum(&input) {
+    let input = parse_macro_input!(input as ItemEnum);
+    if !input.variants.is_empty() {
         return syn::Error::new(input.ident.span(), "not an empty enum")
             .into_compile_error()
             .into();
@@ -47,10 +47,6 @@ pub fn parameter_codes(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
     .into()
-}
-
-fn is_empty_enum(input: &DeriveInput) -> bool {
-    matches!(&input.data, syn::Data::Enum(enum_) if enum_.variants.is_empty())
 }
 
 #[derive(Debug)]

--- a/codegen/tests/01-normal-case.rs
+++ b/codegen/tests/01-normal-case.rs
@@ -1,6 +1,8 @@
 use grib_codegen::parameter_codes;
 
 #[parameter_codes(path = "tests/data/table")]
+#[derive(Debug, PartialEq)]
+#[repr(u32)]
 pub enum FooCodes {}
 
 #[allow(dead_code)]
@@ -20,4 +22,6 @@ fn main() {
     assert_eq!(FooCodes::HGT as u32, 0x_00_03_05);
     assert_eq!(FooCodes::remap(&0), None);
     assert_eq!(FooCodes::remap(&0x_00_03_c2), Some(FooCodes::U_GWD as u32));
+    assert_eq!(format!("{:?}", FooCodes::TMP), "TMP");
+    assert_eq!(FooCodes::TMP, FooCodes::TMP);
 }

--- a/codegen/tests/02-not-empty-enum.stderr
+++ b/codegen/tests/02-not-empty-enum.stderr
@@ -4,8 +4,8 @@ error: not an empty enum
 4 | pub enum FooCodes {
   |          ^^^^^^^^
 
-error: not an empty enum
-  --> tests/02-not-empty-enum.rs:10:12
+error: expected `enum`
+  --> tests/02-not-empty-enum.rs:10:5
    |
 10 | pub struct BarCodes;
-   |            ^^^^^^^^
+   |     ^^^^^^


### PR DESCRIPTION
This PR makes minor improvements to the proc macro.
Now the proc macro copies attributes from the source enum.