### PR TITLE
Fix longitude computation failures due to inconsistent grid definitions

### DIFF
--- a/src/grid/latlon.rs
+++ b/src/grid/latlon.rs
@@ -134,12 +134,10 @@ impl LatLonGridDefinition {
         let (first_lon, last_lon) = (self.first_point_lon as f32, self.last_point_lon as f32);
         let (first_lon, last_lon) = if self.is_consistent_for_i() {
             (first_lon, last_lon)
+        } else if self.first_point_lon > self.last_point_lon {
+            (first_lon, last_lon + 360_000_000_f32)
         } else {
-            if self.first_point_lon > self.last_point_lon {
-                (first_lon, last_lon + 360_000_000_f32)
-            } else {
-                (first_lon + 360_000_000_f32, last_lon)
-            }
+            (first_lon + 360_000_000_f32, last_lon)
         };
 
         let lon = evenly_spaced_degrees(first_lon, last_lon, (self.ni - 1) as usize);


### PR DESCRIPTION
This PR fixes longitude computation failures due to inconsistent grid definitions.

Lat/lon computation of grid points failed for `testdata/CMC_glb_TMP_ISBL_1_latlon.24x.24_2021051800_P000.grib2`.
The root cause of the failure is an inconsistency between the longitude range and scanning mode in the grid definition;
although longitudes are expected to increase since the scanning mode is `0b01000000`,
the starting longitude is 180.00 degrees and the ending longitude is 179.76 degrees.

This PR corrects the issue by putting in a process that allows computation across the prime meridian.

Closes #51.