### PR TITLE
Submessage filtering improvement part 5: make specification changes to support ECMWF codes

### DIFF
--- a/codegen/src/param_codes.rs
+++ b/codegen/src/param_codes.rs
@@ -154,7 +154,7 @@ impl Wgrib2TableEntry {
         }
     }
 
-    fn normalized_name(&self) -> Cow<'_, str> {
+    fn normalized_name(&self) -> String {
         normalize_name(&self.name)
     }
 
@@ -194,38 +194,14 @@ impl fmt::Display for DocTableEntries<'_> {
 }
 
 // Makes the specified string available as an Rust enum variant identifier.
-// Only supports cases used in the NCEP table.
-fn normalize_name(name: &str) -> Cow<str> {
-    let name = normalize_name_starting_with_number(name);
-    normalize_name_with_hyphens(name)
-}
-
-fn normalize_name_starting_with_number(name: &str) -> Cow<str> {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some('4') => {
-            let mut s = String::with_capacity(name.len() + 4);
-            s.push_str("Four");
-            s.push_str(chars.as_str());
-            Cow::Owned(s)
-        }
-        Some('5') => {
-            let mut s = String::with_capacity(name.len() + 4);
-            s.push_str("Five");
-            s.push_str(chars.as_str());
-            Cow::Owned(s)
-        }
-        _ => Cow::Borrowed(name),
-    }
-}
-
-fn normalize_name_with_hyphens(name: Cow<str>) -> Cow<str> {
-    if name.contains('-') {
+fn normalize_name(name: &str) -> String {
+    let name = if name.contains('-') {
         let s = name.replace('-', "_");
         Cow::Owned(s)
     } else {
-        name
-    }
+        Cow::Borrowed(name)
+    };
+    format!("_{name}")
 }
 
 #[cfg(test)]

--- a/codegen/tests/01-normal-case.rs
+++ b/codegen/tests/01-normal-case.rs
@@ -22,8 +22,10 @@ fn determine(value: FooCodes) -> ! {
 
 fn main() {
     assert_eq!(FooCodes::_HGT as u32, 0x_00_03_05);
-    assert_eq!(FooCodes::remap(&0), None);
-    assert_eq!(FooCodes::remap(&0x_00_03_c2), Some(FooCodes::_U_GWD as u32));
+    assert_eq!(FooCodes::try_from(0x_00_00_00), Ok(FooCodes::_TMP));
+    assert_eq!(FooCodes::try_from(0x_00_03_10), Ok(FooCodes::_U_GWD));
+    assert_eq!(FooCodes::try_from(0x_00_03_c2), Ok(FooCodes::_U_GWD));
+    assert_eq!(FooCodes::try_from(0xffffffff), Err("code not found"));
     assert_eq!(format!("{:?}", FooCodes::_TMP), "_TMP");
     assert_eq!(FooCodes::_TMP, FooCodes::_TMP);
 }

--- a/codegen/tests/01-normal-case.rs
+++ b/codegen/tests/01-normal-case.rs
@@ -8,20 +8,22 @@ pub enum FooCodes {}
 #[allow(dead_code)]
 fn determine(value: FooCodes) -> ! {
     match value {
-        FooCodes::TMP => todo!(),
-        FooCodes::VTMP => todo!(),
-        FooCodes::SOIL_M => todo!(),
-        FooCodes::HGT => todo!(),
-        FooCodes::U_GWD => todo!(),
-        FooCodes::FiveWAVA => todo!(),
-        FooCodes::FourLFTX => todo!(),
+        FooCodes::_TMP => todo!(),
+        FooCodes::_VTMP => todo!(),
+        FooCodes::_SOIL_M => todo!(),
+        FooCodes::_HGT => todo!(),
+        FooCodes::_U_GWD => todo!(),
+        FooCodes::_5WAVA => todo!(),
+        FooCodes::_260120 => todo!(),
+        FooCodes::_4LFTX => todo!(),
+        FooCodes::_CH3O2NO2 => todo!(),
     }
 }
 
 fn main() {
-    assert_eq!(FooCodes::HGT as u32, 0x_00_03_05);
+    assert_eq!(FooCodes::_HGT as u32, 0x_00_03_05);
     assert_eq!(FooCodes::remap(&0), None);
-    assert_eq!(FooCodes::remap(&0x_00_03_c2), Some(FooCodes::U_GWD as u32));
-    assert_eq!(format!("{:?}", FooCodes::TMP), "TMP");
-    assert_eq!(FooCodes::TMP, FooCodes::TMP);
+    assert_eq!(FooCodes::remap(&0x_00_03_c2), Some(FooCodes::_U_GWD as u32));
+    assert_eq!(format!("{:?}", FooCodes::_TMP), "_TMP");
+    assert_eq!(FooCodes::_TMP, FooCodes::_TMP);
 }

--- a/codegen/tests/data/table
+++ b/codegen/tests/data/table
@@ -4,5 +4,7 @@
 0:1:0:255:0:0:3:5:HGT:Geopotential Height:gpm
 0:1:0:255:0:0:3:16:U-GWD:Zonal Flux of Gravity Wave Stress:N/m^2
 0:1:0:255:0:0:3:19:5WAVA:5-Wave Geopotential Height Anomaly:gpm
+0:0:0:255:0:0:6:25:260120:Horizontal extent of cumulonimbus (CB):%
 0:1:0:255:0:0:7:11:4LFTX:Best (4 layer) Lifted Index:K
+0:0:0:255:0:0:20:2:CH3O2NO2:Methyl peroxy nitrate mass mixing ratio:kg/kg
 0:0:0:255:7:1:3:194:U-GWD:Zonal Flux of Gravity Wave Stress:N/m^2


### PR DESCRIPTION
This PR makes 2 specification changes for grib-codegen to support ECMWF codes:

- change of the code normalization rule
- change of the way to conversion from numbers to enum variants

First, since only 3 NCEP codes begin with a number, and those numbers are single digits,
I originally used a code normalization rule such as replacing "4" with "Four".
However, since ECMWF codes seem to include numeric-only codes such as `260120`,
in this PR, I change the normalization rule to add an underscore prefix to the code.

Second, since it is unnecessarily complicated to remap from a number to a number and then
convert the number to an enum variant,
in this PR, I change it so that we can derive the enum variant directly from the number.