### PR TITLE
Submessage filtering improvement part 6: use "grib-codegen" in the main "grib" library crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ keywords = ["GRIB", "weather", "meteorology"]
 
 [dependencies]
 chrono = "0.4.23" # `TimeZone::with_ymd_and_hms` needed
+grib-codegen = { path = "codegen", version = "0.1.0" }
 num = "0.4"
 num_enum = "0.7"
 png = "0.17"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grib-codegen"
-version.workspace = true
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -11,7 +11,7 @@ use syn::{
 pub fn parameter_codes(args: TokenStream, input: TokenStream) -> TokenStream {
     let attr_args = parse_macro_input!(args as ParameterCodesArgs);
     let (table_path, span) = &attr_args.path;
-    let table_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(table_path);
+    let table_path = std::path::Path::new(table_path);
     let (entries, mapper) = if let Ok(entries) = param_codes::Wgrib2Table::from_file(table_path) {
         entries.enum_variants()
     } else {

--- a/codegen/tests/01-normal-case.rs
+++ b/codegen/tests/01-normal-case.rs
@@ -1,6 +1,6 @@
 use grib_codegen::parameter_codes;
 
-#[parameter_codes(path = "tests/data/table")]
+#[parameter_codes(path = "codegen/tests/data/table")]
 #[derive(Debug, PartialEq)]
 #[repr(u32)]
 pub enum FooCodes {}

--- a/codegen/tests/02-not-empty-enum.rs
+++ b/codegen/tests/02-not-empty-enum.rs
@@ -1,12 +1,12 @@
 use grib_codegen::parameter_codes;
 
-#[parameter_codes(path = "tests/data/table")]
+#[parameter_codes(path = "codegen/tests/data/table")]
 pub enum FooCodes {
     Foo,
     Bar,
 }
 
-#[parameter_codes(path = "tests/data/table")]
+#[parameter_codes(path = "codegen/tests/data/table")]
 pub struct BarCodes;
 
 fn main() {}

--- a/def/wgrib2/README.md
+++ b/def/wgrib2/README.md
@@ -1,0 +1,1 @@
+This data file is taken from the source code of wgirb2 3.2 (wgrib2/gribtables/ncep/gribtable).

--- a/def/wgrib2/gribtable
+++ b/def/wgrib2/gribtable
@@ -1,0 +1,1566 @@
+0:1:0:255:0:0:0:0:TMP:Temperature:K
+0:1:0:255:0:0:0:1:VTMP:Virtual Temperature:K
+0:1:0:255:0:0:0:2:POT:Potential Temperature:K
+0:1:0:255:0:0:0:3:EPOT:Pseudo-Adiabatic Potential Temperature (or Equivalent Potential Temperature):K
+0:1:0:255:0:0:0:4:TMAX:Maximum Temperature:K
+0:1:0:255:0:0:0:5:TMIN:Minimum Temperature:K
+0:1:0:255:0:0:0:6:DPT:Dew Point Temperature:K
+0:1:0:255:0:0:0:7:DEPR:Dew Point Depression (or Deficit):K
+0:1:0:255:0:0:0:8:LAPR:Lapse Rate:K/m
+0:1:0:255:0:0:0:9:TMPA:Temperature Anomaly:K
+0:1:0:255:0:0:0:10:LHTFL:Latent Heat Net Flux:W/m^2
+0:1:0:255:0:0:0:11:SHTFL:Sensible Heat Net Flux:W/m^2
+0:1:0:255:0:0:0:12:HEATX:Heat Index:K
+0:1:0:255:0:0:0:13:WCF:Wind Chill Factor:K
+0:1:0:255:0:0:0:14:MINDPD:Minimum Dew Point Depression:K
+0:1:0:255:0:0:0:15:VPTMP:Virtual Potential Temperature:K
+0:1:0:255:0:0:0:16:SNOHF:Snow Phase Change Heat Flux:W/m^2
+0:1:0:255:0:0:0:17:SKINT:Skin Temperature:K
+0:1:0:255:0:0:0:18:SNOT:Snow Temperature (top of snow):K
+0:1:0:255:0:0:0:19:TTCHT:Turbulent Transfer Coefficient for Heat:Numeric
+0:1:0:255:0:0:0:20:TDCHT:Turbulent Diffusion Coefficient for Heat:m^2/s
+0:1:0:255:0:0:0:21:APTMP:Apparent Temperature:K
+0:1:0:255:0:0:0:22:TTSWR:Temperature Tendency due to Short-Wave Radiation:K/s
+0:1:0:255:0:0:0:23:TTLWR:Temperature Tendency due to Long-Wave Radiation:K/s
+0:1:0:255:0:0:0:24:TTSWRCS:Temperature Tendency due to Short-Wave Radiation, Clear Sky:K/s
+0:1:0:255:0:0:0:25:TTLWRCS:Temperature Tendency due to Long-Wave Radiation, Clear Sky:K/s
+0:1:0:255:0:0:0:26:TTPARM:Temperature Tendency due to parameterizations:K/s
+0:1:0:255:0:0:0:27:WETBT:Wet Bulb Temperature:K
+0:1:0:255:0:0:0:28:UCTMP:Unbalanced Component of Temperature:K
+0:1:0:255:0:0:0:29:TMPADV:Temperature Advection:K/s
+0:1:0:255:0:0:0:30:LHFLXE:Latent Heat Net Flux Due to Evaporation:W/m^2
+0:1:0:255:0:0:0:31:LHFLXS:Latent Heat Net Flux Due to Sublimation:W/m^2
+0:1:0:255:0:0:0:32:WETBPT:Wet-Bulb Potential Temperature:K
+0:0:0:255:7:1:0:192:SNOHF:Snow Phase Change Heat Flux:W/m^2
+0:0:0:255:7:1:0:193:TTRAD:Temperature Tendency by All Radiation:K/s
+0:0:0:255:7:1:0:194:REV:Relative Error Variance:-
+0:0:0:255:7:1:0:195:LRGHR:Large Scale Condensate Heating Rate:K/s
+0:0:0:255:7:1:0:196:CNVHR:Deep Convective Heating Rate:K/s
+0:0:0:255:7:1:0:197:THFLX:Total Downward Heat Flux at Surface:W/m^2
+0:0:0:255:7:1:0:198:TTDIA:Temperature Tendency by All Physics:K/s
+0:0:0:255:7:1:0:199:TTPHY:Temperature Tendency by Non-radiation Physics:K/s
+0:0:0:255:7:1:0:200:TSD1D:Standard Dev. of IR Temp. over 1x1 deg. area:K
+0:0:0:255:7:1:0:201:SHAHR:Shallow Convective Heating Rate:K/s
+0:0:0:255:7:1:0:202:VDFHR:Vertical Diffusion Heating rate:K/s
+0:0:0:255:7:1:0:203:THZ0:Potential Temperature at Top of Viscous Sublayer:K
+0:0:0:255:7:1:0:204:TCHP:Tropical Cyclone Heat Potential:J/m^2*K
+0:0:0:255:7:1:0:205:ELMELT:Effective Layer (EL) Temperature:C
+0:0:0:255:7:1:0:206:WETGLBT:Wet Bulb Globe Temperature:K
+0:1:0:255:0:0:1:0:SPFH:Specific Humidity:kg/kg
+0:1:0:255:0:0:1:1:RH:Relative Humidity:%
+0:1:0:255:0:0:1:2:MIXR:Humidity Mixing Ratio:kg/kg
+0:1:0:255:0:0:1:3:PWAT:Precipitable Water:kg/m^2
+0:1:0:255:0:0:1:4:VAPP:Vapour Pressure:Pa
+0:1:0:255:0:0:1:5:SATD:Saturation Deficit:Pa
+0:1:0:255:0:0:1:6:EVP:Evaporation:kg/m^2
+0:1:0:255:0:0:1:7:PRATE:Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:8:APCP:Total Precipitation:kg/m^2
+0:1:0:255:0:0:1:9:NCPCP:Large-Scale Precipitation (non-convective):kg/m^2
+0:1:0:255:0:0:1:10:ACPCP:Convective Precipitation:kg/m^2
+0:1:0:255:0:0:1:11:SNOD:Snow Depth:m
+0:1:0:255:0:0:1:12:SRWEQ:Snowfall Rate Water Equivalent:kg/m^2/s
+0:1:0:255:0:0:1:13:WEASD:Water Equivalent of Accumulated Snow Depth:kg/m^2
+0:1:0:255:0:0:1:14:SNOC:Convective Snow:kg/m^2
+0:1:0:255:0:0:1:15:SNOL:Large-Scale Snow:kg/m^2
+0:1:0:255:0:0:1:16:SNOM:Snow Melt:kg/m^2
+0:1:0:255:0:0:1:17:SNOAG:Snow Age:day
+0:1:0:255:0:0:1:18:ABSH:Absolute Humidity:kg/m^3
+0:1:0:255:0:0:1:19:PTYPE:Precipitation Type:-
+0:1:0:255:0:0:1:20:ILIQW:Integrated Liquid Water:kg/m^2
+0:1:0:255:0:0:1:21:TCOND:Condensate:kg/kg
+0:1:0:255:0:0:1:22:CLMR:Cloud Mixing Ratio:kg/kg
+0:1:0:255:0:0:1:23:ICMR:Ice Water Mixing Ratio:kg/kg
+0:1:0:255:0:0:1:24:RWMR:Rain Mixing Ratio:kg/kg
+0:1:0:255:0:0:1:25:SNMR:Snow Mixing Ratio:kg/kg
+0:1:0:255:0:0:1:26:MCONV:Horizontal Moisture Convergence:kg/kg/s
+0:1:0:255:0:0:1:27:MAXRH:Maximum Relative Humidity:%
+0:1:0:255:0:0:1:28:MAXAH:Maximum Absolute Humidity:kg/m^3
+0:1:0:255:0:0:1:29:ASNOW:Total Snowfall:m
+0:1:0:255:0:0:1:30:PWCAT:Precipitable Water Category:-
+0:1:0:255:0:0:1:31:HAIL:Hail:m
+0:1:0:255:0:0:1:32:GRLE:Graupel:kg/kg
+0:1:0:255:0:0:1:33:CRAIN:Categorical Rain:-
+0:1:0:255:0:0:1:34:CFRZR:Categorical Freezing Rain:-
+0:1:0:255:0:0:1:35:CICEP:Categorical Ice Pellets:-
+0:1:0:255:0:0:1:36:CSNOW:Categorical Snow:-
+0:1:0:255:0:0:1:37:CPRAT:Convective Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:38:MDIVER:Horizontal Moisture Divergence:kg/kg/s
+0:1:0:255:0:0:1:39:CPOFP:Percent frozen precipitation:%
+0:1:0:255:0:0:1:40:PEVAP:Potential Evaporation:kg/m^2
+0:1:0:255:0:0:1:41:PEVPR:Potential Evaporation Rate:W/m^2
+0:1:0:255:0:0:1:42:SNOWC:Snow Cover:%
+0:1:0:255:0:0:1:43:FRAIN:Rain Fraction of Total Cloud Water:Proportion
+0:1:0:255:0:0:1:44:RIME:Rime Factor:Numeric
+0:1:0:255:0:0:1:45:TCOLR:Total Column Integrated Rain:kg/m^2
+0:1:0:255:0:0:1:46:TCOLS:Total Column Integrated Snow:kg/m^2
+0:1:0:255:0:0:1:47:LSWP:Large Scale Water Precipitation (Non-Convective):kg/m^2
+0:1:0:255:0:0:1:48:CWP:Convective Water Precipitation:kg/m^2
+0:1:0:255:0:0:1:49:TWATP:Total Water Precipitation:kg/m^2
+0:1:0:255:0:0:1:50:TSNOWP:Total Snow Precipitation:kg/m^2
+0:1:0:255:0:0:1:51:TCWAT:Total Column Water (Vertically integrated total water (vapour+cloud water/ice):kg/m^2
+0:1:0:255:0:0:1:52:TPRATE:Total Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:53:TSRWE:Total Snowfall Rate Water Equivalent:kg/m^2/s
+0:1:0:255:0:0:1:54:LSPRATE:Large Scale Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:55:CSRWE:Convective Snowfall Rate Water Equivalent:kg/m^2/s
+0:1:0:255:0:0:1:56:LSSRWE:Large Scale Snowfall Rate Water Equivalent:kg/m^2/s
+0:1:0:255:0:0:1:57:TSRATE:Total Snowfall Rate:m/s
+0:1:0:255:0:0:1:58:CSRATE:Convective Snowfall Rate:m/s
+0:1:0:255:0:0:1:59:LSSRATE:Large Scale Snowfall Rate:m/s
+0:1:0:255:0:0:1:60:SDWE:Snow Depth Water Equivalent:kg/m^2
+0:1:0:255:0:0:1:61:SDEN:Snow Density:kg/m^3
+0:1:0:255:0:0:1:62:SEVAP:Snow Evaporation:kg/m^2
+0:1:0:255:0:0:1:64:TCIWV:Total Column Integrated Water Vapour:kg/m^2
+0:1:0:255:0:0:1:65:RPRATE:Rain Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:66:SPRATE:Snow Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:67:FPRATE:Freezing Rain Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:68:IPRATE:Ice Pellets Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:69:TCOLW:Total Column Integrate Cloud Water:kg/m^2
+0:1:0:255:0:0:1:70:TCOLI:Total Column Integrate Cloud Ice:kg/m^2
+0:1:0:255:0:0:1:71:HAILMXR:Hail Mixing Ratio:kg/kg
+0:1:0:255:0:0:1:72:TCOLH:Total Column Integrate Hail:kg/m^2
+0:1:0:255:0:0:1:73:HAILPR:Hail Prepitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:74:TCOLG:Total Column Integrate Graupel:kg/m^2
+0:1:0:255:0:0:1:75:GPRATE:Graupel (Snow Pellets) Prepitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:76:CRRATE:Convective Rain Rate:kg/m^2/s
+0:1:0:255:0:0:1:77:LSRRATE:Large Scale Rain Rate:kg/m^2/s
+0:1:0:255:0:0:1:78:TCOLWA:Total Column Integrate Water (All components including precipitation):kg/m^2
+0:1:0:255:0:0:1:79:EVARATE:Evaporation Rate:kg/m^2/s
+0:1:0:255:0:0:1:80:TOTCON:Total Condensate:kg/kg
+0:1:0:255:0:0:1:81:TCICON:Total Column-Integrate Condensate:kg/m^2
+0:1:0:255:0:0:1:82:CIMIXR:Cloud Ice Mixing Ratio:kg/kg
+0:1:0:255:0:0:1:83:SCLLWC:Specific Cloud Liquid Water Content:kg/kg
+0:1:0:255:0:0:1:84:SCLIWC:Specific Cloud Ice Water Content:kg/kg
+0:1:0:255:0:0:1:85:SRAINW:Specific Rain Water Content:kg/kg
+0:1:0:255:0:0:1:86:SSNOWW:Specific Snow Water Content:kg/kg
+0:1:0:255:0:0:1:87:STRPRATE:Stratiform Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:88:CATCP:Categorical Convective Precipitation:-
+0:1:0:255:0:0:1:90:TKMFLX:Total Kinematic Moisture Flux:kg/kg*m/s
+0:1:0:255:0:0:1:91:UKMFLX:U-component (zonal) Kinematic Moisture Flux:kg/kg*m/s
+0:1:0:255:0:0:1:92:VKMFLX:V-component (meridional) Kinematic Moisture Flux:kg/kg*m/s
+0:1:0:255:0:0:1:93:RHWATER:Relative Humidity With Respect to Water:%
+0:1:0:255:0:0:1:94:RHICE:Relative Humidity With Respect to Ice:%
+0:1:0:255:0:0:1:95:FZPRATE:Freezing or Frozen Precipitation Rate:kg/m^2/s
+0:1:0:255:0:0:1:96:MASSDR:Mass Density of Rain:kg/m^3
+0:1:0:255:0:0:1:97:MASSDS:Mass Density of Snow:kg/m^3
+0:1:0:255:0:0:1:98:MASSDG:Mass Density of Graupel:kg/m^3
+0:1:0:255:0:0:1:99:MASSDH:Mass Density of Hail:kg/m^3
+0:1:0:255:0:0:1:100:SPNCR:Specific Number Concentration of Rain:1/kg
+0:1:0:255:0:0:1:101:SPNCS:Specific Number Concentration of Snow:1/kg
+0:1:0:255:0:0:1:102:SPNCG:Specific Number Concentration of Graupel:1/kg
+0:1:0:255:0:0:1:103:SPNCH:Specific Number Concentration of Hail:1/kg
+0:1:0:255:0:0:1:104:NUMDR:Number Density of Rain:1/m^3
+0:1:0:255:0:0:1:105:NUMDS:Number Density of Snow:1/m^3
+0:1:0:255:0:0:1:106:NUMDG:Number Density of Graupel:1/m^3
+0:1:0:255:0:0:1:107:NUMDH:Number Density of Hail:1/m^3
+0:1:0:255:0:0:1:108:SHTPRM:Specific Humidity Tendency due to Parameterizations:kg/kg/s
+0:1:0:255:0:0:1:109:MDLWHVA:Mass Density of Liquid Water Coating on Hail Expressed as Mass of Liquid Water per Unit Volume of Air:kg/m^3
+0:1:0:255:0:0:1:110:SMLWHMA:Specific Mass of Liquid Water Coating on Hail Expressed as Mass of Liquid Water per Unit Mass of Moist Air:kg/kg
+0:1:0:255:0:0:1:111:MMLWHDA:Mass Mixing Ratio of Liquid Water Coating on Hail Expressed as Mass of Liquid Water per Unit Mass of Dry Air:kg/kg
+0:1:0:255:0:0:1:112:MDLWGVA:Mass Density of Liquid Water Coating on Graupel Expressed as Mass of Liquid Water per Unit Volume of Air:kg/m^3
+0:1:0:255:0:0:1:113:SMLWGMA:Specific Mass of Liquid Water Coating on Graupel Expressed as Mass of Liquid Water per Unit Mass of Moist Air:kg/kg
+0:1:0:255:0:0:1:114:MMLWGDA:Mass Mixing Ratio of Liquid Water Coating on Graupel Expressed as Mass of Liquid Water per Unit Mass of Dry Air:kg/kg
+0:1:0:255:0:0:1:115:MDLWSVA:Mass Density of Liquid Water Coating on Snow Expressed as Mass of Liquid Water per Unit Volume of Air:kg/m^3
+0:1:0:255:0:0:1:116:SMLWSMA:Specific Mass of Liquid Water Coating on Snow Expressed as Mass of Liquid Water per Unit Mass of Moist Air:kg/kg
+0:1:0:255:0:0:1:117:MMLWSDA:Mass Mixing Ratio of Liquid Water Coating on Snow Expressed as Mass of Liquid Water per Unit Mass of Dry Air:kg/kg
+0:1:0:255:0:0:1:118:UNCSH:Unbalanced Component of Specific Humidity:kg/kg
+0:1:0:255:0:0:1:119:UCSCLW:Unbalanced Component of Specific Cloud Liquid Water content:kg/kg
+0:1:0:255:0:0:1:120:UCSCIW:Unbalanced Component of Specific Cloud Ice Water content:kg/kg
+0:1:0:255:0:0:1:121:FSNOWC:Fraction of Snow Cover:Proportion
+0:1:0:255:0:0:1:122:PIIDX:Precipitation intensity index:-
+0:1:0:255:0:0:1:123:DPTYPE:Dominant precipitation type:-
+0:1:0:255:0:0:1:124:PSHOW:Presence of showers:-
+0:1:0:255:0:0:1:125:PBSNOW:Presence of blowing snow:-
+0:1:0:255:0:0:1:126:PBLIZZ:Presence of blizzard:-
+0:1:0:255:0:0:1:127:ICEP:Ice pellets (non-water equivalent) precipitation rate:m/s
+0:1:0:255:0:0:1:128:TSPRATE:Total solid precipitation rate:kg/m^2/s
+0:1:0:255:0:0:1:129:EFRCWAT:Effective Radius of Cloud Water:m
+0:1:0:255:0:0:1:130:EFRRAIN:Effective Radius of Rain:m
+0:1:0:255:0:0:1:131:EFRCICE:Effective Radius of Cloud Ice:m
+0:1:0:255:0:0:1:132:EFRSNOW:Effective Radius of Snow:m
+0:1:0:255:0:0:1:133:EFRGRL:Effective Radius of Graupel:m
+0:1:0:255:0:0:1:134:EFRHAIL:Effective Radius of Hail:m
+0:1:0:255:0:0:1:135:EFRSLC:Effective Radius of Subgrid Liquid Clouds:m
+0:1:0:255:0:0:1:136:EFRSICEC:Effective Radius of Subgrid Ice Clouds:m
+0:1:0:255:0:0:1:137:EFARRAIN:Effective Aspect Ratio of Rain:-
+0:1:0:255:0:0:1:138:EFARCICE:Effective Aspect Ratio of Cloud Ice:-
+0:1:0:255:0:0:1:139:EFARSNOW:Effective Aspect Ratio of Snow:-
+0:1:0:255:0:0:1:140:EFARGRL:Effective Aspect Ratio of Graupel:-
+0:1:0:255:0:0:1:141:EFARHAIL:Effective Aspect Ratio of Hail:-
+0:1:0:255:0:0:1:142:EFARSIC:Effective Aspect Ratio of Subgrid Ice Clouds:-
+0:1:0:255:0:0:1:143:PERATE:Potential evaporation rate:kg/m^2/s
+0:1:0:255:0:0:1:144:SRWATERC:Specific rain water content (convective):kg/kg
+0:1:0:255:0:0:1:145:SSNOWWC:Specific snow water content (convective):kg/kg
+0:1:0:255:0:0:1:146:CICEPR:Cloud ice precipitation rate:kg/m^2/s
+0:1:0:255:0:0:1:147:CHPRECIP:Character of precipitation:-
+0:1:0:255:0:0:1:148:SNOWERAT:Snow evaporation rate:kg/m^2/s
+0:1:0:255:0:0:1:149:CWATERMR:Cloud water mixing ratio:kg/kg
+0:1:0:255:0:0:1:150:CEWVMF:Column integrated eastward water vapour mass flux:kgm-1s-1
+0:1:0:255:0:0:1:151:CNWVMF:Column integrated northward water vapour mass flux:kgm-1s-1
+0:1:0:255:0:0:1:152:CECLWMF:Column integrated eastward cloud liquid water mass flux:kgm-1s-1
+0:1:0:255:0:0:1:153:CNCLWMF:Column integrated northward cloud liquid water mass flux:kgm-1s-1
+0:1:0:255:0:0:1:154:CECIMF:Column integrated eastward cloud ice mass flux:kgm-1s-1
+0:1:0:255:0:0:1:155:CNCIMF:Column integrated northward cloud ice mass flux:kgm-1s-1
+0:1:0:255:0:0:1:156:CERMF:Column integrated eastward rain mass flux:kgm-1s-1
+0:1:0:255:0:0:1:157:CNRMF:Column integrated northward rain mass flux:kgm-1s-1
+0:1:0:255:0:0:1:158:CEFMF:Column integrated eastward snow mass flux:kgm-1s-1
+0:1:0:255:0:0:1:159:CNSMF:Column integrated northward snow mass flux:kgm-1s-1
+0:1:0:255:0:0:1:160:CDWFMF:Column integrated divergence of water vapour mass flux:kgm-1s-1
+0:1:0:255:0:0:1:161:CDCLWMF:Column integrated divergence of cloud liquid water mass flux:kgm-1s-1
+0:1:0:255:0:0:1:162:CDCIMF:Column integrated divergence of cloud ice mass flux:kgm-1s-1
+0:1:0:255:0:0:1:163:CDRMF:Column integrated divergence of rain mass flux:kgm-1s-1
+0:1:0:255:0:0:1:164:CDSMF:Column integrated divergence of snow mass flux:kgm-1s-1
+0:1:0:255:0:0:1:165:CDTWMF:Column integrated divergence of total water mass flux:kgm-1s-1
+0:1:0:255:0:0:1:166:CWVF:Column integrated water vapour flux:kgm-1s-1
+0:1:0:255:0:0:1:167:TCSLW:Total column supercooled liquid water:kg/m^2
+0:0:0:255:7:1:1:192:CRAIN:Categorical Rain:-
+0:0:0:255:7:1:1:193:CFRZR:Categorical Freezing Rain:-
+0:0:0:255:7:1:1:194:CICEP:Categorical Ice Pellets:-
+0:0:0:255:7:1:1:195:CSNOW:Categorical Snow:-
+0:0:0:255:7:1:1:196:CPRAT:Convective Precipitation Rate:kg/m^2/s
+0:0:0:255:7:1:1:197:MDIV:Horizontal Moisture Divergence:kg/kg/s
+0:0:0:255:7:1:1:198:MINRH:Minimum Relative Humidity:%
+0:0:0:255:7:1:1:199:PEVAP:Potential Evaporation:kg/m^2
+0:0:0:255:7:1:1:200:PEVPR:Potential Evaporation Rate:W/m^2
+0:0:0:255:7:1:1:201:SNOWC:Snow Cover:%
+0:0:0:255:7:1:1:202:FRAIN:Rain Fraction of Total Liquid Water:non-dim
+0:0:0:255:7:1:1:203:RIME:Rime Factor:non-dim
+0:0:0:255:7:1:1:204:TCOLR:Total Column Integrated Rain:kg/m^2
+0:0:0:255:7:1:1:205:TCOLS:Total Column Integrated Snow:kg/m^2
+0:0:0:255:7:1:1:206:TIPD:Total Icing Potential Diagnostic:non-dim
+0:0:0:255:7:1:1:207:NCIP:Number concentration for ice particles:non-dim
+0:0:0:255:7:1:1:208:SNOT:Snow temperature:K
+0:0:0:255:7:1:1:209:TCLSW:Total column-integrated supercooled liquid water:kg/m^2
+0:0:0:255:7:1:1:210:TCOLM:Total column-integrated melting ice:kg/m^2
+0:0:0:255:7:1:1:211:EMNP:Evaporation - Precipitation:cm/day
+0:0:0:255:7:1:1:212:SBSNO:Sublimation (evaporation from snow):W/m^2
+0:0:0:255:7:1:1:213:CNVMR:Deep Convective Moistening Rate:kg/kg/s
+0:0:0:255:7:1:1:214:SHAMR:Shallow Convective Moistening Rate:kg/kg/s
+0:0:0:255:7:1:1:215:VDFMR:Vertical Diffusion Moistening Rate:kg/kg/s
+0:0:0:255:7:1:1:216:CONDP:Condensation Pressure of Parcali Lifted From Indicate Surface:Pa
+0:0:0:255:7:1:1:217:LRGMR:Large scale moistening rate:kg/kg/s
+0:0:0:255:7:1:1:218:QZ0:Specific humidity at top of viscous sublayer:kg/kg
+0:0:0:255:7:1:1:219:QMAX:Maximum specific humidity at 2m:kg/kg
+0:0:0:255:7:1:1:220:QMIN:Minimum specific humidity at 2m:kg/kg
+0:0:0:255:7:1:1:221:ARAIN:Liquid precipitation (Rainfall):kg/m^2
+0:0:0:255:7:1:1:222:SNOWT:Snow temperature, depth-avg:K
+0:0:0:255:7:1:1:223:APCPN:Total precipitation (nearest grid point):kg/m^2
+0:0:0:255:7:1:1:224:ACPCPN:Convective precipitation (nearest grid point):kg/m^2
+0:0:0:255:7:1:1:225:FRZR:Freezing Rain:kg/m^2
+0:0:0:255:7:1:1:226:PWTHER:Predominant Weather (see Local Use Note A):Numeric
+0:0:0:255:7:1:1:227:FROZR:Frozen Rain:kg/m^2
+0:0:0:255:7:1:1:228:FICEAC:Flat Ice Accumulation (FRAM):kg/m^2
+0:0:0:255:7:1:1:229:LICEAC:Line Ice Accumulation (FRAM):kg/m^2
+0:0:0:255:7:1:1:230:SLACC:Sleet Accumulation:kg/m^2
+0:0:0:255:7:1:1:231:PPINDX:Precipitation Potential Index:%
+0:0:0:255:7:1:1:232:PROBCIP:Probability Cloud Ice Present:%
+0:0:0:255:7:1:1:233:SNOWLR:Snow Liquid ratio:kg/kg
+0:0:0:255:7:1:1:234:PCPDUR:Precipitation Duration:hour
+0:0:0:255:7:1:1:235:CLLMR:Cloud Liquid Mixing Ratio:kg/kg
+0:0:0:255:7:1:1:241:TSNOW:Total Snow:kg/m^2
+0:0:0:255:7:1:1:242:RHPW:Relative Humidity with Respect to Precipitable Water:%
+0:0:0:255:7:1:1:245:MAXVIG:Hourly Maximum of Column Vertical Integrated Graupel on Entire Atmosphere:kg/m^2
+0:1:0:255:0:0:2:0:WDIR:Wind Direction (from which blowing):deg
+0:1:0:255:0:0:2:1:WIND:Wind Speed:m/s
+0:1:0:255:0:0:2:2:UGRD:U-Component of Wind:m/s
+0:1:0:255:0:0:2:3:VGRD:V-Component of Wind:m/s
+0:1:0:255:0:0:2:4:STRM:Stream Function:m^2/s
+0:1:0:255:0:0:2:5:VPOT:Velocity Potential:m^2/s
+0:1:0:255:0:0:2:6:MNTSF:Montgomery Stream Function:m^2/s^2
+0:1:0:255:0:0:2:7:SGCVV:Sigma Coordinate Vertical Velocity:1/s
+0:1:0:255:0:0:2:8:VVEL:Vertical Velocity (Pressure):Pa/s
+0:1:0:255:0:0:2:9:DZDT:Vertical Velocity (Geometric):m/s
+0:1:0:255:0:0:2:10:ABSV:Absolute Vorticity:1/s
+0:1:0:255:0:0:2:11:ABSD:Absolute Divergence:1/s
+0:1:0:255:0:0:2:12:RELV:Relative Vorticity:1/s
+0:1:0:255:0:0:2:13:RELD:Relative Divergence:1/s
+0:1:0:255:0:0:2:14:PVORT:Potential Vorticity:K*m^2/kg/s
+0:1:0:255:0:0:2:15:VUCSH:Vertical U-Component Shear:1/s
+0:1:0:255:0:0:2:16:VVCSH:Vertical V-Component Shear:1/s
+0:1:0:255:0:0:2:17:UFLX:Momentum Flux, U-Component:N/m^2
+0:1:0:255:0:0:2:18:VFLX:Momentum Flux, V-Component:N/m^2
+0:1:0:255:0:0:2:19:WMIXE:Wind Mixing Energy:J
+0:1:0:255:0:0:2:20:BLYDP:Boundary Layer Dissipation:W/m^2
+0:1:0:255:0:0:2:21:MAXGUST:Maximum Wind Speed:m/s
+0:1:0:255:0:0:2:22:GUST:Wind Speed (Gust):m/s
+0:1:0:255:0:0:2:23:UGUST:U-Component of Wind (Gust):m/s
+0:1:0:255:0:0:2:24:VGUST:V-Component of Wind (Gust):m/s
+0:1:0:255:0:0:2:25:VWSH:Vertical Speed Shear:1/s
+0:1:0:255:0:0:2:26:MFLX:Horizontal Momentum Flux:N/m^2
+0:1:0:255:0:0:2:27:USTM:U-Component Storm Motion:m/s
+0:1:0:255:0:0:2:28:VSTM:V-Component Storm Motion:m/s
+0:1:0:255:0:0:2:29:CD:Drag Coefficient:Numeric
+0:1:0:255:0:0:2:30:FRICV:Frictional Velocity:m/s
+0:1:0:255:0:0:2:31:TDCMOM:Turbulent Diffusion Coefficient for Momentum:m^2/s
+0:1:0:255:0:0:2:32:ETACVV:Eta Coordinate Vertical Velocity:1/s
+0:1:0:255:0:0:2:33:WINDF:Wind Fetch:m
+0:1:0:255:0:0:2:34:NWIND:Normal Wind Component:m/s
+0:1:0:255:0:0:2:35:TWIND:Tangential Wind Component:m/s
+0:1:0:255:0:0:2:36:AFRWE:Amplitude Function for Rossby Wave Envelope for Meridional Wind:m/s
+0:1:0:255:0:0:2:37:NTSS:Northward Turbulent Surface Stress:N/m^2*s
+0:1:0:255:0:0:2:38:ETSS:Eastward Turbulent Surface Stress:N/m^2*s
+0:1:0:255:0:0:2:39:EWTPARM:Eastward Wind Tendency Due to Parameterizations:m/s^2
+0:1:0:255:0:0:2:40:NWTPARM:Northward Wind Tendency Due to Parameterizations:m/s^2
+0:1:0:255:0:0:2:41:UGWIND:U-Component of Geostrophic Wind:m/s
+0:1:0:255:0:0:2:42:VGWIND:V-Component of Geostrophic Wind:m/s
+0:1:0:255:0:0:2:43:GEOWD:Geostrophic Wind Direction:deg
+0:1:0:255:0:0:2:44:GEOWS:Geostrophic Wind Speed:m/s
+0:1:0:255:0:0:2:45:UNDIV:Unbalanced Component of Divergence:1/s
+0:1:0:255:0:0:2:46:VORTADV:Vorticity Advection:1/s^2
+0:1:0:255:0:0:2:47:SFRHEAT:Surface roughness for heat,:m
+0:1:0:255:0:0:2:48:SFRMOIST:Surface roughness for moisture,:m
+0:1:0:255:0:0:2:49:WINDSTR:Wind stress:N/m^2
+0:1:0:255:0:0:2:50:EWINDSTR:Eastward wind stress:N/m^2
+0:1:0:255:0:0:2:51:NWINDSTR:Northward wind stress:N/m^2
+0:1:0:255:0:0:2:52:UWINDSTR:u-component of wind stress:N/m^2
+0:1:0:255:0:0:2:53:VWINDSTR:v-component of wind stress:N/m^2
+0:1:0:255:0:0:2:54:NLSRLH:Natural logarithm of surface roughness length for heat:m
+0:1:0:255:0:0:2:55:NLSRLM:Natural logarithm of surface roughness length for moisture:m
+0:1:0:255:0:0:2:56:UNWIND:u-component of neutral wind:m/s
+0:1:0:255:0:0:2:57:VNWIND:v-component of neutral wind:m/s
+0:1:0:255:0:0:2:58:TSFCSTR:Magnitude of turbulent surface stress:N/m^2
+0:0:0:255:7:1:2:192:VWSH:Vertical Speed Shear:1/s
+0:0:0:255:7:1:2:193:MFLX:Horizontal Momentum Flux:N/m^2
+0:0:0:255:7:1:2:194:USTM:U-Component Storm Motion:m/s
+0:0:0:255:7:1:2:195:VSTM:V-Component Storm Motion:m/s
+0:0:0:255:7:1:2:196:CD:Drag Coefficient:non-dim
+0:0:0:255:7:1:2:197:FRICV:Frictional Velocity:m/s
+0:0:0:255:7:1:2:198:LAUV:Latitude of U Wind Component of Velocity:deg
+0:0:0:255:7:1:2:199:LOUV:Longitude of U Wind Component of Velocity:deg
+0:0:0:255:7:1:2:200:LAVV:Latitude of V Wind Component of Velocity:deg
+0:0:0:255:7:1:2:201:LOVV:Longitude of V Wind Component of Velocity:deg
+0:0:0:255:7:1:2:202:LAPP:Latitude of Presure Point:deg
+0:0:0:255:7:1:2:203:LOPP:Longitude of Presure Point:deg
+0:0:0:255:7:1:2:204:VEDH:Vertical Eddy Diffusivity Heat exchange:m^2/s
+0:0:0:255:7:1:2:205:COVMZ:Covariance between Meridional and Zonal Components of the wind:m^2/s^2
+0:0:0:255:7:1:2:206:COVTZ:Covariance between Temperature and Zonal Components of the wind:K*m/s
+0:0:0:255:7:1:2:207:COVTM:Covariance between Temperature and Meridional Components of the wind:K*m/s
+0:0:0:255:7:1:2:208:VDFUA:Vertical Diffusion Zonal Acceleration:m/s^2
+0:0:0:255:7:1:2:209:VDFVA:Vertical Diffusion Meridional Acceleration:m/s^2
+0:0:0:255:7:1:2:210:GWDU:Gravity wave drag zonal acceleration:m/s^2
+0:0:0:255:7:1:2:211:GWDV:Gravity wave drag meridional acceleration:m/s^2
+0:0:0:255:7:1:2:212:CNVU:Convective zonal momentum mixing acceleration:m/s^2
+0:0:0:255:7:1:2:213:CNVV:Convective meridional momentum mixing acceleration:m/s^2
+0:0:0:255:7:1:2:214:WTEND:Tendency of vertical velocity:m/s^2
+0:0:0:255:7:1:2:215:OMGALF:Omega (Dp/Dt) divide by density:K
+0:0:0:255:7:1:2:216:CNGWDU:Convective Gravity wave drag zonal acceleration:m/s^2
+0:0:0:255:7:1:2:217:CNGWDV:Convective Gravity wave drag meridional acceleration:m/s^2
+0:0:0:255:7:1:2:218:LMV:Velocity Point Model Surface:-
+0:0:0:255:7:1:2:219:PVMWW:Potential Vorticity (Mass-Weighted):1/s/m
+0:0:0:255:7:1:2:220:MAXUVV:Hourly Maximum of Upward Vertical Velocity:m/s
+0:0:0:255:7:1:2:221:MAXDVV:Hourly Maximum of Downward Vertical Velocity:m/s
+0:0:0:255:7:1:2:222:MAXUW:U Component of Hourly Maximum 10m Wind Speed:m/s
+0:0:0:255:7:1:2:223:MAXVW:V Component of Hourly Maximum 10m Wind Speed:m/s
+0:0:0:255:7:1:2:224:VRATE:Ventilation Rate:m^2/s
+0:0:0:255:7:1:2:225:TRWSPD:Transport Wind Speed:m/s
+0:0:0:255:7:1:2:226:TRWDIR:Transport Wind Direction:deg
+0:0:0:255:7:1:2:227:TOA10:Earliest Reasonable Arrival Time (10% exceedance):s
+0:0:0:255:7:1:2:228:TOA50:Most Likely Arrival Time (50% exceedance):s
+0:0:0:255:7:1:2:229:TOD50:Most Likely Departure Time (50% exceedance):s
+0:0:0:255:7:1:2:230:TOD90:Latest Reasonable Departure Time (90% exceedance):s
+0:0:0:255:7:1:2:231:TPWDIR:Tropical Wind Direction:deg
+0:0:0:255:7:1:2:232:TPWSPD:Tropical Wind Speed:m/s
+0:0:0:255:7:1:2:233:ESHR:Inflow Based (ESFC) to 50% EL Shear Magnitude:kt
+0:0:0:255:7:1:2:234:UESH:U Component Inflow Based to 50% EL Shear Vector:kt
+0:0:0:255:7:1:2:235:VESH:V Component Inflow Based to 50% EL Shear Vector:kt
+0:0:0:255:7:1:2:236:UEID:U Component Bunkers Effective Right Motion:kt
+0:0:0:255:7:1:2:237:VEID:V Component Bunkers Effective Right Motion:kt
+0:1:0:255:0:0:3:0:PRES:Pressure:Pa
+0:1:0:255:0:0:3:1:PRMSL:Pressure Reduced to MSL:Pa
+0:1:0:255:0:0:3:2:PTEND:Pressure Tendency:Pa/s
+0:1:0:255:0:0:3:3:ICAHT:ICAO Standard Atmosphere Reference Height:m
+0:1:0:255:0:0:3:4:GP:Geopotential:m^2/s^2
+0:1:0:255:0:0:3:5:HGT:Geopotential Height:gpm
+0:1:0:255:0:0:3:6:DIST:Geometric Height:m
+0:1:0:255:0:0:3:7:HSTDV:Standard Deviation of Height:m
+0:1:0:255:0:0:3:8:PRESA:Pressure Anomaly:Pa
+0:1:0:255:0:0:3:9:GPA:Geopotential Height Anomaly:gpm
+0:1:0:255:0:0:3:10:DEN:Density:kg/m^3
+0:1:0:255:0:0:3:11:ALTS:Altimeter Setting:Pa
+0:1:0:255:0:0:3:12:THICK:Thickness:m
+0:1:0:255:0:0:3:13:PRESALT:Pressure Altitude:m
+0:1:0:255:0:0:3:14:DENALT:Density Altitude:m
+0:1:0:255:0:0:3:15:5WAVH:5-Wave Geopotential Height:gpm
+0:1:0:255:0:0:3:16:U-GWD:Zonal Flux of Gravity Wave Stress:N/m^2
+0:1:0:255:0:0:3:17:V-GWD:Meridional Flux of Gravity Wave Stress:N/m^2
+0:1:0:255:0:0:3:18:HPBL:Planetary Boundary Layer Height:m
+0:1:0:255:0:0:3:19:5WAVA:5-Wave Geopotential Height Anomaly:gpm
+0:1:0:255:0:0:3:20:SDSGSO:Standard Deviation of Sub-Grid Scale Orography:m
+0:1:0:255:0:0:3:21:AOSGSO:Angle of Sub-Grid Scale Orography:rad
+0:1:0:255:0:0:3:22:SSGSO:Slope of Sub-Grid Scale Orography:Numeric
+0:1:0:255:0:0:3:23:GWD:Gravity Wave Dissipation:W/m^2
+0:1:0:255:0:0:3:24:ASGSO:Anisotropy of Sub-Grid Scale Orography:Numeric
+0:1:0:255:0:0:3:25:NLPRES:Natural Logarithm of Pressure in Pa:Numeric
+0:1:0:255:0:0:3:26:EXPRES:Exner Pressure:Numeric
+0:1:0:255:0:0:3:27:UMFLX:Updraught Mass Flux:kg/m^2/s
+0:1:0:255:0:0:3:28:DMFLX:Downdraught Mass Flux:kg/m^2/s
+0:1:0:255:0:0:3:29:UDRATE:Updraught Detrainment Rate:kg/m^3/s
+0:1:0:255:0:0:3:30:DDRATE:Downdraught Detrainment Rate:kg/m^3/s
+0:1:0:255:0:0:3:31:UCLSPRS:Unbalanced Component of Logarithm of Surface Pressure:-
+0:1:0:255:0:0:3:32:SWATERVP:Saturation water vapour pressure:Pa
+0:1:0:255:0:0:3:33:GAMSL:Geometric altitude above mean sea level:m
+0:1:0:255:0:0:3:34:GHAGRD:Geometric height above ground level:m
+0:1:0:255:0:0:3:35:CDTMF:Column integrated divergence of total mass flux:kg/m^2/s
+0:1:0:255:0:0:3:36:CETMF:Column integrated eastward total mass flux:kg/m^2/s
+0:1:0:255:0:0:3:37:CNTMF:Column integrated northward total mass flux:kg/m^2/s
+0:1:0:255:0:0:3:38:SDFSO:Standard deviation of filtered subgrid orography:m
+0:1:0:255:0:0:3:39:CMATMOS:Column integrated mass of atmosphere:kg/m^2/s
+0:1:0:255:0:0:3:40:CEGFLUX:Column integrated eastward geopotential flux:Wm-1
+0:1:0:255:0:0:3:41:CNGFLUX:Column integrated northward geopotential flux:Wm-1
+0:1:0:255:0:0:3:42:CDWGFLUX:Column integrated divergence of water geopotential flux:W/m^2
+0:1:0:255:0:0:3:43:CDGFLUX:Column integrated divergence of geopotential flux:W/m^2
+0:1:0:255:0:0:3:44:HWBT:Height of zero-degree wet-bulb temperature:m
+0:1:0:255:0:0:3:45:WOBT:Height of one-degree wet-bulb temperature:m
+0:0:0:255:7:1:3:192:MSLET:MSLP (Eta model reduction):Pa
+0:0:0:255:7:1:3:193:5WAVH:5-Wave Geopotential Height:gpm
+0:0:0:255:7:1:3:194:U-GWD:Zonal Flux of Gravity Wave Stress:N/m^2
+0:0:0:255:7:1:3:195:V-GWD:Meridional Flux of Gravity Wave Stress:N/m^2
+0:0:0:255:7:1:3:196:HPBL:Planetary Boundary Layer Height:m
+0:0:0:255:7:1:3:197:5WAVA:5-Wave Geopotential Height Anomaly:gpm
+0:0:0:255:7:1:3:198:MSLMA:MSLP (MAPS System Reduction):Pa
+0:0:0:255:7:1:3:199:TSLSA:3-hr pressure tendency (Std. Atmos. Reduction):Pa/s
+0:0:0:255:7:1:3:200:PLPL:Pressure of level from which parcel was lifted:Pa
+0:0:0:255:7:1:3:201:LPSX:X-gradient of Log Pressure:1/m
+0:0:0:255:7:1:3:202:LPSY:Y-gradient of Log Pressure:1/m
+0:0:0:255:7:1:3:203:HGTX:X-gradient of Height:1/m
+0:0:0:255:7:1:3:204:HGTY:Y-gradient of Height:1/m
+0:0:0:255:7:1:3:205:LAYTH:Layer Thickness:m
+0:0:0:255:7:1:3:206:NLGSP:Natural Log of Surface Pressure:ln(kPa)
+0:0:0:255:7:1:3:207:CNVUMF:Convective updraft mass flux:kg/m^2/s
+0:0:0:255:7:1:3:208:CNVDMF:Convective downdraft mass flux:kg/m^2/s
+0:0:0:255:7:1:3:209:CNVDEMF:Convective detrainment mass flux:kg/m^2/s
+0:0:0:255:7:1:3:210:LMH:Mass Point Model Surface:-
+0:0:0:255:7:1:3:211:HGTN:Geopotential Height (nearest grid point):gpm
+0:0:0:255:7:1:3:212:PRESN:Pressure (nearest grid point):Pa
+0:0:0:255:7:1:3:213:ORCONV:Orographic Convexity:-
+0:0:0:255:7:1:3:214:ORASW:Orographic Asymmetry, W Component:-
+0:0:0:255:7:1:3:215:ORASS:Orographic Asymmetry, S Component:-
+0:0:0:255:7:1:3:216:ORASSW:Orographic Asymmetry, SW Component:-
+0:0:0:255:7:1:3:217:ORASNW:Orographic Asymmetry, NW Component:-
+0:0:0:255:7:1:3:218:ORLSW:Orographic Length Scale, W Component:-
+0:0:0:255:7:1:3:219:ORLSS:Orographic Length Scale, S Component:-
+0:0:0:255:7:1:3:220:ORLSSW:Orographic Length Scale, SW Component:-
+0:0:0:255:7:1:3:221:ORLSNW:Orographic Length Scale, NW Component:-
+0:0:0:255:7:1:3:222:EFSH:Effective Surface Height:m
+0:1:0:255:0:0:4:0:NSWRS:Net Short-Wave Radiation Flux (Surface):W/m^2
+0:1:0:255:0:0:4:1:NSWRT:Net Short-Wave Radiation Flux (Top of Atmosphere):W/m^2
+0:1:0:255:0:0:4:2:SWAVR:Short-Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:4:3:GRAD:Global Radiation Flux:W/m^2
+0:1:0:255:0:0:4:4:BRTMP:Brightness Temperature:K
+0:1:0:255:0:0:4:5:LWRAD:Radiance (with respect to wave number):W/m/sr
+0:1:0:255:0:0:4:6:SWRAD:Radiance (with respect to wavelength):W/m^3/sr
+0:1:0:255:0:0:4:7:DSWRF:Downward Short-Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:4:8:USWRF:Upward Short-Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:4:9:NSWRF:Net Short Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:4:10:PHOTAR:Photosynthetically Active Radiation:W/m^2
+0:1:0:255:0:0:4:11:NSWRFCS:Net Short-Wave Radiation Flux, Clear Sky:W/m^2
+0:1:0:255:0:0:4:12:DWUVR:Downward UV Radiation:W/m^2
+0:1:0:255:0:0:4:13:DSWRFLX:Direct Short Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:4:14:DIFSWRF:Diffuse Short Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:4:50:UVIUCS:UV Index (Under Clear Sky):Numeric
+0:1:0:255:0:0:4:51:UVI:UV Index:Numeric
+0:1:0:255:0:0:4:52:DSWRFCS:Downward Short-Wave Radiation Flux, Clear Sky:W/m^2
+0:1:0:255:0:0:4:53:USWRFCS:Upward Short-Wave Radiation Flux, Clear Sky:W/m^2
+0:1:0:255:0:0:4:54:DNSWRFLX:Direct normal short-wave radiation flux,:W/m^2
+0:1:0:255:0:0:4:55:UVALBDIF:UV visible albedo for diffuse radiation:%
+0:1:0:255:0:0:4:56:UVALBDIR:UV visible albedo for direct radiation:%
+0:1:0:255:0:0:4:57:UBALBDIRG:UV visible albedo for direct radiation, geometric component:%
+0:1:0:255:0:0:4:58:UVALBDIRI:UV visible albedo for direct radiation, isotropic component:%
+0:1:0:255:0:0:4:59:UVBDIRV:UV visible albedo for direct radiation, volumetric component:%
+0:1:0:255:0:0:4:60:PHOARFCS:Photosynthetically active radiation flux, clear sky:W/m^2
+0:1:0:255:0:0:4:61:DSWRFLXCS:Direct short-wave radiation flux, clear sky:W/m^2
+0:0:0:255:7:1:4:192:DSWRF:Downward Short-Wave Radiation Flux:W/m^2
+0:0:0:255:7:1:4:193:USWRF:Upward Short-Wave Radiation Flux:W/m^2
+0:0:0:255:7:1:4:194:DUVB:UV-B Downward Solar Flux:W/m^2
+0:0:0:255:7:1:4:195:CDUVB:Clear sky UV-B Downward Solar Flux:W/m^2
+0:0:0:255:7:1:4:196:CSDSF:Clear Sky Downward Solar Flux:W/m^2
+0:0:0:255:7:1:4:197:SWHR:Solar Radiative Heating Rate:K/s
+0:0:0:255:7:1:4:198:CSUSF:Clear Sky Upward Solar Flux:W/m^2
+0:0:0:255:7:1:4:199:CFNSF:Cloud Forcing Net Solar Flux:W/m^2
+0:0:0:255:7:1:4:200:VBDSF:Visible Beam Downward Solar Flux:W/m^2
+0:0:0:255:7:1:4:201:VDDSF:Visible Diffuse Downward Solar Flux:W/m^2
+0:0:0:255:7:1:4:202:NBDSF:Near IR Beam Downward Solar Flux:W/m^2
+0:0:0:255:7:1:4:203:NDDSF:Near IR Diffuse Downward Solar Flux:W/m^2
+0:0:0:255:7:1:4:204:DTRF:Downward Total Radiation Flux:W/m^2
+0:0:0:255:7:1:4:205:UTRF:Upward Total Radiation Flux:W/m^2
+0:1:0:255:0:0:5:0:NLWRS:Net Long-Wave Radiation Flux (Surface):W/m^2
+0:1:0:255:0:0:5:1:NLWRT:Net Long-Wave Radiation Flux (Top of Atmosphere):W/m^2
+0:1:0:255:0:0:5:2:LWAVR:Long-Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:5:3:DLWRF:Downward Long-Wave Rad. Flux:W/m^2
+0:1:0:255:0:0:5:4:ULWRF:Upward Long-Wave Rad. Flux:W/m^2
+0:1:0:255:0:0:5:5:NLWRF:Net Long-Wave Radiation Flux:W/m^2
+0:1:0:255:0:0:5:6:NLWRCS:Net Long-Wave Radiation Flux, Clear Sky:W/m^2
+0:1:0:255:0:0:5:7:BRTEMP:Brightness Temperature:K
+0:1:0:255:0:0:5:8:DLWRFCS:Downward Long-Wave Radiation Flux, Clear Sky:W/m^2
+0:1:0:255:0:0:5:9:NIRALBDIF:Near IR albedo for diffuse radiation:%
+0:1:0:255:0:0:5:10:NIRALBDIR:Near IR albedo for direct radiation:%
+0:1:0:255:0:0:5:11:NIRALBDIRG:Near IR albedo for direct radiation, geometric component:%
+0:1:0:255:0:0:5:12:NIRALBDIRI:Near IR albedo for direct radiation, isotropic component:%
+0:1:0:255:0:0:5:13:NIRALBDIRV:Near IR albedo for direct radiation, volumetric component:%
+0:0:0:255:7:1:5:192:DLWRF:Downward Long-Wave Rad. Flux:W/m^2
+0:0:0:255:7:1:5:193:ULWRF:Upward Long-Wave Rad. Flux:W/m^2
+0:0:0:255:7:1:5:194:LWHR:Long-Wave Radiative Heating Rate:K/s
+0:0:0:255:7:1:5:195:CSULF:Clear Sky Upward Long Wave Flux:W/m^2
+0:0:0:255:7:1:5:196:CSDLF:Clear Sky Downward Long Wave Flux:W/m^2
+0:0:0:255:7:1:5:197:CFNLF:Cloud Forcing Net Long Wave Flux:W/m^2
+0:1:0:255:0:0:6:0:CICE:Cloud Ice:kg/m^2
+0:1:0:255:0:0:6:1:TCDC:Total Cloud Cover:%
+0:1:0:255:0:0:6:2:CDCON:Convective Cloud Cover:%
+0:1:0:255:0:0:6:3:LCDC:Low Cloud Cover:%
+0:1:0:255:0:0:6:4:MCDC:Medium Cloud Cover:%
+0:1:0:255:0:0:6:5:HCDC:High Cloud Cover:%
+0:1:0:255:0:0:6:6:CWAT:Cloud Water:kg/m^2
+0:1:0:255:0:0:6:7:CDCA:Cloud Amount:%
+0:1:0:255:0:0:6:8:CDCT:Cloud Type:-
+0:1:0:255:0:0:6:9:TMAXT:Thunderstorm Maximum Tops:m
+0:1:0:255:0:0:6:10:THUNC:Thunderstorm Coverage:-
+0:1:0:255:0:0:6:11:CDCB:Cloud Base:m
+0:1:0:255:0:0:6:12:CDCTOP:Cloud Top:m
+0:1:0:255:0:0:6:13:CEIL:Ceiling:m
+0:1:0:255:0:0:6:14:CDLYR:Non-Convective Cloud Cover:%
+0:1:0:255:0:0:6:15:CWORK:Cloud Work Function:J/kg
+0:1:0:255:0:0:6:16:CUEFI:Convective Cloud Efficiency:Proportion
+0:1:0:255:0:0:6:17:TCONDold:Total Condensate:kg/kg
+0:1:0:255:0:0:6:18:TCOLWold:Total Column-Integrated Cloud Water:kg/m^2
+0:1:0:255:0:0:6:19:TCOLIold:Total Column-Integrated Cloud Ice:kg/m^2
+0:1:0:255:0:0:6:20:TCOLC:Total Column-Integrated Condensate:kg/m^2
+0:1:0:255:0:0:6:21:FICE:Ice fraction of total condensate:Proportion
+0:1:0:255:0:0:6:22:CDCC:Cloud Cover:%
+0:1:0:255:0:0:6:23:CDCIMR:Cloud Ice Mixing Ratio:kg/kg
+0:1:0:255:0:0:6:24:SUNS:Sunshine:Numeric
+0:1:0:255:0:0:6:25:CBHE:Horizontal Extent of Cumulonimbus (CB):%
+0:1:0:255:0:0:6:26:HCONCB:Height of Convective Cloud Base:m
+0:1:0:255:0:0:6:27:HCONCT:Height of Convective Cloud Top:m
+0:1:0:255:0:0:6:28:NCONCD:Number Concentration of Cloud Droplets:1/kg
+0:1:0:255:0:0:6:29:NCCICE:Number Concentration of Cloud Ice:1/kg
+0:1:0:255:0:0:6:30:NDENCD:Number Density of Cloud Droplets:1/m^3
+0:1:0:255:0:0:6:31:NDCICE:Number Density of Cloud Ice:1/m^3
+0:1:0:255:0:0:6:32:FRACCC:Fraction of Cloud Cover:Numeric
+0:1:0:255:0:0:6:33:SUNSD:Sunshine Duration:s
+0:1:0:255:0:0:6:34:SLWTC:Surface Long Wave Effective Total Cloudiness:Numeric
+0:1:0:255:0:0:6:35:SSWTC:Surface Short Wave Effective Total Cloudiness:Numeric
+0:1:0:255:0:0:6:36:FSTRPC:Fraction of Stratiform Precipitation Cover:Proportion
+0:1:0:255:0:0:6:37:FCONPC:Fraction of Convective Precipitation Cover:Proportion
+0:1:0:255:0:0:6:38:MASSDCD:Mass Density of Cloud Droplets:kg/m^3
+0:1:0:255:0:0:6:39:MASSDCI:Mass Density of Cloud Ice:kg/m^3
+0:1:0:255:0:0:6:40:MDCCWD:Mass Density of Convective Cloud Water Droplets:kg/m^3
+0:1:0:255:0:0:6:47:VFRCWD:Volume Fraction of Cloud Water Droplets:Numeric
+0:1:0:255:0:0:6:48:VFRCICE:Volume Fraction of Cloud Ice Particles:Numeric
+0:1:0:255:0:0:6:49:VFRCIW:Volume Fraction of Cloud (Ice and/or Water):Numeric
+0:1:0:255:0:0:6:50:FOG:Fog:%
+0:1:0:255:0:0:6:51:SUNFRAC:Sunshine Duration Fraction:Proportion
+0:0:0:255:7:1:6:192:CDLYR:Non-Convective Cloud Cover:%
+0:0:0:255:7:1:6:193:CWORK:Cloud Work Function:J/kg
+0:0:0:255:7:1:6:194:CUEFI:Convective Cloud Efficiency:non-dim
+0:0:0:255:7:1:6:195:TCOND:Total Condensate:kg/kg
+0:0:0:255:7:1:6:196:TCOLW:Total Column-Integrated Cloud Water:kg/m^2
+0:0:0:255:7:1:6:197:TCOLI:Total Column-Integrated Cloud Ice:kg/m^2
+0:0:0:255:7:1:6:198:TCOLC:Total Column-Integrated Condensate:kg/m^2
+0:0:0:255:7:1:6:199:FICE:Ice fraction of total condensate:non-dim
+0:0:0:255:7:1:6:200:MFLUX:Convective Cloud Mass Flux:Pa/s
+0:0:0:255:7:1:6:201:SUNSD:Sunshine Duration:s
+0:1:0:255:0:0:7:0:PLI:Parcel Lifted Index (to 500 hPa):K
+0:1:0:255:0:0:7:1:BLI:Best Lifted Index (to 500 hPa):K
+0:1:0:255:0:0:7:2:KX:K Index:K
+0:1:0:255:0:0:7:3:KOX:KO Index:K
+0:1:0:255:0:0:7:4:TOTALX:Total Totals Index:K
+0:1:0:255:0:0:7:5:SX:Sweat Index:Numeric
+0:1:0:255:0:0:7:6:CAPE:Convective Available Potential Energy:J/kg
+0:1:0:255:0:0:7:7:CIN:Convective Inhibition:J/kg
+0:1:0:255:0:0:7:8:HLCY:Storm Relative Helicity:m^2/s^2
+0:1:0:255:0:0:7:9:EHLX:Energy Helicity Index:Numeric
+0:1:0:255:0:0:7:10:LFTX:Surface Lifted Index:K
+0:1:0:255:0:0:7:11:4LFTX:Best (4 layer) Lifted Index:K
+0:1:0:255:0:0:7:12:RI:Richardson Number:Numeric
+0:1:0:255:0:0:7:13:SHWINX:Showalter Index:K
+0:1:0:255:0:0:7:15:UPHL:Updraft Helicity:m^2/s^2
+0:1:0:255:0:0:7:16:BLKRN:Bulk Richardson Number:Numeric
+0:1:0:255:0:0:7:17:GRDRN:Gradient Richardson Number:Numeric
+0:1:0:255:0:0:7:18:FLXRN:Flux Richardson Number:Numeric
+0:1:0:255:0:0:7:19:CONAPES:Convective Available Potential Energy Shear:m^2/s^2
+0:1:0:255:0:0:7:20:TIIDEX:Thunderstorm intensity index:-
+0:0:0:255:7:1:7:192:LFTX:Surface Lifted Index:K
+0:0:0:255:7:1:7:193:4LFTX:Best (4 layer) Lifted Index:K
+0:0:0:255:7:1:7:194:RI:Richardson Number:Numeric
+0:0:0:255:7:1:7:195:CWDI:Convective Weather Detection Index:-
+0:0:0:255:7:1:7:196:UVI:Ultra Violet Index:W/m^2
+0:0:0:255:7:1:7:197:UPHL:Updraft Helicity:m^2/s^2
+0:0:0:255:7:1:7:198:LAI:Leaf Area Index:Numeric
+0:0:0:255:7:1:7:199:MXUPHL:Hourly Maximum of Updraft Helicity:m^2/s^2
+0:0:0:255:7:1:7:200:MNUPHL:Hourly Minimum of Updraft Helicity:m^2/s^2
+0:0:0:255:7:1:7:201:BNEGELAY:Bourgoiun Negative Energy Layer (surface to freezing level):J/kg
+0:0:0:255:7:1:7:202:BPOSELAY:Bourgoiun Positive Energy Layer (2k ft AGL to 400 hPa):J/kg
+0:0:0:255:7:1:7:203:DCAPE:Downdraft CAPE:J/kg
+0:0:0:255:7:1:7:204:EFHL:Effective Storm Relative Helicity:m^2/s^2
+0:0:0:255:7:1:7:205:ESP:Enhanced Stretching Potential:Numeric
+0:0:0:255:7:1:7:206:CANGLE:Critical Angle:degree
+0:0:0:255:7:1:7:207:E3KH:Effective Surface Helicity:m^2/s^2
+0:0:0:255:7:1:7:208:STPC:Significant Tornado Parameter with CIN-Effective Layer:Numeric
+0:0:0:255:7:1:7:209:SIGH:Significant Hail Parameter:Numeric
+0:0:0:255:7:1:7:210:SCCP:Supercell Composite Parameter-Effective Layer:Numeric
+0:0:0:255:7:1:7:211:SIGT:Significant Tornado parameter-Fixed Layer:Numeric
+0:0:0:255:7:1:7:212:MLFC:Mixed Layer (100 mb) Virtual LFC:Numeric
+0:1:0:255:0:0:13:0:AEROT:Aerosol Type:-
+0:0:0:255:7:1:13:192:PMTC:Particulate matter (coarse):10^-6g/m^3
+0:0:0:255:7:1:13:193:PMTF:Particulate matter (fine):10^-6g/m^3
+0:0:0:255:7:1:13:194:LPMTF:Particulate matter (fine):log10(10^-6g/m^3)
+0:0:0:255:7:1:13:195:LIPMF:Integrated column particulate matter (fine):log10(10^-6g/m^3)
+0:1:0:255:0:0:14:0:TOZNE:Total Ozone:DU
+0:1:0:255:0:0:14:1:O3MR:Ozone Mixing Ratio:kg/kg
+0:1:0:255:0:0:14:2:TCIOZ:Total Column Integrated Ozone:DU
+0:0:0:255:7:1:14:192:O3MR:Ozone Mixing Ratio:kg/kg
+0:0:0:255:7:1:14:193:OZCON:Ozone Concentration:ppb
+0:0:0:255:7:1:14:194:OZCAT:Categorical Ozone Concentration:non-dim
+0:0:0:255:7:1:14:195:VDFOZ:Ozone Vertical Diffusion:kg/kg/s
+0:0:0:255:7:1:14:196:POZ:Ozone Production:kg/kg/s
+0:0:0:255:7:1:14:197:TOZ:Ozone Tendency:kg/kg/s
+0:0:0:255:7:1:14:198:POZT:Ozone Production from Temperature Term:kg/kg/s
+0:0:0:255:7:1:14:199:POZO:Ozone Production from Column Ozone Term:kg/kg/s
+0:0:0:255:7:1:14:200:OZMAX1:Ozone Daily Max from 1-hour Average:ppbV
+0:0:0:255:7:1:14:201:OZMAX8:Ozone Daily Max from 8-hour Average:ppbV
+0:0:0:255:7:1:14:202:PDMAX1:PM 2.5 Daily Max from 1-hour Average:10^-6g/m^3
+0:0:0:255:7:1:14:203:PDMAX24:PM 2.5 Daily Max from 24-hour Average:10^-6g/m^3
+0:0:0:255:7:1:14:204:ALD2:Acetaldehyde & Higher Aldehydes:ppbV
+0:1:0:255:0:0:15:0:BSWID:Base Spectrum Width:m/s
+0:1:0:255:0:0:15:1:BREF:Base Reflectivity:dB
+0:1:0:255:0:0:15:2:BRVEL:Base Radial Velocity:m/s
+0:1:0:255:0:0:15:3:VIL:Vertically-Integrated Liquid Water:kg/m^2
+0:1:0:255:0:0:15:4:LMAXBR:Layer Maximum Base Reflectivity:dB
+0:1:0:255:0:0:15:5:PREC:Precipitation:kg/m^2
+0:1:0:255:0:0:15:6:RDSP1:Radar Spectra (1):-
+0:1:0:255:0:0:15:7:RDSP2:Radar Spectra (2):-
+0:1:0:255:0:0:15:8:RDSP3:Radar Spectra (3):-
+0:1:0:255:0:0:15:9:RFCD:Reflectivity of Cloud Droplets:dB
+0:1:0:255:0:0:15:10:RFCI:Reflectivity of Cloud Ice:dB
+0:1:0:255:0:0:15:11:RFSNOW:Reflectivity of Snow:dB
+0:1:0:255:0:0:15:12:RFRAIN:Reflectivity of Rain:dB
+0:1:0:255:0:0:15:13:RFGRPL:Reflectivity of Graupel:dB
+0:1:0:255:0:0:15:14:RFHAIL:Reflectivity of Hail:dB
+0:1:0:255:0:0:15:15:HSR:Hybrid Scan Reflectivity:dB
+0:1:0:255:0:0:15:16:HSRHT:Hybrid Scan Reflectivity Height:m
+0:1:0:255:0:0:16:0:REFZR:Equivalent radar reflectivity factor for rain:mm^6/m^3
+0:1:0:255:0:0:16:1:REFZI:Equivalent radar reflectivity factor for snow:mm^6/m^3
+0:1:0:255:0:0:16:2:REFZC:Equivalent radar reflectivity factor for parameterized convection:mm^6/m^3
+0:1:0:255:0:0:16:3:RETOP:Echo Top:m
+0:1:0:255:0:0:16:4:REFD:Reflectivity:dB
+0:1:0:255:0:0:16:5:REFC:Composite reflectivity:dB
+0:0:0:255:7:1:16:192:REFZR:Equivalent radar reflectivity factor for rain:mm^6/m^3
+0:0:0:255:7:1:16:193:REFZI:Equivalent radar reflectivity factor for snow:mm^6/m^3
+0:0:0:255:7:1:16:194:REFZC:Equivalent radar reflectivity factor for parameterized convection:mm^6/m^3
+0:0:0:255:7:1:16:195:REFD:Reflectivity:dB
+0:0:0:255:7:1:16:196:REFC:Composite reflectivity:dB
+0:0:0:255:7:1:16:197:RETOP:Echo Top:m
+0:0:0:255:7:1:16:198:MAXREF:Hourly Maximum of Simulated Reflectivity:dB
+0:1:0:255:0:0:17:0:LTNGSD:Lightning Strike Density:1/m^2/s
+0:1:0:255:0:0:17:1:LTPINX:Lightning Potential Index (LPI):J/kg
+0:1:0:255:0:0:17:2:CDGDLTFD:Cloud-to-Ground Lightning Flash Density:1/km^2/day
+0:1:0:255:0:0:17:3:CDCDLTFD:Cloud-to-Cloud Lightning Flash Density:1/km^2/day
+0:1:0:255:0:0:17:4:TLGTFD:Total Lightning Flash Density:1/km^2/day
+0:1:0:255:0:0:17:5:SLNGPIDX:Subgrid-scale lightning potential index:J/kg
+0:0:0:255:7:1:17:192:LTNG:Lightning:non-dim
+0:1:0:255:0:0:18:0:ACCES:Air Concentration of Caesium 137:Bq/m^3
+0:1:0:255:0:0:18:1:ACIOD:Air Concentration of Iodine 131:Bq/m^3
+0:1:0:255:0:0:18:2:ACRADP:Air Concentration of Radioactive Pollutant:Bq/m^3
+0:1:0:255:0:0:18:3:GDCES:Ground Deposition of Caesium 137:Bq/m^2
+0:1:0:255:0:0:18:4:GDIOD:Ground Deposition of Iodine 131:Bq/m^2
+0:1:0:255:0:0:18:5:GDRADP:Ground Deposition of Radioactive Pollutant:Bq/m^2
+0:1:0:255:0:0:18:6:TIACCP:Time Integrated Air Concentration of Cesium Pollutant:Bqs/m^3
+0:1:0:255:0:0:18:7:TIACIP:Time Integrated Air Concentration of Iodine Pollutant:Bqs/m^3
+0:1:0:255:0:0:18:8:TIACRP:Time Integrated Air Concentration of Radioactive Pollutant:Bqs/m^3
+0:1:0:255:0:0:18:10:AIRCON:Air Concentration:Bq/m^3
+0:1:0:255:0:0:18:11:WETDEP:Wet Deposition:Bq/m^2
+0:1:0:255:0:0:18:12:DRYDEP:Dry Deposition:Bq/m^2
+0:1:0:255:0:0:18:13:TOTLWD:Total Deposition (Wet + Dry):Bq/m^2
+0:1:0:255:0:0:18:14:SACON:Specific Activity Concentration:Bq/kg
+0:1:0:255:0:0:18:15:MAXACON:Maximum of Air Concentration in Layer:Bq/m^3
+0:1:0:255:0:0:18:16:HMXACON:Height of Maximum of Air Concentration:m
+0:1:0:255:0:0:18:17:CIAIRC:Column-Integrated Air Concentration:Bq/m^2
+0:1:0:255:0:0:18:18:CAACL:Column-Averaged Air Concentration in Layer:Bq/m^3
+0:1:0:255:0:0:19:0:VIS:Visibility:m
+0:1:0:255:0:0:19:1:ALBDO:Albedo:%
+0:1:0:255:0:0:19:2:TSTM:Thunderstorm Probability:%
+0:1:0:255:0:0:19:3:MIXHT:Mixed Layer Depth:m
+0:1:0:255:0:0:19:4:VOLASH:Volcanic Ash:-
+0:1:0:255:0:0:19:5:ICIT:Icing Top:m
+0:1:0:255:0:0:19:6:ICIB:Icing Base:m
+0:1:0:255:0:0:19:7:ICI:Icing:-
+0:1:0:255:0:0:19:8:TURBT:Turbulence Top:m
+0:1:0:255:0:0:19:9:TURBB:Turbulence Base:m
+0:1:0:255:0:0:19:10:TURB:Turbulence:-
+0:1:0:255:0:0:19:11:TKE:Turbulent Kinetic Energy:J/kg
+0:1:0:255:0:0:19:12:PBLREG:Planetary Boundary Layer Regime:-
+0:1:0:255:0:0:19:13:CONTI:Contrail Intensity:-
+0:1:0:255:0:0:19:14:CONTET:Contrail Engine Type:-
+0:1:0:255:0:0:19:15:CONTT:Contrail Top:m
+0:1:0:255:0:0:19:16:CONTB:Contrail Base:m
+0:1:0:255:0:0:19:17:MXSALB:Maximum Snow Albedo:%
+0:1:0:255:0:0:19:18:SNFALB:Snow-Free Albedo:%
+0:1:0:255:0:0:19:19:SALBD:Snow Albedo:%
+0:1:0:255:0:0:19:20:ICIP:Icing:%
+0:1:0:255:0:0:19:21:CTP:In-Cloud Turbulence:%
+0:1:0:255:0:0:19:22:CAT:Clear Air Turbulence (CAT):%
+0:1:0:255:0:0:19:23:SLDP:Supercooled Large Droplet Probability:%
+0:1:0:255:0:0:19:24:CONTKE:Convective Turbulent Kinetic Energy:J/kg
+0:1:0:255:0:0:19:25:WIWW:Weather:-
+0:1:0:255:0:0:19:26:CONVO:Convective Outlook:-
+0:1:0:255:0:0:19:27:ICESC:Icing Scenario:-
+0:1:0:255:0:0:19:28:MWTURB:Mountain Wave Turbulence (Eddy Dissipation Rate):m2/3s-1
+0:1:0:255:0:0:19:29:CATEDR:Clear Air Turbulence (CAT) (Eddy Dissipation Rate):m2/3s-1
+0:1:0:255:0:0:19:30:EDPARM:Eddy Dissipation Parameter:m2/3s-1
+0:1:0:255:0:0:19:31:MXEDPRM:Maximum of Eddy Dissipation Parameter in Layer:m2/3s-1
+0:1:0:255:0:0:19:32:HIFREL:Highest Freezing Level:m
+0:1:0:255:0:0:19:33:VISLFOG:Visibility Through Liquid Fog:m
+0:1:0:255:0:0:19:34:VISIFOG:Visibility Through Ice Fog:m
+0:1:0:255:0:0:19:35:VISBSN:Visibility Through Blowing Snow:m
+0:1:0:255:0:0:19:36:PSNOWS:Presence of Snow Squalls:-
+0:1:0:255:0:0:19:37:ICESEV:Icing Severity:-
+0:1:0:255:0:0:19:38:SKYIDX:Sky transparency index:-
+0:1:0:255:0:0:19:39:SEEINDEX:Seeing index:-
+0:1:0:255:0:0:19:40:SNOWLVL:Snow level:m
+0:1:0:255:0:0:19:41:DBHEIGHT:Duct base height:m
+0:1:0:255:0:0:19:42:TLBHEIGHT:Trapping layer base height:m
+0:1:0:255:0:0:19:43:TLTHEIGHT:Trapping layer top height:m
+0:1:0:255:0:0:19:44:MEANVGRTL:Mean vertical gradient of refractivity inside trapping layer:1/m
+0:1:0:255:0:0:19:45:MINVGRTL:Minimum vertical gradient of refractivity inside trapping layer:1/m
+0:0:0:255:7:1:19:192:MXSALB:Maximum Snow Albedo:%
+0:0:0:255:7:1:19:193:SNFALB:Snow-Free Albedo:%
+0:0:0:255:7:1:19:194:SRCONO:Slight risk convective outlook:Categorical
+0:0:0:255:7:1:19:195:MRCONO:Moderate risk convective outlook:Categorical
+0:0:0:255:7:1:19:196:HRCONO:High risk convective outlook:Categorical
+0:0:0:255:7:1:19:197:TORPROB:Tornado probability:%
+0:0:0:255:7:1:19:198:HAILPROB:Hail probability:%
+0:0:0:255:7:1:19:199:WINDPROB:Wind probability:%
+0:0:0:255:7:1:19:200:STORPROB:Significant Tornado probability:%
+0:0:0:255:7:1:19:201:SHAILPRO:Significant Hail probability:%
+0:0:0:255:7:1:19:202:SWINDPRO:Significant Wind probability:%
+0:0:0:255:7:1:19:203:TSTMC:Categorical Thunderstorm:-
+0:0:0:255:7:1:19:204:MIXLY:Number of mixed layers next to surface:Integer
+0:0:0:255:7:1:19:205:FLGHT:Flight Category:-
+0:0:0:255:7:1:19:206:CICEL:Confidence - Ceiling:-
+0:0:0:255:7:1:19:207:CIVIS:Confidence - Visibility:-
+0:0:0:255:7:1:19:208:CIFLT:Confidence - Flight Category:-
+0:0:0:255:7:1:19:209:LAVNI:Low-Level aviation interest:-
+0:0:0:255:7:1:19:210:HAVNI:High-Level aviation interest:-
+0:0:0:255:7:1:19:211:SBSALB:Visible, Black Sky Albedo:%
+0:0:0:255:7:1:19:212:SWSALB:Visible, White Sky Albedo:%
+0:0:0:255:7:1:19:213:NBSALB:Near IR, Black Sky Albedo:%
+0:0:0:255:7:1:19:214:NWSALB:Near IR, White Sky Albedo:%
+0:0:0:255:7:1:19:215:PRSVR:Total Probability of Severe Thunderstorms (Days 2,3):%
+0:0:0:255:7:1:19:216:PRSIGSVR:Total Probability of Extreme Severe Thunderstorms (Days 2,3):%
+0:0:0:255:7:1:19:217:SIPD:Supercooled Large Droplet (SLD) Icing:-
+0:0:0:255:7:1:19:218:EPSR:Radiative emissivity:-
+0:0:0:255:7:1:19:219:TPFI:Turbulence Potential Forecast Index:-
+0:0:0:255:7:1:19:220:SVRTS:Categorical Severe Thunderstorm:-
+0:0:0:255:7:1:19:221:PROCON:Probability of Convection:%
+0:0:0:255:7:1:19:222:CONVP:Convection Potential:-
+0:0:0:255:7:1:19:232:VAFTD:Volcanic Ash Forecast Transport and Dispersion:log10(kg/m^3)
+0:0:0:255:7:1:19:233:ICPRB:Icing probability:non-dim
+0:0:0:255:7:1:19:234:ICSEV:Icing Severity:non-dim
+0:0:0:255:7:1:19:235:JFWPRB:Joint Fire Weather Probability:%
+0:0:0:255:7:1:19:236:SNOWLVL:Snow Level:m
+0:0:0:255:7:1:19:237:DRYTPROB:Dry Thunderstorm Probability:%
+0:0:0:255:7:1:19:238:ELLINX:Ellrod Index:-
+0:0:0:255:7:1:19:239:CWASP:Craven-Wiedenfeld Aggregate Severe Parameter:Numeric
+0:1:0:255:0:0:20:0:MASSDEN:Mass Density (Concentration):kg/m^3
+0:1:0:255:0:0:20:1:COLMD:Column-Integrated Mass Density:kg/m^2
+0:1:0:255:0:0:20:2:MASSMR:Mass Mixing Ratio (Mass Fraction in Air):kg/kg
+0:1:0:255:0:0:20:3:AEMFLX:Atmosphere Emission Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:4:ANPMFLX:Atmosphere Net Production Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:5:ANPEMFLX:Atmosphere Net Production And Emision Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:6:SDDMFLX:Surface Dry Deposition Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:7:SWDMFLX:Surface Wet Deposition Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:8:AREMFLX:Atmosphere Re-Emission Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:9:WLSMFLX:Wet Deposition by Large-Scale Precipitation Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:10:WDCPMFLX:Wet Deposition by Convective Precipitation Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:11:SEDMFLX:Sedimentation Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:12:DDMFLX:Dry Deposition Mass Flux:kg/m^2/s
+0:1:0:255:0:0:20:13:TRANHH:Transfer From Hydrophobic to Hydrophilic:kg/kg/s
+0:1:0:255:0:0:20:14:TRSDS:Transfer From SO2 (Sulphur Dioxide) to SO4 (Sulphate):kg/kg/s
+0:1:0:255:0:0:20:15:DDVEL:Dry deposition velocity:m/s
+0:1:0:255:0:0:20:16:MSSRDRYA:Mass mixing ratio with respect to dry air:kg/kg
+0:1:0:255:0:0:20:17:MSSRWETA:Mass mixing ratio with respect to wet air:kg/kg
+0:1:0:255:0:0:20:18:POTHPH:Potential of hydrogen (pH):pH
+0:1:0:255:0:0:20:50:AIA:Amount in Atmosphere:mol
+0:1:0:255:0:0:20:51:CONAIR:Concentration In Air:mol/m^3
+0:1:0:255:0:0:20:52:VMXR:Volume Mixing Ratio (Fraction in Air):mol/mol
+0:1:0:255:0:0:20:53:CGPRC:Chemical Gross Production Rate of Concentration:mol/m^3/s
+0:1:0:255:0:0:20:54:CGDRC:Chemical Gross Destruction Rate of Concentration:mol/m^3/s
+0:1:0:255:0:0:20:55:SFLUX:Surface Flux:mol/m^2/s
+0:1:0:255:0:0:20:56:COAIA:Changes Of Amount in Atmosphere:mol/s
+0:1:0:255:0:0:20:57:TYABA:-:mol
+0:1:0:255:0:0:20:58:TYAAL:Total Yearly Average Atmospheric Loss:mol/s
+0:1:0:255:0:0:20:59:ANCON:Aerosol Number Concentration:1/m^3
+0:1:0:255:0:0:20:60:ASNCON:Aerosol Specific Number Concentration:1/kg
+0:1:0:255:0:0:20:61:MXMASSD:Maximum of Mass Density:kg/m^3
+0:1:0:255:0:0:20:62:HGTMD:Height of Mass Density:m
+0:1:0:255:0:0:20:63:CAVEMDL:Column-Averaged Mass Density in Layer:kg/m^3
+0:1:0:255:0:0:20:64:MOLRDRYA:Mole fraction with respect to dry air:mol/mol
+0:1:0:255:0:0:20:65:MOLRWETA:Mole fraction with respect to wet air:mol/mol
+0:1:0:255:0:0:20:66:CINCLDSP:Column-integrated in-cloud scavenging rate by precipitation:kg/m^2/s
+0:1:0:255:0:0:20:67:CBLCLDSP:Column-integrated below-cloud scavenging rate by precipitation:kg/m^2/s
+0:1:0:255:0:0:20:68:CIRELREP:Column-integrated release rate from evaporating precipitation:kg/m^2/s
+0:1:0:255:0:0:20:69:CINCSLSP:Column-integrated in-cloud scavenging rate by large-scale precipitation:kg/m^2/s
+0:1:0:255:0:0:20:70:CBECSLSP:Column-integrated below-cloud scavenging rate by large-scale precipitation:kg/m^2/s
+0:1:0:255:0:0:20:71:CRERELSP:Column-integrated release rate from evaporating large-scale precipitation:kg/m^2/s
+0:1:0:255:0:0:20:72:CINCSRCP:Column-integrated in-cloud scavenging rate by convective precipitation:kg/m^2/s
+0:1:0:255:0:0:20:73:CBLCSRCP:Column-integrated below-cloud scavenging rate by convective precipitation:kg/m^2/s
+0:1:0:255:0:0:20:74:CIRERECP:Column-integrated release rate from evaporating convective precipitation:kg/m^2/s
+0:1:0:255:0:0:20:75:WFIREFLX:Wildfire flux:kg/m^2/s
+0:1:0:255:0:0:20:76:EMISFLX:Emission Rate:kg/kg/s
+0:1:0:255:0:0:20:77:SFCEFLX:Surface Emission flux:kg/m^2/s
+0:1:0:255:0:0:20:78:CEMF:Column integrated eastward mass flux:kg/m^2/s
+0:1:0:255:0:0:20:79:CNMF:Column integrated northward mass flux:kg/m^2/s
+0:1:0:255:0:0:20:80:CDIVMF:Column integrated divergence of mass flux:kg/m^2/s
+0:1:0:255:0:0:20:81:CDNETS:Column integrated net source:kg/m^2/s
+0:1:0:255:0:0:20:100:SADEN:Surface Area Density (Aerosol):1/m
+0:1:0:255:0:0:20:101:ATMTK:Vertical Visual Range:m
+0:1:0:255:0:0:20:102:AOTK:Aerosol Optical Thickness:Numeric
+0:1:0:255:0:0:20:103:SSALBK:Single Scattering Albedo:Numeric
+0:1:0:255:0:0:20:104:ASYSFK:Asymmetry Factor:Numeric
+0:1:0:255:0:0:20:105:AECOEF:Aerosol Extinction Coefficient:1/m
+0:1:0:255:0:0:20:106:AACOEF:Aerosol Absorption Coefficient:1/m
+0:1:0:255:0:0:20:107:ALBSAT:Aerosol Lidar Backscatter from Satellite:1/m/sr
+0:1:0:255:0:0:20:108:ALBGRD:Aerosol Lidar Backscatter from the Ground:1/m/sr
+0:1:0:255:0:0:20:109:ALESAT:Aerosol Lidar Extinction from Satellite:1/m
+0:1:0:255:0:0:20:110:ALEGRD:Aerosol Lidar Extinction from the Ground:1/m
+0:1:0:255:0:0:20:111:ANGSTEXP:Angstrom Exponent:Numeric
+0:1:0:255:0:0:20:112:SCTAOTK:Scattering Aerosol Optical Thickness:Numeric
+0:1:0:255:0:0:190:0:ATEXT:Arbitrary Text String:CCITTIA5
+0:1:0:255:0:0:191:0:TSEC:Seconds prior to initial reference time:s
+0:1:0:255:0:0:191:1:GEOLAT:Geographical Latitude:deg
+0:1:0:255:0:0:191:2:GEOLON:Geographical Longitude:deg
+0:1:0:255:0:0:191:3:DSLOBS:Days Since Last Observation:day
+0:0:0:255:7:1:191:192:NLAT:Latitude (-90 to 90):deg
+0:0:0:255:7:1:191:193:ELON:East Longitude (0 to 360):deg
+0:0:0:255:7:1:191:194:RTSEC:Seconds prior to initial reference time:s
+0:0:0:255:7:1:191:195:MLYNO:Model Layer number (From bottom up):-
+0:0:0:255:7:1:191:196:NLATN:Latitude (nearest neighbor) (-90 to 90):deg
+0:0:0:255:7:1:191:197:ELONN:East Longitude (nearest neighbor) (0 to 360):deg
+0:0:0:255:7:1:192:1:COVMZ:Covariance between zonal and meridional components of the wind. Defined as [uv]-[u][v], where [] indicates the mean over the indicated time span:m^2/s^2
+0:0:0:255:7:1:192:2:COVTZ:Covariance between zonal component of the wind and temperature. Defined as [uT]-[u][T], where [] indicates the mean over the indicated time span:K*m/s
+0:0:0:255:7:1:192:3:COVTM:Covariance between meridional component of the wind and temperature. Defined as [vT]-[v][T], where [] indicates the mean over the indicated time span:K*m/s
+0:0:0:255:7:1:192:4:COVTW:Covariance between temperature and vertical component of the wind. Defined as [wT]-[w][T], where [] indicates the mean over the indicated time span:K*m/s
+0:0:0:255:7:1:192:5:COVZZ:Covariance between zonal and zonal components of the wind. Defined as [uu]-[u][u], where [] indicates the mean over the indicated time span:m^2/s^2
+0:0:0:255:7:1:192:6:COVMM:Covariance between meridional and meridional components of the wind. Defined as [vv]-[v][v], where [] indicates the mean over the indicated time span:m^2/s^2
+0:0:0:255:7:1:192:7:COVQZ:Covariance between specific humidity and zonal components of the wind. Defined as [uq]-[u][q], where [] indicates the mean over the indicated time span:kg/kg*m/s
+0:0:0:255:7:1:192:8:COVQM:Covariance between specific humidity and meridional components of the wind. Defined as [vq]-[v][q], where [] indicates the mean over the indicated time span:kg/kg*m/s
+0:0:0:255:7:1:192:9:COVTVV:Covariance between temperature and vertical components of the wind. Defined as [OmegaT]-[Omega][T], where [] indicates the mean over the indicated time span:K*Pa/s
+0:0:0:255:7:1:192:10:COVQVV:Covariance between specific humidity and vertical components of the wind. Defined as [Omegaq]-[Omega][q], where [] indicates the mean over the indicated time span:kg/kg*Pa/s
+0:0:0:255:7:1:192:11:COVPSPS:Covariance between surface pressure and surface pressure. Defined as [Psfc]-[Psfc][Psfc], where [] indicates the mean over the indicated time span:Pa*Pa
+0:0:0:255:7:1:192:12:COVQQ:Covariance between specific humidity and specific humidy. Defined as [qq]-[q][q], where [] indicates the mean over the indicated time span:kg/kg*kg/kg
+0:0:0:255:7:1:192:13:COVVVVV:Covariance between vertical and vertical components of the wind. Defined as [OmegaOmega]-[Omega][Omega], where [] indicates the mean over the indicated time span:Pa^2/s^2
+0:0:0:255:7:1:192:14:COVTT:Covariance between temperature and temperature. Defined as [TT]-[T][T], where [] indicates the mean over the indicated time span:K*K
+1:1:0:255:0:0:0:0:FFLDG:Flash Flood Guidance (Encoded as an accumulation over a floating subinterval of time between the reference time and valid time):kg/m^2
+1:1:0:255:0:0:0:1:FFLDRO:Flash Flood Runoff (Encoded as an accumulation over a floating subinterval of time):kg/m^2
+1:1:0:255:0:0:0:2:RSSC:Remotely Sensed Snow Cover:-
+1:1:0:255:0:0:0:3:ESCT:Elevation of Snow Covered Terrain:-
+1:1:0:255:0:0:0:4:SWEPON:Snow Water Equivalent Percent of Normal:%
+1:1:0:255:0:0:0:5:BGRUN:Baseflow-Groundwater Runoff:kg/m^2
+1:1:0:255:0:0:0:6:SSRUN:Storm Surface Runoff:kg/m^2
+1:1:0:255:0:0:0:7:DISRS:Discharge from Rivers or Streams:m^3/s
+1:1:0:255:0:0:0:8:GWUPS:Group Water Upper Storage:kg/m^2
+1:1:0:255:0:0:0:9:GWLOWS:Group Water Lower Storage:kg/m^2
+1:1:0:255:0:0:0:10:SFLORC:Side Flow into River Channel:m^3/s/m
+1:1:0:255:0:0:0:11:RVERSW:River Storage of Water:m^3
+1:1:0:255:0:0:0:12:FLDPSW:Flood Plain Storage of Water:m^3
+1:1:0:255:0:0:0:13:DEPWSS:Depth of Water on Soil Surface:kg/m^2
+1:1:0:255:0:0:0:14:UPAPCP:Upstream Accumulated Precipitation:kg/m^2
+1:1:0:255:0:0:0:15:UPASM:Upstream Accumulated Snow Melt:kg/m^2
+1:1:0:255:0:0:0:16:PERRATE:Percolation Rate:kg/m^2/s
+1:0:0:255:7:1:0:192:BGRUN:Baseflow-Groundwater Runoff:kg/m^2
+1:0:0:255:7:1:0:193:SSRUN:Storm Surface Runoff:kg/m^2
+1:1:0:255:0:0:1:0:CPPOP:Conditional percent precipitation amount fractile for an overall period (encoded as an accumulation):kg/m^2
+1:1:0:255:0:0:1:1:PPOSP:Percent Precipitation in a sub-period of an overall period (encoded as a percent accumulation over the sub-period):%
+1:1:0:255:0:0:1:2:POP:Probability of 0.01 inch of precipitation (POP):%
+1:0:0:255:7:1:1:192:CPOZP:Probability of Freezing Precipitation:%
+1:0:0:255:7:1:1:193:CPOFP:Percent of Frozen Precipitation:%
+1:0:0:255:7:1:1:194:PPFFG:Probability of precipitation exceeding flash flood guidance values:%
+1:0:0:255:7:1:1:195:CWR:Probability of Wetting Rain, exceeding in 0.10 in a given time period:%
+1:1:0:255:0:0:2:0:WDPTHIL:Water Depth:m
+1:1:0:255:0:0:2:1:WTMPIL:Water Temperature:K
+1:1:0:255:0:0:2:2:WFRACT:Water Fraction:Proportion
+1:1:0:255:0:0:2:3:SEDTK:Sediment Thickness:m
+1:1:0:255:0:0:2:4:SEDTMP:Sediment Temperature:K
+1:1:0:255:0:0:2:5:ICTKIL:Ice Thickness:m
+1:1:0:255:0:0:2:6:ICETIL:Ice Temperature:K
+1:1:0:255:0:0:2:7:ICECIL:Ice Cover:Proportion
+1:1:0:255:0:0:2:8:LANDIL:Land Cover (0=water, 1=land):Proportion
+1:1:0:255:0:0:2:9:SFSAL:Shape Factor with Respect to Salinity Profile:-
+1:1:0:255:0:0:2:10:SFTMP:Shape Factor with Respect to Temperature Profile in Thermocline:-
+1:1:0:255:0:0:2:11:ACWSR:Attenuation Coefficient of Water with Respect to Solar Radiation:1/m
+1:1:0:255:0:0:2:12:SALTIL:Salinity:kg/kg
+1:1:0:255:0:0:2:13:CSAFC:Cross Sectional Area of Flow in Channel:m^2
+1:1:0:255:0:0:2:14:LNDSNOWT:Snow temperature:K
+2:1:0:255:0:0:0:0:LAND:Land Cover (0=sea, 1=land):Proportion
+2:1:0:255:0:0:0:1:SFCR:Surface Roughness:m
+2:1:0:255:0:0:0:2:TSOIL:Soil Temperature (Parameter Deprecated,):K
+2:1:0:255:0:0:0:3:SOILM:Soil Moisture Content:kg/m^2
+2:1:0:255:0:0:0:4:VEG:Vegetation:%
+2:1:0:255:0:0:0:5:WATR:Water Runoff:kg/m^2
+2:1:0:255:0:0:0:6:EVAPT:Evapotranspiration:1/kg^2/s
+2:1:0:255:0:0:0:7:MTERH:Model Terrain Height:m
+2:1:0:255:0:0:0:8:LANDU:Land Use:-
+2:1:0:255:0:0:0:9:SOILW:Volumetric Soil Moisture Content:Proportion
+2:1:0:255:0:0:0:10:GFLUX:Ground Heat Flux:W/m^2
+2:1:0:255:0:0:0:11:MSTAV:Moisture Availability:%
+2:1:0:255:0:0:0:12:SFEXC:Exchange Coefficient:kg/m^2/s
+2:1:0:255:0:0:0:13:CNWAT:Plant Canopy Surface Water:kg/m^2
+2:1:0:255:0:0:0:14:BMIXL:Blackadars Mixing Length Scale:m
+2:1:0:255:0:0:0:15:CCOND:Canopy Conductance:m/s
+2:1:0:255:0:0:0:16:RSMIN:Minimal Stomatal Resistance:s/m
+2:1:0:255:0:0:0:17:WILT:Wilting Point (Parameter Deprecated,):Proportion
+2:1:0:255:0:0:0:18:RCS:Solar parameter in canopy conductance:Proportion
+2:1:0:255:0:0:0:19:RCT:Temperature parameter in canopy:Proportion
+2:1:0:255:0:0:0:20:RCQ:Humidity parameter in canopy conductance:Proportion
+2:1:0:255:0:0:0:21:RCSOL:Soil moisture parameter in canopy conductance:Proportion
+2:1:0:255:0:0:0:22:SOIL_M:Soil Moisture:kg/m^3
+2:1:0:255:0:0:0:23:CISOILW:Column-Integrated Soil Water (Parameter Deprecated,):kg/m^2
+2:1:0:255:0:0:0:24:HFLUX:Heat Flux:W/m^2
+2:1:0:255:0:0:0:25:VSOILM:Volumetric Soil Moisture:m^3/m^3
+2:1:0:255:0:0:0:26:WILTPT:Wilting Point:kg/m^3
+2:1:0:255:0:0:0:27:VWILTP:Volumetric Wilting Point:m^3/m^3
+2:1:0:255:0:0:0:28:LEAINX:Leaf Area Index:Numeric
+2:1:0:255:0:0:0:29:EVGFC:Evergreen Forest Cover:Proportion
+2:1:0:255:0:0:0:30:DECFC:Deciduous Forest Cover:Proportion
+2:1:0:255:0:0:0:31:NDVINX:Normalized Differential Vegetation Index (NDVI):Numeric
+2:1:0:255:0:0:0:32:RDVEG:Root Depth of Vegetation:m
+2:1:0:255:0:0:0:33:WROD:Water Runoff and Drainage:kg/m^2
+2:1:0:255:0:0:0:34:SFCWRO:Surface Water Runoff:kg/m^2
+2:1:0:255:0:0:0:35:TCLASS:Tile Class:-
+2:1:0:255:0:0:0:36:TFRCT:Tile Fraction:Proportion
+2:1:0:255:0:0:0:37:TPERCT:Tile Percentage:%
+2:1:0:255:0:0:0:38:SOILVIC:Soil Volumetric Ice Content (Water Equivalent):m^3/m^3
+2:1:0:255:0:0:0:39:EVAPTRAT:Evapotranspiration Rate:kg/m^2/s
+2:1:0:255:0:0:0:40:PEVAPTRAT:Potential Evapotranspiration Rate:kg/m^2/s
+2:1:0:255:0:0:0:41:SMRATE:Snow Melt Rate:kg/m^2/s
+2:1:0:255:0:0:0:42:WRDRATE:Water Runoff and Drainage Rate:kg/m^2/s
+2:1:0:255:0:0:0:43:DRAINDIR:Drainage direction:-
+2:1:0:255:0:0:0:44:UPSAREA:Upstream Area:m^2
+2:1:0:255:0:0:0:45:WETCOV:Wetland Cover:Proportion
+2:1:0:255:0:0:0:46:WETTYPE:Wetland Type:-
+2:1:0:255:0:0:0:47:IRRCOV:Irrigation Cover:Proportion
+2:1:0:255:0:0:0:48:CROPCOV:C4 Crop Cover:Proportion
+2:1:0:255:0:0:0:49:GRASSCOV:C4 Grass Cover:Proportion
+2:1:0:255:0:0:0:50:SKINRC:Skin Resovoir Content:kg/m^2
+2:1:0:255:0:0:0:51:SURFRATE:Surface Runoff Rate:kg/m^2/s
+2:1:0:255:0:0:0:52:SUBSRATE:Subsurface Runoff Rate:kg/m^2/s
+2:1:0:255:0:0:0:53:LOVEGCOV:Low-Vegetation Cover:Proportion
+2:1:0:255:0:0:0:54:HIVEGCOV:High-Vegetation Cover:Proportion
+2:1:0:255:0:0:0:55:LAILO:Leaf Area Index (Low-Vegetation):m2m-2
+2:1:0:255:0:0:0:56:LAIHI:Leaf Area Index (High-Vegetation):m2m-2
+2:1:0:255:0:0:0:57:TYPLOVEG:Type of Low-Vegetation:-
+2:1:0:255:0:0:0:58:TYPHIVEG:Type of High-Vegetation:-
+2:1:0:255:0:0:0:59:NECOFLUX:Net Ecosystem Exchange Flux:1/kg^2/s
+2:1:0:255:0:0:0:60:GROSSFLUX:Gross Primary Production Flux:1/kg^2/s
+2:1:0:255:0:0:0:61:ECORFLUX:Ecosystem Respiration Flux:1/kg^2/s
+2:0:0:255:7:1:0:192:SOILW:Volumetric Soil Moisture Content:Fraction
+2:0:0:255:7:1:0:193:GFLUX:Ground Heat Flux:W/m^2
+2:0:0:255:7:1:0:194:MSTAV:Moisture Availability:%
+2:0:0:255:7:1:0:195:SFEXC:Exchange Coefficient:(kg/m^3)(m/s)
+2:0:0:255:7:1:0:196:CNWAT:Plant Canopy Surface Water:kg/m^2
+2:0:0:255:7:1:0:197:BMIXL:Blackadars Mixing Length Scale:m
+2:0:0:255:7:1:0:198:VGTYP:Vegetation Type:Integer(0-13)
+2:0:0:255:7:1:0:199:CCOND:Canopy Conductance:m/s
+2:0:0:255:7:1:0:200:RSMIN:Minimal Stomatal Resistance:s/m
+2:0:0:255:7:1:0:201:WILT:Wilting Point:Fraction
+2:0:0:255:7:1:0:202:RCS:Solar parameter in canopy conductance:Fraction
+2:0:0:255:7:1:0:203:RCT:Temperature parameter in canopy conductance:Fraction
+2:0:0:255:7:1:0:204:RCQ:Humidity parameter in canopy conductance:Fraction
+2:0:0:255:7:1:0:205:RCSOL:Soil moisture parameter in canopy conductance:Fraction
+2:0:0:255:7:1:0:206:RDRIP:Rate of water dropping from canopy to ground:-
+2:0:0:255:7:1:0:207:ICWAT:Ice-free water surface:%
+2:0:0:255:7:1:0:208:AKHS:Surface exchange coefficients for T and Q divided by delta z:m/s
+2:0:0:255:7:1:0:209:AKMS:Surface exchange coefficients for U and V divided by delta z:m/s
+2:0:0:255:7:1:0:210:VEGT:Vegetation canopy temperature:K
+2:0:0:255:7:1:0:211:SSTOR:Surface water storage:kg/m^2
+2:0:0:255:7:1:0:212:LSOIL:Liquid soil moisture content (non-frozen):kg/m^2
+2:0:0:255:7:1:0:213:EWATR:Open water evaporation (standing water):W/m^2
+2:0:0:255:7:1:0:214:GWREC:Groundwater recharge:kg/m^2
+2:0:0:255:7:1:0:215:QREC:Flood plain recharge:kg/m^2
+2:0:0:255:7:1:0:216:SFCRH:Roughness length for heat:m
+2:0:0:255:7:1:0:217:NDVI:Normalized Difference Vegetation Index:-
+2:0:0:255:7:1:0:218:LANDN:Land-sea coverage (nearest neighbor) [land=1,sea=0]:-
+2:0:0:255:7:1:0:219:AMIXL:Asymptotic mixing length scale:m
+2:0:0:255:7:1:0:220:WVINC:Water vapor added by precip assimilation:kg/m^2
+2:0:0:255:7:1:0:221:WCINC:Water condensate added by precip assimilation:kg/m^2
+2:0:0:255:7:1:0:222:WVCONV:Water Vapor Flux Convergance (Vertical Int):kg/m^2
+2:0:0:255:7:1:0:223:WCCONV:Water Condensate Flux Convergance (Vertical Int):kg/m^2
+2:0:0:255:7:1:0:224:WVUFLX:Water Vapor Zonal Flux (Vertical Int):kg/m^2
+2:0:0:255:7:1:0:225:WVVFLX:Water Vapor Meridional Flux (Vertical Int):kg/m^2
+2:0:0:255:7:1:0:226:WCUFLX:Water Condensate Zonal Flux (Vertical Int):kg/m^2
+2:0:0:255:7:1:0:227:WCVFLX:Water Condensate Meridional Flux (Vertical Int):kg/m^2
+2:0:0:255:7:1:0:228:ACOND:Aerodynamic conductance:m/s
+2:0:0:255:7:1:0:229:EVCW:Canopy water evaporation:W/m^2
+2:0:0:255:7:1:0:230:TRANS:Transpiration:W/m^2
+2:0:0:255:7:1:0:231:VEGMIN:Seasonally Minimum Green Vegetation Fraction (over 1-year period):%
+2:0:0:255:7:1:0:232:VEGMAX:Seasonally Maximum Green Vegetation Fraction (over 1-year period):%
+2:0:0:255:7:1:0:233:LANDFRC:Land Fraction:Fraction
+2:0:0:255:7:1:0:234:LAKEFRC:Lake Fraction:Fraction
+2:0:0:255:7:1:0:235:PAHFLX:Precipitation Advected Heat Flux:W/m^2
+2:0:0:255:7:1:0:236:WATERSA:Water Storage in Aquifer:kg/m^2
+2:0:0:255:7:1:0:237:EIWATER:Evaporation of Intercepted Water:kg/m^2
+2:0:0:255:7:1:0:238:PLANTTR:Plant Transpiration:kg/m^2
+2:0:0:255:7:1:0:239:SOILSE:Soil Surface Evaporation:kg/m^2
+2:0:0:255:7:1:1:192:CANL:Cold Advisory for Newborn Livestock:-
+2:1:0:255:0:0:3:0:SOTYP:Soil Type:-
+2:1:0:255:0:0:3:1:UPLST:Upper Layer Soil Temperature:K
+2:1:0:255:0:0:3:2:UPLSM:Upper Layer Soil Moisture:kg/m^3
+2:1:0:255:0:0:3:3:LOWLSM:Lower Layer Soil Moisture:kg/m^3
+2:1:0:255:0:0:3:4:BOTLST:Bottom Layer Soil Temperature:K
+2:1:0:255:0:0:3:5:SOILL:Liquid Volumetric Soil Moisture(non-frozen):Proportion
+2:1:0:255:0:0:3:6:RLYRS:Number of Soil Layers in Root Zone:Numeric
+2:1:0:255:0:0:3:7:SMREF:Transpiration Stress-onset (soil moisture):Proportion
+2:1:0:255:0:0:3:8:SMDRY:Direct Evaporation Cease (soil moisture):Proportion
+2:1:0:255:0:0:3:9:POROS:Soil Porosity:Proportion
+2:1:0:255:0:0:3:10:LIQVSM:Liquid Volumetric Soil Moisture (Non-Frozen):m^3/m^3
+2:1:0:255:0:0:3:11:VOLTSO:Volumetric Transpiration Stree-Onset(Soil Moisture):m^3/m^3
+2:1:0:255:0:0:3:12:TRANSO:Transpiration Stree-Onset(Soil Moisture):kg/m^3
+2:1:0:255:0:0:3:13:VOLDEC:Volumetric Direct Evaporation Cease(Soil Moisture):m^3/m^3
+2:1:0:255:0:0:3:14:DIREC:Direct Evaporation Cease(Soil Moisture):kg/m^3
+2:1:0:255:0:0:3:15:SOILP:Soil Porosity:m^3/m^3
+2:1:0:255:0:0:3:16:VSOSM:Volumetric Saturation Of Soil Moisture:m^3/m^3
+2:1:0:255:0:0:3:17:SATOSM:Saturation Of Soil Moisture:kg/m^3
+2:1:0:255:0:0:3:18:SOILTMP:Soil Temperature:K
+2:1:0:255:0:0:3:19:SOILMOI:Soil Moisture:kg/m^3
+2:1:0:255:0:0:3:20:CISOILM:Column-Integrated Soil Moisture:kg/m^2
+2:1:0:255:0:0:3:21:SOILICE:Soil Ice:kg/m^3
+2:1:0:255:0:0:3:22:CISICE:Column-Integrated Soil Ice:kg/m^2
+2:1:0:255:0:0:3:23:LWSNWP:Liquid Water in Snow Pack:kg/m^2
+2:1:0:255:0:0:3:24:FRSTINX:Frost Index:kg/day
+2:1:0:255:0:0:3:25:SNWDEB:Snow Depth at Elevation Bands:kg/m^2
+2:1:0:255:0:0:3:26:SHFLX:Soil Heat Flux:W/m^2
+2:1:0:255:0:0:3:27:SOILDEP:Soil Depth:m
+2:1:0:255:0:0:3:28:SNOWTMP:Snow Temperature:K
+2:1:0:255:0:0:3:29:ICETEMP:Ice Temperature:K
+2:0:0:255:7:1:3:192:SOILL:Liquid Volumetric Soil Moisture (non Frozen):Proportion
+2:0:0:255:7:1:3:193:RLYRS:Number of Soil Layers in Root Zone:non-dim
+2:0:0:255:7:1:3:194:SLTYP:Surface Slope Type:Index
+2:0:0:255:7:1:3:195:SMREF:Transpiration Stress-onset (soil moisture):Proportion
+2:0:0:255:7:1:3:196:SMDRY:Direct Evaporation Cease (soil moisture):Proportion
+2:0:0:255:7:1:3:197:POROS:Soil Porosity:Proportion
+2:0:0:255:7:1:3:198:EVBS:Direct Evaporation from Bare Soil:W/m^2
+2:0:0:255:7:1:3:199:LSPA:Land Surface Precipitation Accumulation:kg/m^2
+2:0:0:255:7:1:3:200:BARET:Bare Soil Surface Skin temperature:K
+2:0:0:255:7:1:3:201:AVSFT:Average Surface Skin Temperature:K
+2:0:0:255:7:1:3:202:RADT:Effective Radiative Skin Temperature:K
+2:0:0:255:7:1:3:203:FLDCP:Field Capacity:Fraction
+2:0:0:255:7:1:3:204:MSTAV:Soil Moisture Availability In The Top Soil Layer:%
+2:1:0:255:0:0:4:0:FIREOLK:Fire Outlook:-
+2:1:0:255:0:0:4:1:FIREODT:Fire Outlook Due to Dry Thunderstorm:-
+2:1:0:255:0:0:4:2:HINDEX:Haines Index:Numeric
+2:1:0:255:0:0:4:3:FBAREA:Fire Burned Area:%
+2:1:0:255:0:0:4:4:FOSINDX:Fosberg Index:Numeric
+2:1:0:255:0:0:4:5:FWINX:Fire Weath Index (Canadian Forest Service):Numeric
+2:1:0:255:0:0:4:6:FFMCODE:Fine Fuel Moisture Code (Canadian Forest Service):Numeric
+2:1:0:255:0:0:4:7:DUFMCODE:Duff Moisture Code (Canadian Forest Service):Numeric
+2:1:0:255:0:0:4:8:DRTCODE:Drought Code (Canadian Forest Service):Numeric
+2:1:0:255:0:0:4:9:INFSINX:Initial Fire Spread Index (Canadian Forest Service):Numeric
+2:1:0:255:0:0:4:10:FBUPINX:Fire Build Up Index (Canadian Forest Service):Numeric
+2:1:0:255:0:0:4:11:FDSRTE:Fire Daily Severity Rating (Canadian Forest Service):Numeric
+2:1:0:255:0:0:4:12:KRIDX:Keetch-Byram Drought Index:Numeric
+2:1:0:255:0:0:4:13:DRFACT:Drought Factor (as defined by the Australian forest service):Numeric
+2:1:0:255:0:0:4:14:RATESPRD:Rate of Spread (as defined by the Australian forest service):m/s
+2:1:0:255:0:0:4:15:FIREDIDX:Fire Danger index (as defined by the Australian forest service):Numeric
+2:1:0:255:0:0:4:16:SPRDCOMP:Spread component (as defined by the US Forest Service National Fire Danger Rating System):Numeric
+2:1:0:255:0:0:4:17:BURNIDX:Burning Index (as defined by the Australian forest service):Numeric
+2:1:0:255:0:0:4:18:IGNCOMP:Ignition Component (as defined by the Australian forest service):%
+2:1:0:255:0:0:4:19:ENRELCOM:Energy Release Component (as defined by the Australian forest service):J/m^2
+2:1:0:255:0:0:4:20:BURNAREA:Burning Area:%
+2:1:0:255:0:0:4:21:BURNABAREA:Burnable Area:%
+2:1:0:255:0:0:4:22:UNBURNAREA:Unburnable Area:%
+2:1:0:255:0:0:4:23:FUELLOAD:Fuel Load:kg/m^2
+2:1:0:255:0:0:4:24:COMBCO:Combustion Completeness:%
+2:1:0:255:0:0:4:25:FUELMC:Fuel Moisture Content:kg/kg
+2:1:0:255:0:0:4:26:WFIREPOT:Wildfire Potential (as defined by NOAA Global Systems Laboratory):Numeric
+2:1:0:255:0:0:5:0:GLACCOV:Glacier Cover:Proportion
+2:1:0:255:0:0:5:1:GLACTMP:Glacier Temperature:K
+3:1:0:255:0:0:0:0:SRAD:Scaled Radiance:Numeric
+3:1:0:255:0:0:0:1:SALBEDO:Scaled Albedo:Numeric
+3:1:0:255:0:0:0:2:SBTMP:Scaled Brightness Temperature:Numeric
+3:1:0:255:0:0:0:3:SPWAT:Scaled Precipitable Water:Numeric
+3:1:0:255:0:0:0:4:SLFTI:Scaled Lifted Index:Numeric
+3:1:0:255:0:0:0:5:SCTPRES:Scaled Cloud Top Pressure:Numeric
+3:1:0:255:0:0:0:6:SSTMP:Scaled Skin Temperature:Numeric
+3:1:0:255:0:0:0:7:CLOUDM:Cloud Mask:-
+3:1:0:255:0:0:0:8:PIXST:Pixel scene type:-
+3:1:0:255:0:0:0:9:FIREDI:Fire Detection Indicator:-
+3:1:0:255:0:0:1:0:ESTP:Estimated Precipitation:kg/m^2
+3:1:0:255:0:0:1:1:IRRATE:Instantaneous Rain Rate:kg/m^2/s
+3:1:0:255:0:0:1:2:CTOPH:Cloud Top Height:m
+3:1:0:255:0:0:1:3:CTOPHQI:Cloud Top Height Quality Indicator:-
+3:1:0:255:0:0:1:4:ESTUGRD:Estimated u-Component of Wind:m/s
+3:1:0:255:0:0:1:5:ESTVGRD:Estimated v-Component of Wind:m/s
+3:1:0:255:0:0:1:6:NPIXU:Number Of Pixels Used:Numeric
+3:1:0:255:0:0:1:7:SOLZA:Solar Zenith Angle:deg
+3:1:0:255:0:0:1:8:RAZA:Relative Azimuth Angle:deg
+3:1:0:255:0:0:1:9:RFL06:Reflectance in 0.6 Micron Channel:%
+3:1:0:255:0:0:1:10:RFL08:Reflectance in 0.8 Micron Channel:%
+3:1:0:255:0:0:1:11:RFL16:Reflectance in 1.6 Micron Channel:%
+3:1:0:255:0:0:1:12:RFL39:Reflectance in 3.9 Micron Channel:%
+3:1:0:255:0:0:1:13:ATMDIV:Atmospheric Divergence:1/s
+3:1:0:255:0:0:1:14:CBTMP:Cloudy Brightness Temperature:K
+3:1:0:255:0:0:1:15:CSBTMP:Clear Sky Brightness Temperature:K
+3:1:0:255:0:0:1:16:CLDRAD:Cloudy Radiance (with respect to wave number):W/m/sr
+3:1:0:255:0:0:1:17:CSKYRAD:Clear Sky Radiance (with respect to wave number):W/m/sr
+3:1:0:255:0:0:1:19:WINDS:Wind Speed:m/s
+3:1:0:255:0:0:1:20:AOT06:Aerosol Optical Thickness at 0.635 um:-
+3:1:0:255:0:0:1:21:AOT08:Aerosol Optical Thickness at 0.810 um:-
+3:1:0:255:0:0:1:22:AOT16:Aerosol Optical Thickness at 1.640 um:-
+3:1:0:255:0:0:1:23:ANGCOE:Angstrom Coefficient:-
+3:1:0:255:0:0:1:27:BRFLF:Bidirectional Reflecance Factor:Numeric
+3:1:0:255:0:0:1:28:SPBRT:Brightness Temperature:K
+3:1:0:255:0:0:1:29:SCRAD:Scaled Radiance:Numeric
+3:1:0:255:0:0:1:30:RFL04:Reflectance in 0.4 Micron Channel:%
+3:1:0:255:0:0:1:98:CCMPEMRR:Correlation coefficient between MPE rain rates for the co-located IR data and the microwave data rain rates:Numeric
+3:1:0:255:0:0:1:99:SDMPEMRR:Standard deviation between MPE rain rates for the co-located IR data and the microwave data rain rates:Numeric
+3:0:0:255:7:1:1:192:USCT:Scatterometer Estimated U Wind Component:m/s
+3:0:0:255:7:1:1:193:VSCT:Scatterometer Estimated V Wind Component:m/s
+3:0:0:255:7:1:1:194:SWQI:Scatterometer Wind Quality:-
+3:1:0:255:0:0:2:0:CSKPROB:Clear Sky Probability:%
+3:1:0:255:0:0:2:1:CTOPTMP:Cloud Top Temperature:K
+3:1:0:255:0:0:2:2:CTOPRES:Cloud Top Pressure:Pa
+3:1:0:255:0:0:2:3:CLDTYPE:Cloud Type:-
+3:1:0:255:0:0:2:4:CLDPHAS:Cloud Phase:-
+3:1:0:255:0:0:2:5:CLDODEP:Cloud Optical Depth:Numeric
+3:1:0:255:0:0:2:6:CLDPER:Cloud Particle Effective Radius:m
+3:1:0:255:0:0:2:7:CLDLWP:Cloud Liquid Water Path:kg/m^2
+3:1:0:255:0:0:2:8:CLDIWP:Cloud Ice Water Path:kg/m^2
+3:1:0:255:0:0:2:9:CLDALB:Cloud Albedo:Numeric
+3:1:0:255:0:0:2:10:CLDEMISS:Cloud Emissivity:Numeric
+3:1:0:255:0:0:2:11:EAODR:Effective Absorption Optical Depth Ratio:Numeric
+3:1:0:255:0:0:2:30:MEACST:Measurement cost:Numeric
+3:1:0:255:0:0:3:0:PBMVFRC:Probability of Encountering Marginal Visual Flight Rules Conditions:%
+3:1:0:255:0:0:3:1:PBLIFRC:Probability of Encountering Low Instrument Flight Rules Conditions:%
+3:1:0:255:0:0:3:2:PBINFRC:Probability of Encountering Instrument Flight Rules Conditions:%
+3:1:0:255:0:0:4:0:VOLAPROB:Volcanic Ash Probability:%
+3:1:0:255:0:0:4:1:VOLACDTT:Volcanic Ash Cloud Top Temperature:K
+3:1:0:255:0:0:4:2:VOLACDTP:Volcanic Ash Cloud Top Pressure:Pa
+3:1:0:255:0:0:4:3:VOLACDTH:Volcanic Ash Cloud Top Height:m
+3:1:0:255:0:0:4:4:VOLACDEM:Volcanic Ash Cloud Emissity:Numeric
+3:1:0:255:0:0:4:5:VOLAEADR:Volcanic Ash Effective Absorption Depth Ratio:Numeric
+3:1:0:255:0:0:4:6:VOLACDOD:Volcanic Ash Cloud Optical Depth:Numeric
+3:1:0:255:0:0:4:7:VOLACDEN:Volcanic Ash Column Density:kg/m^2
+3:1:0:255:0:0:4:8:VOLAPER:Volcanic Ash Particle Effective Radius:m
+3:1:0:255:0:0:5:0:ISSTMP:Interface Sea-Surface Temperature:K
+3:1:0:255:0:0:5:1:SKSSTMP:Skin Sea-Surface Temperature:K
+3:1:0:255:0:0:5:2:SSKSSTMP:Sub-Skin Sea-Surface Temperature:K
+3:1:0:255:0:0:5:3:FDNSSTMP:Foundation Sea-Surface Temperature:K
+3:1:0:255:0:0:5:4:EBSSTSTD:Estimated bias between Sea-Surface Temperature and Standard:K
+3:1:0:255:0:0:5:5:EBSDSSTS:Estimated bias Standard Deviation between Sea-Surface Temperature and Standard:K
+3:1:0:255:0:0:6:0:GSOLIRR:Global Solar Irradiance:W/m^2
+3:1:0:255:0:0:6:1:GSOLEXP:Global Solar Exposure:J/m^2
+3:1:0:255:0:0:6:2:DIRSOLIR:Direct Solar Irradiance:W/m^2
+3:1:0:255:0:0:6:3:DIRSOLEX:Direct Solar Exposure:J/m^2
+3:1:0:255:0:0:6:4:DIFSOLIR:Diffuse Solar Irradiance:W/m^2
+3:1:0:255:0:0:6:5:DIFSOLEX:Diffuse Solar Exposure:J/m^2
+3:0:0:255:7:1:192:0:SBT122:Simulated Brightness Temperature for GOES 12, Channel 2:K
+3:0:0:255:7:1:192:1:SBT123:Simulated Brightness Temperature for GOES 12, Channel 3:K
+3:0:0:255:7:1:192:2:SBT124:Simulated Brightness Temperature for GOES 12, Channel 4:K
+3:0:0:255:7:1:192:3:SBT126:Simulated Brightness Temperature for GOES 12, Channel 6:K
+3:0:0:255:7:1:192:4:SBC123:Simulated Brightness Counts for GOES 12, Channel 3:Byte
+3:0:0:255:7:1:192:5:SBC124:Simulated Brightness Counts for GOES 12, Channel 4:Byte
+3:0:0:255:7:1:192:6:SBT112:Simulated Brightness Temperature for GOES 11, Channel 2:K
+3:0:0:255:7:1:192:7:SBT113:Simulated Brightness Temperature for GOES 11, Channel 3:K
+3:0:0:255:7:1:192:8:SBT114:Simulated Brightness Temperature for GOES 11, Channel 4:K
+3:0:0:255:7:1:192:9:SBT115:Simulated Brightness Temperature for GOES 11, Channel 5:K
+3:0:0:255:7:1:192:10:AMSRE9:Simulated Brightness Temperature for AMSRE on Aqua, Channel 9:K
+3:0:0:255:7:1:192:11:AMSRE10:Simulated Brightness Temperature for AMSRE on Aqua, Channel 10:K
+3:0:0:255:7:1:192:12:AMSRE11:Simulated Brightness Temperature for AMSRE on Aqua, Channel 11:K
+3:0:0:255:7:1:192:13:AMSRE12:Simulated Brightness Temperature for AMSRE on Aqua, Channel 12:K
+3:0:0:255:7:1:192:14:SRFA161:Simulated Reflectance Factor for ABI GOES-16, Band-1:-
+3:0:0:255:7:1:192:15:SRFA162:Simulated Reflectance Factor for ABI GOES-16, Band-2:-
+3:0:0:255:7:1:192:16:SRFA163:Simulated Reflectance Factor for ABI GOES-16, Band-3:-
+3:0:0:255:7:1:192:17:SRFA164:Simulated Reflectance Factor for ABI GOES-16, Band-4:-
+3:0:0:255:7:1:192:18:SRFA165:Simulated Reflectance Factor for ABI GOES-16, Band-5:-
+3:0:0:255:7:1:192:19:SRFA166:Simulated Reflectance Factor for ABI GOES-16, Band-6:-
+3:0:0:255:7:1:192:20:SBTA167:Simulated Brightness Temperature for ABI GOES-16, Band-7:K
+3:0:0:255:7:1:192:21:SBTA168:Simulated Brightness Temperature for ABI GOES-16, Band-8:K
+3:0:0:255:7:1:192:22:SBTA169:Simulated Brightness Temperature for ABI GOES-16, Band-9:K
+3:0:0:255:7:1:192:23:SBTA1610:Simulated Brightness Temperature for ABI GOES-16, Band-10:K
+3:0:0:255:7:1:192:24:SBTA1611:Simulated Brightness Temperature for ABI GOES-16, Band-11:K
+3:0:0:255:7:1:192:25:SBTA1612:Simulated Brightness Temperature for ABI GOES-16, Band-12:K
+3:0:0:255:7:1:192:26:SBTA1613:Simulated Brightness Temperature for ABI GOES-16, Band-13:K
+3:0:0:255:7:1:192:27:SBTA1614:Simulated Brightness Temperature for ABI GOES-16, Band-14:K
+3:0:0:255:7:1:192:28:SBTA1615:Simulated Brightness Temperature for ABI GOES-16, Band-15:K
+3:0:0:255:7:1:192:29:SBTA1616:Simulated Brightness Temperature for ABI GOES-16, Band-16:K
+3:0:0:255:7:1:192:30:SRFA171:Simulated Reflectance Factor for ABI GOES-17, Band-1:-
+3:0:0:255:7:1:192:31:SRFA172:Simulated Reflectance Factor for ABI GOES-17, Band-2:-
+3:0:0:255:7:1:192:32:SRFA173:Simulated Reflectance Factor for ABI GOES-17, Band-3:-
+3:0:0:255:7:1:192:33:SRFA174:Simulated Reflectance Factor for ABI GOES-17, Band-4:-
+3:0:0:255:7:1:192:34:SRFA175:Simulated Reflectance Factor for ABI GOES-17, Band-5:-
+3:0:0:255:7:1:192:35:SRFA176:Simulated Reflectance Factor for ABI GOES-17, Band-6:-
+3:0:0:255:7:1:192:36:SBTA177:Simulated Brightness Temperature for ABI GOES-17, Band-7:K
+3:0:0:255:7:1:192:37:SBTA178:Simulated Brightness Temperature for ABI GOES-17, Band-8:K
+3:0:0:255:7:1:192:38:SBTA179:Simulated Brightness Temperature for ABI GOES-17, Band-9:K
+3:0:0:255:7:1:192:39:SBTA1710:Simulated Brightness Temperature for ABI GOES-17, Band-10:K
+3:0:0:255:7:1:192:40:SBTA1711:Simulated Brightness Temperature for ABI GOES-17, Band-11:K
+3:0:0:255:7:1:192:41:SBTA1712:Simulated Brightness Temperature for ABI GOES-17, Band-12:K
+3:0:0:255:7:1:192:42:SBTA1713:Simulated Brightness Temperature for ABI GOES-17, Band-13:K
+3:0:0:255:7:1:192:43:SBTA1714:Simulated Brightness Temperature for ABI GOES-17, Band-14:K
+3:0:0:255:7:1:192:44:SBTA1715:Simulated Brightness Temperature for ABI GOES-17, Band-15:K
+3:0:0:255:7:1:192:45:SBTA1716:Simulated Brightness Temperature for ABI GOES-17, Band-16:K
+3:0:0:255:7:1:192:46:SRFAGR1:Simulated Reflectance Factor for nadir ABI GOES-R, Band-1:-
+3:0:0:255:7:1:192:47:SRFAGR2:Simulated Reflectance Factor for nadir ABI GOES-R, Band-2:-
+3:0:0:255:7:1:192:48:SRFAGR3:Simulated Reflectance Factor for nadir ABI GOES-R, Band-3:-
+3:0:0:255:7:1:192:49:SRFAGR4:Simulated Reflectance Factor for nadir ABI GOES-R, Band-4:-
+3:0:0:255:7:1:192:50:SRFAGR5:Simulated Reflectance Factor for nadir ABI GOES-R, Band-5:-
+3:0:0:255:7:1:192:51:SRFAGR6:Simulated Reflectance Factor for nadir ABI GOES-R, Band-6:-
+3:0:0:255:7:1:192:52:SBTAGR7:Simulated Brightness Temperature for nadir ABI GOES-R, Band-7:-
+3:0:0:255:7:1:192:53:SBTAGR8:Simulated Brightness Temperature for nadir ABI GOES-R, Band-8:-
+3:0:0:255:7:1:192:54:SBTAGR9:Simulated Brightness Temperature for nadir ABI GOES-R, Band-9:-
+3:0:0:255:7:1:192:55:SBTAGR10:Simulated Brightness Temperature for nadir ABI GOES-R, Band-10:-
+3:0:0:255:7:1:192:56:SBTAGR11:Simulated Brightness Temperature for nadir ABI GOES-R, Band-11:-
+3:0:0:255:7:1:192:57:SBTAGR12:Simulated Brightness Temperature for nadir ABI GOES-R, Band-12:-
+3:0:0:255:7:1:192:58:SBTAGR13:Simulated Brightness Temperature for nadir ABI GOES-R, Band-13:-
+3:0:0:255:7:1:192:59:SBTAGR14:Simulated Brightness Temperature for nadir ABI GOES-R, Band-14:-
+3:0:0:255:7:1:192:60:SBTAGR15:Simulated Brightness Temperature for nadir ABI GOES-R, Band-15:-
+3:0:0:255:7:1:192:61:SBTAGR16:Simulated Brightness Temperature for nadir ABI GOES-R, Band-16:-
+3:0:0:255:7:1:192:62:SSMS1715:Simulated Brightness Temperature for SSMIS-F17, Channel 15:K
+3:0:0:255:7:1:192:63:SSMS1716:Simulated Brightness Temperature for SSMIS-F17, Channel 16:K
+3:0:0:255:7:1:192:64:SSMS1717:Simulated Brightness Temperature for SSMIS-F17, Channel 17:K
+3:0:0:255:7:1:192:65:SSMS1718:Simulated Brightness Temperature for SSMIS-F17, Channel 18:K
+3:0:0:255:7:1:192:66:SBTAHI7:Simulated Brightness Temperature for Himawari-8, Band-7:K
+3:0:0:255:7:1:192:67:SBTAHI8:Simulated Brightness Temperature for Himawari-8, Band-8:K
+3:0:0:255:7:1:192:68:SBTAHI9:Simulated Brightness Temperature for Himawari-8, Band-9:K
+3:0:0:255:7:1:192:69:SBTAHI10:Simulated Brightness Temperature for Himawari-8, Band-10:K
+3:0:0:255:7:1:192:70:SBTAHI11:Simulated Brightness Temperature for Himawari-8, Band-11:K
+3:0:0:255:7:1:192:71:SBTAHI12:Simulated Brightness Temperature for Himawari-8, Band-12:K
+3:0:0:255:7:1:192:72:SBTAHI13:Simulated Brightness Temperature for Himawari-8, Band-13:K
+3:0:0:255:7:1:192:73:SBTAHI14:Simulated Brightness Temperature for Himawari-8, Band-14:K
+3:0:0:255:7:1:192:74:SBTAHI15:Simulated Brightness Temperature for Himawari-8, Band-15:K
+3:0:0:255:7:1:192:75:SBTAHI16:Simulated Brightness Temperature for Himawari-8, Band-16:K
+3:0:0:255:7:1:192:76:SBTA187:Simulated Brightness Temperature for ABI GOES-18, Band-7:K
+3:0:0:255:7:1:192:77:SBTA188:Simulated Brightness Temperature for ABI GOES-18, Band-8:K
+3:0:0:255:7:1:192:78:SBTA189:Simulated Brightness Temperature for ABI GOES-18, Band-9:K
+3:0:0:255:7:1:192:79:SBTA1810:Simulated Brightness Temperature for ABI GOES-18, Band-10:K
+3:0:0:255:7:1:192:80:SBTA1811:Simulated Brightness Temperature for ABI GOES-18, Band-11:K
+3:0:0:255:7:1:192:81:SBTA1812:Simulated Brightness Temperature for ABI GOES-18, Band-12:K
+3:0:0:255:7:1:192:82:SBTA1813:Simulated Brightness Temperature for ABI GOES-18, Band-13:K
+3:0:0:255:7:1:192:83:SBTA1814:Simulated Brightness Temperature for ABI GOES-18, Band-14:K
+3:0:0:255:7:1:192:84:SBTA1815:Simulated Brightness Temperature for ABI GOES-18, Band-15:K
+3:0:0:255:7:1:192:85:SBTA1816:Simulated Brightness Temperature for ABI GOES-18, Band-16:K
+4:1:0:255:0:0:0:0:TMPSWP:Temperature:K
+4:1:0:255:0:0:0:1:ELECTMP:Electron Temperature:K
+4:1:0:255:0:0:0:2:PROTTMP:Proton Temperature:K
+4:1:0:255:0:0:0:3:IONTMP:Ion Temperature:K
+4:1:0:255:0:0:0:4:PRATMP:Parallel Temperature:K
+4:1:0:255:0:0:0:5:PRPTMP:Perpendicular Temperature:K
+4:1:0:255:0:0:1:0:SPEED:Velocity Magnitude (Speed):m/s
+4:1:0:255:0:0:1:1:VEL1:1st Vector Component of Velocity (Coordinate system dependent):m/s
+4:1:0:255:0:0:1:2:VEL2:2nd Vector Component of Velocity (Coordinate system dependent):m/s
+4:1:0:255:0:0:1:3:VEL3:3rd Vector Component of Velocity (Coordinate system dependent):m/s
+4:1:0:255:0:0:2:0:PLSMDEN:Particle Number Density:1/m^3
+4:1:0:255:0:0:2:1:ELCDEN:Electron Density:1/m^3
+4:1:0:255:0:0:2:2:PROTDEN:Proton Density:1/m^3
+4:1:0:255:0:0:2:3:IONDEN:Ion Density:1/m^3
+4:1:0:255:0:0:2:4:VTEC:Vertical Total Electron Content:TECU
+4:1:0:255:0:0:2:5:ABSFRQ:HF Absorption Frequency:Hz
+4:1:0:255:0:0:2:6:ABSRB:HF Absorption:dB
+4:1:0:255:0:0:2:7:SPRDF:Spread F:m
+4:1:0:255:0:0:2:8:HPRIMF:hF:m
+4:1:0:255:0:0:2:9:CRTFRQ:Critical Frequency:Hz
+4:1:0:255:0:0:2:10:MAXUFZ:Maximal Usable Frequency (MUF):Hz
+4:1:0:255:0:0:2:11:PEAKH:Peak Height (hm):m
+4:1:0:255:0:0:2:12:PEAKDEN:Peak Density:1/m^3
+4:1:0:255:0:0:2:13:EQSLABT:Equivalent Slab Thickness (tau):km
+4:1:0:255:0:0:3:0:BTOT:Magnetic Field Magnitude:T
+4:1:0:255:0:0:3:1:BVEC1:1st Vector Component of Magnetic Field:T
+4:1:0:255:0:0:3:2:BVEC2:2nd Vector Component of Magnetic Field:T
+4:1:0:255:0:0:3:3:BVEC3:3rd Vector Component of Magnetic Field:T
+4:1:0:255:0:0:3:4:ETOT:Electric Field Magnitude:V/m
+4:1:0:255:0:0:3:5:EVEC1:1st Vector Component of Electric Field:V/m
+4:1:0:255:0:0:3:6:EVEC2:2nd Vector Component of Electric Field:V/m
+4:1:0:255:0:0:3:7:EVEC3:3rd Vector Component of Electric Field:V/m
+4:1:0:255:0:0:4:0:DIFPFLUX:Proton Flux (Differential):1/(m^2s*sr*eV)
+4:1:0:255:0:0:4:1:INTPFLUX:Proton Flux (Integral):1/(m^2s*sr)
+4:1:0:255:0:0:4:2:DIFEFLUX:Electron Flux (Differential):1/(m^2s*sr*eV)
+4:1:0:255:0:0:4:3:INTEFLUX:Electron Flux (Integral):1/(m^2s*sr)
+4:1:0:255:0:0:4:4:DIFIFLUX:Heavy Ion Flux (Differential):1/(m^2s*sr*eV/nuc)
+4:1:0:255:0:0:4:5:INTIFLUX:Heavy Ion Flux (iIntegral):1/(m^2s*sr)
+4:1:0:255:0:0:4:6:NTRNFLUX:Cosmic Ray Neutron Flux:1/h
+4:1:0:255:0:0:5:0:AMPL:Amplitude:rad
+4:1:0:255:0:0:5:1:PHASE:Phase:rad
+4:1:0:255:0:0:5:2:FREQ:Frequency:Hz
+4:1:0:255:0:0:5:3:WAVELGTH:Wavelength:m
+4:1:0:255:0:0:6:0:TSI:Integrated Solar Irradiance:W/m^2
+4:1:0:255:0:0:6:1:XLONG:Solar X-ray Flux (XRS Long):W/m^2
+4:1:0:255:0:0:6:2:XSHRT:Solar X-ray Flux (XRS Short):W/m^2
+4:1:0:255:0:0:6:3:EUVIRR:Solar EUV Irradiance:W/m^2
+4:1:0:255:0:0:6:4:SPECIRR:Solar Spectral Irradiance:W/m^2/m^-9
+4:1:0:255:0:0:6:5:F107:F10.7:W/m^2/Hz
+4:1:0:255:0:0:6:6:SOLRF:Solar Radio Emissions:W/m^2/Hz
+4:1:0:255:0:0:7:0:LMBINT:Limb Intensity:Jm-2s-1
+4:1:0:255:0:0:7:1:DSKINT:Disk Intensity:Jm-2s-1
+4:1:0:255:0:0:7:2:DSKDAY:Disk Intensity Day:Jm-2s-1
+4:1:0:255:0:0:7:3:DSKNGT:Disk Intensity Night:Jm-2s-1
+4:1:0:255:0:0:8:0:XRAYRAD:X-Ray Radiance:W/sr/m^2
+4:1:0:255:0:0:8:1:EUVRAD:EUV Radiance:W/sr/m^2
+4:1:0:255:0:0:8:2:HARAD:H-Alpha Radiance:W/sr/m^2
+4:1:0:255:0:0:8:3:WHTRAD:White Light Radiance:W/sr/m^2
+4:1:0:255:0:0:8:4:CAIIRAD:CaII-K Radiance:W/sr/m^2
+4:1:0:255:0:0:8:5:WHTCOR:White Light Coronagraph Radiance:W/sr/m^2
+4:1:0:255:0:0:8:6:HELCOR:Heliospheric Radiance:W/sr/m^2
+4:1:0:255:0:0:8:7:MASK:Thematic Mask:Numeric
+4:1:0:255:0:0:8:8:SICFL:Solar Induced Chlorophyll Fluorscence:W/sr/m^2
+4:1:0:255:0:0:9:0:SIGPED:Pedersen Conductivity:S/m
+4:1:0:255:0:0:9:1:SIGHAL:Hall Conductivity:S/m
+4:1:0:255:0:0:9:2:SIGPAR:Parallel Conductivity:S/m
+4:1:0:255:0:0:10:0:SCINIDX:Scintillation Index (sigma phi):rad
+4:1:0:255:0:0:10:1:SCIDEXS4:Scintillation Index S4:Numeric
+4:1:0:255:0:0:10:2:ROTIDX:Rate of Change of TEC Index (ROTI):TECU/min
+4:1:0:255:0:0:10:3:DIDXSG:Disturbance Ionosphere Index Spatial Gradient (DIXSG):Numeric
+4:1:0:255:0:0:10:4:AATRATE:Along Arc TEC Rate (AATR):TECU/min
+4:1:0:255:0:0:10:5:KP:Kp:Numeric
+4:1:0:255:0:0:10:6:EDISSTIX:Equatorial Disturbance Storm Time Index (Dst):nT
+4:1:0:255:0:0:10:7:AURELEC:Auroral Electrojet (AE):nT
+10:1:0:255:0:0:0:0:WVSP1:Wave Spectra (1):-
+10:1:0:255:0:0:0:1:WVSP2:Wave Spectra (2):-
+10:1:0:255:0:0:0:2:WVSP3:Wave Spectra (3):-
+10:1:0:255:0:0:0:3:HTSGW:Significant Height of Combined Wind Waves and Swell:m
+10:1:0:255:0:0:0:4:WVDIR:Direction of Wind Waves:deg
+10:1:0:255:0:0:0:5:WVHGT:Significant Height of Wind Waves:m
+10:1:0:255:0:0:0:6:WVPER:Mean Period of Wind Waves:s
+10:1:0:255:0:0:0:7:SWDIR:Direction of Swell Waves:deg
+10:1:0:255:0:0:0:8:SWELL:Significant Height of Swell Waves:m
+10:1:0:255:0:0:0:9:SWPER:Mean Period of Swell Waves:s
+10:1:0:255:0:0:0:10:DIRPW:Primary Wave Direction:deg
+10:1:0:255:0:0:0:11:PERPW:Primary Wave Mean Period:s
+10:1:0:255:0:0:0:12:DIRSW:Secondary Wave Direction:deg
+10:1:0:255:0:0:0:13:PERSW:Secondary Wave Mean Period:s
+10:1:0:255:0:0:0:14:WWSDIR:Direction of Combined Wind Waves and Swell:deg
+10:1:0:255:0:0:0:15:MWSPER:Mean Period of Combined Wind Waves and Swell:s
+10:1:0:255:0:0:0:16:CDWW:Coefficient of Drag With Waves:-
+10:1:0:255:0:0:0:17:FRICVW:Friction Velocity:m/s
+10:1:0:255:0:0:0:18:WSTR:Wave Stress:N/m^2
+10:1:0:255:0:0:0:19:NWSTR:Normalised Waves Stress:-
+10:1:0:255:0:0:0:20:MSSW:Mean Square Slope of Waves:-
+10:1:0:255:0:0:0:21:USSD:U-component Surface Stokes Drift:m/s
+10:1:0:255:0:0:0:22:VSSD:V-component Surface Stokes Drift:m/s
+10:1:0:255:0:0:0:23:PMAXWH:Period of Maximum Individual Wave Height:s
+10:1:0:255:0:0:0:24:MAXWH:Maximum Individual Wave Height:m
+10:1:0:255:0:0:0:25:IMWF:Inverse Mean Wave Frequency:s
+10:1:0:255:0:0:0:26:IMFWW:Inverse Mean Frequency of The Wind Waves:s
+10:1:0:255:0:0:0:27:IMFTSW:Inverse Mean Frequency of The Total Swell:s
+10:1:0:255:0:0:0:28:MZWPER:Mean Zero-Crossing Wave Period:s
+10:1:0:255:0:0:0:29:MZPWW:Mean Zero-Crossing Period of The Wind Waves:s
+10:1:0:255:0:0:0:30:MZPTSW:Mean Zero-Crossing Period of The Total Swell:s
+10:1:0:255:0:0:0:31:WDIRW:Wave Directional Width:-
+10:1:0:255:0:0:0:32:DIRWWW:Directional Width of The Wind Waves:-
+10:1:0:255:0:0:0:33:DIRWTS:Directional Width of The Total Swell:-
+10:1:0:255:0:0:0:34:PWPER:Peak Wave Period:s
+10:1:0:255:0:0:0:35:PPERWW:Peak Period of The Wind Waves:s
+10:1:0:255:0:0:0:36:PPERTS:Peak Period of The Total Swell:s
+10:1:0:255:0:0:0:37:ALTWH:Altimeter Wave Height:m
+10:1:0:255:0:0:0:38:ALCWH:Altimeter Corrected Wave Height:m
+10:1:0:255:0:0:0:39:ALRRC:Altimeter Range Relative Correction:-
+10:1:0:255:0:0:0:40:MNWSOW:10 Metre Neutral Wind Speed Over Waves:m/s
+10:1:0:255:0:0:0:41:MWDIRW:10 Metre Wind Direction Over Waves:deg
+10:1:0:255:0:0:0:42:WESP:Wave Engery Spectrum:1/m^2*s/rad
+10:1:0:255:0:0:0:43:KSSEW:Kurtosis of The Sea Surface Elevation Due to Waves:-
+10:1:0:255:0:0:0:44:BENINX:Benjamin-Feir Index:-
+10:1:0:255:0:0:0:45:SPFTR:Spectral Peakedness Factor:1/s
+10:1:0:255:0:0:0:46:PWAVEDIR:Peak wave direction:deg
+10:1:0:255:0:0:0:47:SWHFSWEL:Significant wave height of first swell partition:m
+10:1:0:255:0:0:0:48:SWHSSWEL:Significant wave height of second swell partition:m
+10:1:0:255:0:0:0:49:SWHTSWEL:Significant wave height of third swell partition:m
+10:1:0:255:0:0:0:50:MWPFSWEL:Mean wave period of first swell partition:s
+10:1:0:255:0:0:0:51:MWPSSWEL:Mean wave period of second swell partition:s
+10:1:0:255:0:0:0:52:MWPTSWEL:Mean wave period of third swell partition:s
+10:1:0:255:0:0:0:53:MWDFSWEL:Mean wave direction of first swell partition:deg
+10:1:0:255:0:0:0:54:MWDSSWEL:Mean wave direction of second swell partition:deg
+10:1:0:255:0:0:0:55:MWDTSWEL:Mean wave direction of third swell partition:deg
+10:1:0:255:0:0:0:56:WDWFSWEL:Wave directional width of first swell partition:-
+10:1:0:255:0:0:0:57:WDWSSWEL:Wave directional width of second swell partition:-
+10:1:0:255:0:0:0:58:WDWTSWEL:Wave directional width of third swell partition:-
+10:1:0:255:0:0:0:59:WFWFSWEL:Wave frequency width of first swell partition:-
+10:1:0:255:0:0:0:60:WFWSSWEL:Wave frequency width of second swell partition:-
+10:1:0:255:0:0:0:61:WFWTSWEL:Wave frequency width of third swell partition:-
+10:1:0:255:0:0:0:62:WAVEFREW:Wave frequency width:-
+10:1:0:255:0:0:0:63:FREWWW:Frequency width of wind waves:-
+10:1:0:255:0:0:0:64:FREWTSW:Frequency width of total swell:-
+10:1:0:255:0:0:0:65:PWPFSPAR:Peak Wave Period of First Swell Partition:s
+10:1:0:255:0:0:0:66:PWPSSPAR:Peak Wave Period of Second Swell Partition:s
+10:1:0:255:0:0:0:67:PWPTSPAR:Peak Wave Period of Third Swell Partition:s
+10:1:0:255:0:0:0:68:PWDFSPAR:Peak Wave Direction of First Swell Partition:deg
+10:1:0:255:0:0:0:69:PWDSSPAR:Peak Wave Direction of Second Swell Partition:deg
+10:1:0:255:0:0:0:70:PWDTSPAR:Peak Wave Direction of Third Swell Partition:deg
+10:1:0:255:0:0:0:71:PDWWAVE:Peak Direction of Wind Waves:deg
+10:1:0:255:0:0:0:72:PDTSWELL:Peak Direction of Total Swell:deg
+10:1:0:255:0:0:0:73:WCAPFRAC:Whitecap Fraction:fraction
+10:1:0:255:0:0:0:74:MDTSWEL:Mean Direction of Total Swell:degree
+10:1:0:255:0:0:0:75:MDWWAVE:Mean Direction of Wind Waves:degree
+10:1:0:255:0:0:0:76:CHNCK:Charnock:Numeric
+10:1:0:255:0:0:0:77:WAVESPSK:Wave Spectral Skewness:Numeric
+10:1:0:255:0:0:0:78:WAVEFMAG:Wave Energy Flux Magnitude:Wm-1
+10:1:0:255:0:0:0:79:WAVEFDIR:Wave Energy Flux Mean Direction:deg
+10:1:0:255:0:0:0:80:RWAVEAFW:Raio of Wave Angular and Frequency width:Numeric
+10:1:0:255:0:0:0:81:FCVOCEAN:Free Convective Velocity over the Oceans:m/s
+10:1:0:255:0:0:0:82:AIRDENOC:Air Density over the Oceans:kg/m^3
+10:1:0:255:0:0:0:83:NEFW:Normalized Energy Flux into Waves:Numeric
+10:1:0:255:0:0:0:84:NSOCEAN:Normalized Stress into Ocean:Numeric
+10:1:0:255:0:0:0:85:NEFOCEAN:Normalized Energy Flux into Ocean:Numeric
+10:1:0:255:0:0:0:86:SEVWAVE:Surface Elevation Variance due to Waves (over all frequencies and directions):m2srad-1
+10:1:0:255:0:0:0:87:WAVEMSLC:Wave Induced Mean Se Level Correction:m
+10:1:0:255:0:0:0:88:SPECWI:Spectral Width Index:Numeric
+10:1:0:255:0:0:0:89:EFWS:Number of Events in Freak Wave Statistics:Numeric
+10:1:0:255:0:0:0:90:USMFO:U-Component of Surface Momentum Flux into Ocean:N/m^2
+10:1:0:255:0:0:0:91:VSMFO:U-Component of Surface Momentum Flux into Ocean:N/m^2
+10:1:0:255:0:0:0:92:WAVETEFO:Wave Turbulent Energy Flux into Ocean:W/m^2
+10:0:0:255:7:1:0:192:WSTP:Wave Steepness:Proportion
+10:0:0:255:7:1:0:193:WLENG:Wave Length:-
+10:1:0:255:0:0:1:0:DIRC:Current Direction:deg
+10:1:0:255:0:0:1:1:SPC:Current Speed:m/s
+10:1:0:255:0:0:1:2:UOGRD:U-Component of Current:m/s
+10:1:0:255:0:0:1:3:VOGRD:V-Component of Current:m/s
+10:1:0:255:0:0:1:4:RIPCOP:Rip Current Occurrence Probability:%
+10:1:0:255:0:0:1:5:EASTCUR:Eastward Current:m/s
+10:1:0:255:0:0:1:6:NRTHCUR:Northward Current:m/s
+10:0:0:255:7:1:1:192:OMLU:Ocean Mixed Layer U Velocity:m/s
+10:0:0:255:7:1:1:193:OMLV:Ocean Mixed Layer V Velocity:m/s
+10:0:0:255:7:1:1:194:UBARO:Barotropic U velocity:m/s
+10:0:0:255:7:1:1:195:VBARO:Barotropic V velocity:m/s
+10:1:0:255:0:0:2:0:ICEC:Ice Cover:Proportion
+10:1:0:255:0:0:2:1:ICETK:Ice Thickness:m
+10:1:0:255:0:0:2:2:DICED:Direction of Ice Drift:deg
+10:1:0:255:0:0:2:3:SICED:Speed of Ice Drift:m/s
+10:1:0:255:0:0:2:4:UICE:U-Component of Ice Drift:m/s
+10:1:0:255:0:0:2:5:VICE:V-Component of Ice Drift:m/s
+10:1:0:255:0:0:2:6:ICEG:Ice Growth Rate:m/s
+10:1:0:255:0:0:2:7:ICED:Ice Divergence:1/s
+10:1:0:255:0:0:2:8:ICETMP:Ice Temperature:K
+10:1:0:255:0:0:2:9:ICEPRS:Module of Ice Internal Pressure:Pa*m
+10:1:0:255:0:0:2:10:ZVCICEP:Zonal Vector Component of Vertically Integrated Ice Internal Pressure:Pa*m
+10:1:0:255:0:0:2:11:MVCICEP:Meridional Vector Component of Vertically Integrated Ice Internal Pressure:Pa*m
+10:1:0:255:0:0:2:12:CICES:Compressive Ice Strength:N/m
+10:1:0:255:0:0:2:13:SNOWTSI:Snow Temperature (over sea ice):K
+10:1:0:255:0:0:2:14:ALBDOICE:Albedo:Numeric
+10:1:0:255:0:0:2:15:SICEVOL:Sea Ice Volume per Unit Area:m3m-2
+10:1:0:255:0:0:2:16:SNVOLSI:Snow Volume Over Sea Ice per Unit Area:m3m-2
+10:1:0:255:0:0:2:17:SICEHC:Sea Ice Heat Content:J/m^2
+10:1:0:255:0:0:2:18:SNCEHC:Snow over Sea Ice Heat Content:J/m^2
+10:1:0:255:0:0:2:19:ICEFTHCK:Ice Freeboard Thickness:m
+10:1:0:255:0:0:2:20:ICEMPF:Ice Melt Pond Fraction:fraction
+10:1:0:255:0:0:2:21:ICEMPD:Ice Melt Pond Depth:m
+10:1:0:255:0:0:2:22:ICEMPV:Ice Melt Pond Volume per Unit Area:m3m-2
+10:1:0:255:0:0:2:23:SIFTP:Sea Ice Fraction Tendency due to Parameterization:1/s
+10:1:0:255:0:0:3:0:WTMP:Water Temperature:K
+10:1:0:255:0:0:3:1:DSLM:Deviation of Sea Level from Mean:m
+10:1:0:255:0:0:3:2:CH:Heat Exchange Coefficient:-
+10:1:0:255:0:0:3:3:PRACTSAL:Practical Salinity:Numeric
+10:1:0:255:0:0:3:4:DWHFLUX:Downward Heat Flux:W/m^2
+10:1:0:255:0:0:3:5:EASTWSS:Eastward Surface Stress:N/m^2
+10:1:0:255:0:0:3:6:NORTHWSS:Northward surface stress:N/m^2
+10:1:0:255:0:0:3:7:XCOMPSS:x-component Surface Stress:N/m^2
+10:1:0:255:0:0:3:8:YCOMPSS:y-component Surface Stress:N/m^2
+10:1:0:255:0:0:3:9:THERCSSH:Thermosteric Change in Sea Surface Height:m
+10:1:0:255:0:0:3:10:HALOCSSH:Halosteric Change in Sea Surface Height:m
+10:1:0:255:0:0:3:11:STERCSSH:Steric Change in Sea Surface Height:m
+10:1:0:255:0:0:3:12:SEASFLUX:Sea Salt Flux:kg/m^2/s
+10:1:0:255:0:0:3:13:NETUPWFLUX:Net upward water flux:kg/m^2/s
+10:1:0:255:0:0:3:14:ESURFWVEL:Eastward surface water velocity:m/s
+10:1:0:255:0:0:3:15:NSURFWVEL:Northward surface water velocity:m/s
+10:1:0:255:0:0:3:16:XSURFWVEL:x-component of surface water velocity:m/s
+10:1:0:255:0:0:3:17:YSURFWVEL:y-component of surface water velocity:m/s
+10:1:0:255:0:0:3:18:HFLUXCOR:Heat flux correction:W/m^2
+10:1:0:255:0:0:3:19:SSHGTPARM:Sea surface height tendency due to parameterization:m/s
+10:1:0:255:0:0:3:20:DSLIBARCOR:Deviation of sea level from mean with inverse barometer correction:m
+10:0:0:255:7:1:3:192:SURGE:Hurricane Storm Surge:m
+10:0:0:255:7:1:3:193:ETSRG:Extra Tropical Storm Surge:m
+10:0:0:255:7:1:3:194:ELEV:Ocean Surface Elevation Relative to Geoid:m
+10:0:0:255:7:1:3:195:SSHG:Sea Surface Height Relative to Geoid:m
+10:0:0:255:7:1:3:196:P2OMLT:Ocean Mixed Layer Potential Density (Reference 2000m):kg/m^3
+10:0:0:255:7:1:3:197:AOHFLX:Net Air-Ocean Heat Flux:W/m^2
+10:0:0:255:7:1:3:198:ASHFL:Assimilative Heat Flux:W/m^2
+10:0:0:255:7:1:3:199:SSTT:Surface Temperature Trend:K/day
+10:0:0:255:7:1:3:200:SSST:Surface Salinity Trend:psu/day
+10:0:0:255:7:1:3:201:KENG:Kinetic Energy:J/kg
+10:0:0:255:7:1:3:202:SLTFL:Salt Flux:kg/m^2/s
+10:0:0:255:7:1:3:203:LCH:Heat Exchange Coefficient:-
+10:0:0:255:7:1:3:204:FRZSPR:Freezing Spray:-
+10:0:0:255:7:1:3:205:TWLWAV:Total Water Level Accounting for Tide, Wind and Waves:m
+10:0:0:255:7:1:3:206:RUNUP:Total Water Level Increase due to Waves:m
+10:0:0:255:7:1:3:207:SETUP:Mean Increase in Water Level due to Waves:m
+10:0:0:255:7:1:3:208:SWASH:Time-varying Increase in Water Level due to Waves:m
+10:0:0:255:7:1:3:209:TWLDT:Total Water Level Above Dune Toe:m
+10:0:0:255:7:1:3:210:TWLDC:Total Water Level Above Dune Crest:m
+10:0:0:255:7:1:3:242:TCSRG20:20% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:243:TCSRG30:30% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:244:TCSRG40:40% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:245:TCSRG50:50% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:246:TCSRG60:60% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:247:TCSRG70:70% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:248:TCSRG80:80% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:249:TCSRG90:90% Tropical Cyclone Storm Surge Exceedance:m
+10:0:0:255:7:1:3:250:ETCWL:Extra Tropical Storm Surge Combined Surge and Tide:m
+10:0:0:255:7:1:3:251:TIDE:Tide:m
+10:0:0:255:7:1:3:252:EROSNP:Erosion Occurrence Probability:%
+10:0:0:255:7:1:3:253:OWASHP:Overwash Occurrence Probability:%
+10:1:0:255:0:0:4:0:MTHD:Main Thermocline Depth:m
+10:1:0:255:0:0:4:1:MTHA:Main Thermocline Anomaly:m
+10:1:0:255:0:0:4:2:TTHDP:Transient Thermocline Depth:m
+10:1:0:255:0:0:4:3:SALTY:Salinity:kg/kg
+10:1:0:255:0:0:4:4:OVHD:Ocean Vertical Heat Diffusivity:m^2/s
+10:1:0:255:0:0:4:5:OVSD:Ocean Vertical Salt Diffusivity:m^2/s
+10:1:0:255:0:0:4:6:OVMD:Ocean Vertical Momentum Diffusivity:m^2/s
+10:1:0:255:0:0:4:7:BATHY:Bathymetry:m
+10:1:0:255:0:0:4:11:SFSALP:Shape Factor With Respect To Salinity Profile:-
+10:1:0:255:0:0:4:12:SFTMPP:Shape Factor With Respect To Temperature Profile In Thermocline:-
+10:1:0:255:0:0:4:13:ACWSRD:Attenuation Coefficient Of Water With Respect to Solar Radiation:1/m
+10:1:0:255:0:0:4:14:WDEPTH:Water Depth:m
+10:1:0:255:0:0:4:15:WTMPSS:Water Temperature:K
+10:1:0:255:0:0:4:16:WATERDEN:Water Density (rho):kg/m^3
+10:1:0:255:0:0:4:17:WATDENA:Water Density Anomaly (sigma):kg/m^3
+10:1:0:255:0:0:4:18:WATPTEMP:Water potential temperature (theta):K
+10:1:0:255:0:0:4:19:WATPDEN:Water potential density (rho theta):kg/m^3
+10:1:0:255:0:0:4:20:WATPDENA:Water potential density anomaly (sigma theta):kg/m^3
+10:1:0:255:0:0:4:21:PRTSAL:Practical Salinity:psu(numeric)
+10:1:0:255:0:0:4:22:WCHEATC:Water Column-integrated Heat Content:J/m^2
+10:1:0:255:0:0:4:23:EASTWVEL:Eastward Water Velocity:m/s
+10:1:0:255:0:0:4:24:NRTHWVEL:Northward Water Velocity:m/s
+10:1:0:255:0:0:4:25:XCOMPWV:X-Component Water Velocity:m/s
+10:1:0:255:0:0:4:26:YCOMPWV:Y-Component Water Velocity:m/s
+10:1:0:255:0:0:4:27:UPWWVEL:Upward Water Velocity:m/s
+10:1:0:255:0:0:4:28:VEDDYDIF:Vertical Eddy Diffusivity:m^2/s
+10:1:0:255:0:0:4:29:BPEH:Bottom Pressure Equivalent Height:m
+10:1:0:255:0:0:4:30:FWFSW:Fresh Water Flux into Sea Water from Rivers:kg/m^2/s
+10:1:0:255:0:0:4:31:FWFC:Fresh Water Flux Correction:kg/m^2/s
+10:1:0:255:0:0:4:32:VSFSW:Virtual Salt Flux into Sea Water:gkgm-2s-1
+10:1:0:255:0:0:4:33:VSFC:Virtual Salt Flux Correction:gkgm-2s-1
+10:1:0:255:0:0:4:34:SWTTNR:Sea Water Temperature Tendency due to Newtonian Relaxation:K/s
+10:1:0:255:0:0:4:35:SWSTNR:Sea Water Salinity Tendency due to Newtonian Relaxation:gkgm-2s-1
+10:1:0:255:0:0:4:36:SWTTP:Sea Water Temperature Tendency due to Parameterization:K/s
+10:1:0:255:0:0:4:37:SWSTP:Sea Water Salinity Tendency due to Parameterization:gkgm-2s-1
+10:1:0:255:0:0:4:38:ESWVP:Eastward Sea Water Velocity Tendency Due To Parameterization:1/m^2/s
+10:1:0:255:0:0:4:39:NSWVP:Northward Sea Water Velocity Tendency Due To Parameterization:1/m^2/s
+10:1:0:255:0:0:4:40:SWTTBC:Sea Water Temperature Tendency Due to Direct Bias Correction:K/s
+10:1:0:255:0:0:4:41:SWSTBC:Sea Water Salinity Tendency due to Direct Bias Correction:gkgm-2s-1
+10:0:0:255:7:1:4:192:WTMPC:3-D Temperature:degC
+10:0:0:255:7:1:4:193:SALIN:3-D Salinity:psu
+10:0:0:255:7:1:4:194:BKENG:Barotropic Kinectic Energy:J/kg
+10:0:0:255:7:1:4:195:DBSS:Geometric Depth Below Sea Surface:m
+10:0:0:255:7:1:4:196:INTFD:Interface Depths:m
+10:0:0:255:7:1:4:197:OHC:Ocean Heat Content:J/m^2
+10:1:0:255:0:0:191:0:IRTSEC:Seconds Prior To Initial Reference Time:s
+10:1:0:255:0:0:191:1:MOSF:Meridional Overturning Stream Function:m^3/s
+10:1:0:255:0:0:191:3:DSLOBSO:Days Since Last Observation:day
+10:1:0:255:0:0:191:4:BARDSF:Barotropic Stream Function:m^3/s
+20:1:0:255:0:0:0:0:UTHCIDX:Universal Thermal Climate Index:K
+20:1:0:255:0:0:0:1:MEANRTMP:Mean Radiant Temperature:K
+20:1:0:255:0:0:0:2:WETBGTMP:Wet-bulb Globe Temperature (see Note):K
+20:1:0:255:0:0:0:3:GLOBETMP:Globe Temperature (see Note):K
+20:1:0:255:0:0:0:4:HUMIDX:Humidex:K
+20:1:0:255:0:0:0:5:EFFTEMP:Effective Temperature:K
+20:1:0:255:0:0:0:6:NOREFTMP:Normal Effective Temperature:K
+20:1:0:255:0:0:0:7:STDEFTMP:Standard Effective Temperature:K
+20:1:0:255:0:0:0:8:PEQUTMP:Physiological Equivalent Temperature:K
+20:1:0:255:0:0:1:0:MALACASE:Malaria Cases:Fraction
+20:1:0:255:0:0:1:1:MACPRATE:Malaria Circumsporozoite Protein Rate:Fraction
+20:1:0:255:0:0:1:2:PFEIRATE:Plasmodium Falciparum Entomological Inoculation Rate:Bitesperdayperperson
+20:1:0:255:0:0:1:3:HBRATEAV:Human Bite Rate by Anopheles Vectors:Bitesperdayperperson
+20:1:0:255:0:0:1:4:MALAIMM:Malaria Immunity:Fraction
+20:1:0:255:0:0:1:5:FALPRATE:Falciparum Parasite Rates:Fraction
+20:1:0:255:0:0:1:6:DFPRATIO:Detectable Falciparum Parasite Ratio (after day 10):Fraction
+20:1:0:255:0:0:1:7:AVHRATIO:Anopheles Vector to Host Ratio:Fraction
+20:1:0:255:0:0:1:8:AVECTNUM:Anopheles Vector Number:Numberm-2
+20:1:0:255:0:0:1:9:FMALVRH:Fraction of Malarial Vector Reproductive Habitat:Fraction
+20:1:0:255:0:0:2:0:POPDEN:Population Density:Personm-2
+255:0:0:255:7:1:255:255:IMGD:Image data:-

--- a/src/codetables/external.rs
+++ b/src/codetables/external.rs
@@ -4,8 +4,8 @@ use crate::Parameter;
 
 #[derive(Debug, Eq, PartialEq, Clone, TryFromPrimitive, IntoPrimitive)]
 #[repr(u32)]
-/// Parameter code used in NCEP.
-pub enum NCEP {
+/// Parameter abbreviation codes used in NCEP.
+pub enum NCEPCode {
     /// Pressure.
     PRES = 0x_00_03_00,
     /// Pressure reduced to MSL.
@@ -14,7 +14,7 @@ pub enum NCEP {
     HGT = 0x_00_03_05,
 }
 
-impl TryFrom<&Parameter> for NCEP {
+impl TryFrom<&Parameter> for NCEPCode {
     type Error = &'static str;
 
     fn try_from(value: &Parameter) -> Result<Self, Self::Error> {

--- a/src/codetables/external.rs
+++ b/src/codetables/external.rs
@@ -1,45 +1,17 @@
-use num_enum::{IntoPrimitive, TryFromPrimitive};
+use grib_codegen::parameter_codes;
 
 use crate::Parameter;
 
-#[derive(Debug, Eq, PartialEq, Clone, TryFromPrimitive, IntoPrimitive)]
-#[repr(u32)]
-/// Parameter abbreviation codes used in ECMWF.
-pub enum ECMWFCode {
-    /// Pressure.
-    PRES = 0x_00_03_00,
-    /// Pressure reduced to MSL.
-    PRMSL = 0x_00_03_01,
-    /// Geopotential Height.
-    GH = 0x_00_03_05,
-}
-
-impl TryFrom<&Parameter> for ECMWFCode {
-    type Error = &'static str;
-
-    fn try_from(value: &Parameter) -> Result<Self, Self::Error> {
-        let code = value.as_u32();
-        Self::try_from_primitive(code).map_err(|_| "code not found")
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, TryFromPrimitive, IntoPrimitive)]
+#[parameter_codes(path = "def/wgrib2/gribtable")]
+#[derive(Debug, Eq, PartialEq, Clone)]
 #[repr(u32)]
 /// Parameter abbreviation codes used in NCEP.
-pub enum NCEPCode {
-    /// Pressure.
-    PRES = 0x_00_03_00,
-    /// Pressure reduced to MSL.
-    PRMSL = 0x_00_03_01,
-    /// Geopotential Height.
-    HGT = 0x_00_03_05,
-}
+pub enum NCEPCode {}
 
 impl TryFrom<&Parameter> for NCEPCode {
     type Error = &'static str;
 
     fn try_from(value: &Parameter) -> Result<Self, Self::Error> {
-        let code = value.as_u32();
-        Self::try_from_primitive(code).map_err(|_| "code not found")
+        Self::try_from(value.as_u32())
     }
 }

--- a/src/codetables/external.rs
+++ b/src/codetables/external.rs
@@ -4,6 +4,27 @@ use crate::Parameter;
 
 #[derive(Debug, Eq, PartialEq, Clone, TryFromPrimitive, IntoPrimitive)]
 #[repr(u32)]
+/// Parameter abbreviation codes used in ECMWF.
+pub enum ECMWFCode {
+    /// Pressure.
+    PRES = 0x_00_03_00,
+    /// Pressure reduced to MSL.
+    PRMSL = 0x_00_03_01,
+    /// Geopotential Height.
+    GH = 0x_00_03_05,
+}
+
+impl TryFrom<&Parameter> for ECMWFCode {
+    type Error = &'static str;
+
+    fn try_from(value: &Parameter) -> Result<Self, Self::Error> {
+        let code = value.as_u32();
+        Self::try_from_primitive(code).map_err(|_| "code not found")
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, TryFromPrimitive, IntoPrimitive)]
+#[repr(u32)]
 /// Parameter abbreviation codes used in NCEP.
 pub enum NCEPCode {
     /// Pressure.

--- a/src/context.rs
+++ b/src/context.rs
@@ -377,7 +377,7 @@ impl<R> SubMessage<'_, R> {
     ///     io::{BufReader, Read},
     /// };
     ///
-    /// use grib::codetables::NCEPCode;
+    /// use grib::codetables::{ECMWFCode, NCEPCode};
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let mut buf = Vec::new();
@@ -410,6 +410,7 @@ impl<R> SubMessage<'_, R> {
     ///         param.description(),
     ///         Some("Pressure reduced to MSL".to_owned())
     ///     );
+    ///     assert!(param.is_identical_to(ECMWFCode::PRMSL));
     ///     assert!(param.is_identical_to(NCEPCode::PRMSL));
     ///     Ok(())
     /// }

--- a/src/context.rs
+++ b/src/context.rs
@@ -377,7 +377,7 @@ impl<R> SubMessage<'_, R> {
     ///     io::{BufReader, Read},
     /// };
     ///
-    /// use grib::codetables::{ECMWFCode, NCEPCode};
+    /// use grib::codetables::NCEPCode;
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let mut buf = Vec::new();
@@ -410,8 +410,7 @@ impl<R> SubMessage<'_, R> {
     ///         param.description(),
     ///         Some("Pressure reduced to MSL".to_owned())
     ///     );
-    ///     assert!(param.is_identical_to(ECMWFCode::PRMSL));
-    ///     assert!(param.is_identical_to(NCEPCode::PRMSL));
+    ///     assert!(param.is_identical_to(NCEPCode::_PRMSL));
     ///     Ok(())
     /// }
     /// ```

--- a/src/context.rs
+++ b/src/context.rs
@@ -377,7 +377,7 @@ impl<R> SubMessage<'_, R> {
     ///     io::{BufReader, Read},
     /// };
     ///
-    /// use grib::codetables::NCEP;
+    /// use grib::codetables::NCEPCode;
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let mut buf = Vec::new();
@@ -410,7 +410,7 @@ impl<R> SubMessage<'_, R> {
     ///         param.description(),
     ///         Some("Pressure reduced to MSL".to_owned())
     ///     );
-    ///     assert!(param.is_identical_to(NCEP::PRMSL));
+    ///     assert!(param.is_identical_to(NCEPCode::PRMSL));
     ///     Ok(())
     /// }
     /// ```

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -16,13 +16,13 @@ use crate::codetables::{grib2::*, *};
 pub struct Parameter {
     /// Discipline of processed data in the GRIB message.
     pub discipline: u8,
-    /// GRIB master tables version number.
+    /// Identification of originating/generating centre.
     pub centre: u16,
-    /// Parameter category by product discipline.
+    /// GRIB master tables version number.
     pub master_ver: u8,
     /// GRIB local tables version number.
     pub local_ver: u8,
-    /// Identification of originating/generating centre.
+    /// Parameter category by product discipline.
     pub category: u8,
     /// Parameter number by product discipline and parameter category.
     pub num: u8,

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -9,7 +9,7 @@ use crate::codetables::{grib2::*, *};
 /// quantities.
 ///
 /// With [`is_identical_to`], users can check if the parameter is identical to a
-/// third-party code, such as [`ECMWFCode`] and [`NCEPCode`].
+/// third-party code, such as [`NCEPCode`].
 ///
 /// [`is_identical_to`]: Parameter::is_identical_to
 #[derive(Debug, PartialEq, Eq)]
@@ -52,12 +52,12 @@ impl Parameter {
     }
 
     /// Checks if the parameter is identical to a third-party `code`, such as
-    /// [`ECMWFCode`] and [`NCEPCode`].
+    /// [`NCEPCode`].
     ///
     /// # Examples
     ///
     /// ```
-    /// use grib::codetables::{ECMWFCode, NCEPCode};
+    /// use grib::codetables::NCEPCode;
     ///
     /// // Extracted from the first submessage of JMA MSM GRIB2 data.
     /// let param = grib::Parameter {
@@ -68,8 +68,7 @@ impl Parameter {
     ///     category: 3,
     ///     num: 5,
     /// };
-    /// assert!(param.is_identical_to(ECMWFCode::GH));
-    /// assert!(param.is_identical_to(NCEPCode::HGT));
+    /// assert!(param.is_identical_to(NCEPCode::_HGT));
     /// ```
     pub fn is_identical_to<'a, T>(&'a self, code: T) -> bool
     where

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -9,7 +9,7 @@ use crate::codetables::{grib2::*, *};
 /// quantities.
 ///
 /// With [`is_identical_to`], users can check if the parameter is identical to a
-/// third-party code, such as [`NCEPCode`].
+/// third-party code, such as [`ECMWFCode`] and [`NCEPCode`].
 ///
 /// [`is_identical_to`]: Parameter::is_identical_to
 #[derive(Debug, PartialEq, Eq)]
@@ -52,12 +52,12 @@ impl Parameter {
     }
 
     /// Checks if the parameter is identical to a third-party `code`, such as
-    /// [`NCEPCode`].
+    /// [`ECMWFCode`] and [`NCEPCode`].
     ///
     /// # Examples
     ///
     /// ```
-    /// use grib::codetables::NCEPCode;
+    /// use grib::codetables::{ECMWFCode, NCEPCode};
     ///
     /// // Extracted from the first submessage of JMA MSM GRIB2 data.
     /// let param = grib::Parameter {
@@ -68,6 +68,7 @@ impl Parameter {
     ///     category: 3,
     ///     num: 5,
     /// };
+    /// assert!(param.is_identical_to(ECMWFCode::GH));
     /// assert!(param.is_identical_to(NCEPCode::HGT));
     /// ```
     pub fn is_identical_to<'a, T>(&'a self, code: T) -> bool

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -9,7 +9,7 @@ use crate::codetables::{grib2::*, *};
 /// quantities.
 ///
 /// With [`is_identical_to`], users can check if the parameter is identical to a
-/// third-party code, such as [`NCEP`].
+/// third-party code, such as [`NCEPCode`].
 ///
 /// [`is_identical_to`]: Parameter::is_identical_to
 #[derive(Debug, PartialEq, Eq)]
@@ -52,12 +52,12 @@ impl Parameter {
     }
 
     /// Checks if the parameter is identical to a third-party `code`, such as
-    /// [`NCEP`].
+    /// [`NCEPCode`].
     ///
     /// # Examples
     ///
     /// ```
-    /// use grib::codetables::NCEP;
+    /// use grib::codetables::NCEPCode;
     ///
     /// // Extracted from the first submessage of JMA MSM GRIB2 data.
     /// let param = grib::Parameter {
@@ -68,7 +68,7 @@ impl Parameter {
     ///     category: 3,
     ///     num: 5,
     /// };
-    /// assert!(param.is_identical_to(NCEP::HGT));
+    /// assert!(param.is_identical_to(NCEPCode::HGT));
     /// ```
     pub fn is_identical_to<'a, T>(&'a self, code: T) -> bool
     where


### PR DESCRIPTION
This PR replaces NCEP code mock-ups with an enum auto-generated using "grib-codegen".

Note that support for local code handling is not adequate.