### PR TITLE
Fix build failure of the proj-sys crate on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           components: clippy, rustfmt
       - name: Run rustfmt
         run: cargo fmt --all -- --check
+      - name: Install dependencies needed to build proj
+        run: sudo apt install libsqlite3-dev
       - name: Run clippy
         run: cargo clippy --workspace -- -D warnings
 
@@ -80,6 +82,9 @@ jobs:
       #   run: |
       #     sudo apt -qq install build-essential g++-multilib
       #     sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
+      - name: Install dependencies needed to build proj
+        run: sudo apt install libsqlite3-dev
+        if: matrix.os == 'ubuntu-latest'
       - name: Build
         run: cargo build --target ${{ matrix.target }} --verbose --workspace ${{ matrix.features }}
       - name: Run tests
@@ -112,6 +117,8 @@ jobs:
           submodules: recursive
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
+      - name: Install dependencies needed to build proj
+        run: sudo apt install libsqlite3-dev
       - name: Run test with sanitizer
         env:
           RUSTFLAGS: -Z sanitizer=address


### PR DESCRIPTION
This PR fixes build failure on Linux in CI.
The build failure occurs when the lib crate has a dependency on the proj-sys crate.

The error is like this:

```
error: failed to run custom build command for `proj-sys v0.23.2`

Caused by:
  process didn't exit successfully: `/home/runner/work/grib-rs/grib-rs/target/debug/build/proj-sys-a8ac46c1b648abb4/build-script-build` (exit status: 101)
  --- stdout
(snip)
  --- stderr
  pkg-config unable to find existing libproj installation: 
  pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags proj proj >= 9.2.0

  The system library `proj` required by crate `proj-sys` was not found.
  The file `proj.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  The PKG_CONFIG_PATH environment variable is not set.

  HINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `proj.pc`.

  building libproj from source
  disabling tiff support
  CMake Deprecation Warning at CMakeLists.txt:12 (cmake_minimum_required):
    Compatibility with CMake < 3.10 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.


  CMake Deprecation Warning at cmake/Ccache.cmake:10 (cmake_minimum_required):
    Compatibility with CMake < 3.10 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.
  Call Stack (most recent call first):
    CMakeLists.txt:126 (include)


  CMake Error at CMakeLists.txt:181 (message):
    sqlite3 dependency not found!


  CMake Error at CMakeLists.txt:187 (message):
    sqlite3 >= 3.11 required!


  CMake Warning at CMakeLists.txt:206 (message):
    TIFF support is not enabled and will result in the inability to read some
    grids
```

The direct cause of the error is that `libsqlite3-dev` is not installed and `sqlite3.pc` does not exist.
`libsqlite3-dev` was installed in the [`ubuntu-22.04`][1] image, which was originally referenced as `ubuntu-latest`, but not in [`ubuntu-24.04`][2], and the latter is now referenced as `ubuntu-latest`.

[1]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
[2]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md