### PR TITLE
fix format string in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Err(e) =
         check_nonemptiness(Path::new("def/CCT")).and(check_nonemptiness(Path::new("def/GRIB2")))
     {
-        return Err(format!("{}; run `git submodule update --init`", e).into());
+        return Err(format!("{e}; run `git submodule update --init`").into());
     }
 
     let input_file_names = ["def/CCT/C00.csv", "def/CCT/C11.csv"];


### PR DESCRIPTION
Fixes a `clippy::uninlined-format-args` detected in `build.rs`