### PR TITLE
update proj to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ chrono = "0.4.23" # `TimeZone::with_ymd_and_hms` needed
 num = "0.4"
 num_enum = "0.7"
 png = "0.17"
-proj = { version = "0.28", optional = true }
+proj = { version = "0.30", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 openjpeg-sys = "1.0.5" # avoiding 1.0.2/1.0.4


### PR DESCRIPTION
This MR updates proj to 0.30.

The project I'm working on that uses `grib-rs` already enables `proj/bundled_proj`.  I would also like to take advantage of the fact that the newest `proj-sys` uses `libsqlite3-sys` which provides a similar `bundled` feature.

All tests passed when I ran `cargo test --workspace`.

I ran `cargo +nightly clippy --workspace` per the contribution guide.  The version I'm using, `clippy 0.1.88 (25cdf1f674 2025-04-28)`, identifies unrelated code issues that I mentioned over on #115.  
