### PR TITLE
CLI: standard input/output support

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 homepage.workspace = true
 categories.workspace = true
 keywords.workspace = true
+rust-version = "1.80"
 
 [[bin]]
 name = "gribber"
@@ -23,7 +24,6 @@ chrono = "0.4.23"
 clap = "4.1"
 clap_complete = "4"
 console = "0.15"
-once_cell = "1.13"
 regex = "1.6"
 
 [target.'cfg(unix)'.dependencies]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,7 +1,6 @@
-use std::{fs::File, io::BufReader, path::Path};
+use std::{fs::File, io::BufReader, path::Path, sync::LazyLock};
 
 use grib::{Grib2, SeekableGrib2Reader};
-use once_cell::sync::Lazy;
 #[cfg(unix)]
 use pager::Pager;
 use regex::Regex;
@@ -63,7 +62,7 @@ impl std::str::FromStr for CliMessageIndex {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        static RE: Lazy<Regex> = Lazy::new(|| {
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(
                 r"(?x)      # insignificant whitespace mode
                 ^

--- a/cli/src/commands/decode.rs
+++ b/cli/src/commands/decode.rs
@@ -10,7 +10,10 @@ use crate::cli;
 pub fn cli() -> Command {
     Command::new("decode")
         .about("Export decoded data with latitudes and longitudes")
-        .arg(arg!(<FILE> "Target file").value_parser(clap::value_parser!(PathBuf)))
+        .arg(
+            arg!(<FILE> "Target file name (or a single dash (`-`) for standard input)")
+                .value_parser(clap::value_parser!(PathBuf)),
+        )
         .arg(arg!(<INDEX> "Submessage index"))
         .arg(
             arg!(-b --"big-endian" <OUT_FILE> "Export (without lat/lon) as a big-endian flat binary file")

--- a/cli/src/commands/decode.rs
+++ b/cli/src/commands/decode.rs
@@ -1,9 +1,4 @@
-use std::{
-    fmt,
-    fs::File,
-    io::{BufWriter, Write},
-    path::PathBuf,
-};
+use std::{fmt, path::PathBuf};
 
 use anyhow::Result;
 use clap::{arg, ArgMatches, Command};
@@ -35,10 +30,8 @@ fn write_output(
     mut values: impl Iterator<Item = f32>,
     to_bytes: fn(&f32) -> [u8; 4],
 ) -> Result<()> {
-    File::create(out_path).and_then(|f| {
-        let mut stream = BufWriter::new(f);
-        values.try_for_each(|f| stream.write_all(&to_bytes(&f)))
-    })?;
+    let mut stream = crate::cli::WriteStream::new(out_path)?;
+    values.try_for_each(|f| stream.write_all(&to_bytes(&f)))?;
     Ok(())
 }
 

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -18,7 +18,10 @@ use crate::cli;
 pub fn cli() -> Command {
     Command::new("info")
         .about("Show identification information")
-        .arg(arg!(<FILE> "Target file").value_parser(clap::value_parser!(PathBuf)))
+        .arg(
+            arg!(<FILE> "Target file name (or a single dash (`-`) for standard input)")
+                .value_parser(clap::value_parser!(PathBuf)),
+        )
 }
 
 pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {

--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -25,7 +25,10 @@ pub fn cli() -> Command {
             arg!(-t --templates "Print templates used in the GRIB message")
                 .action(ArgAction::SetTrue),
         )
-        .arg(arg!(<FILE> "Target file").value_parser(clap::value_parser!(PathBuf)))
+        .arg(
+            arg!(<FILE> "Target file name (or a single dash (`-`) for standard input)")
+                .value_parser(clap::value_parser!(PathBuf)),
+        )
         .after_help(
             "\
 This subcommand is mainly targeted at (possible) developers and

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -17,7 +17,10 @@ pub fn cli() -> Command {
     Command::new("list")
         .about("List layers contained in the data")
         .arg(arg!(-d --dump "Show details of each data").action(ArgAction::SetTrue))
-        .arg(arg!(<FILE> "Target file").value_parser(clap::value_parser!(PathBuf)))
+        .arg(
+            arg!(<FILE> "Target file name (or a single dash (`-`) for standard input)")
+                .value_parser(clap::value_parser!(PathBuf)),
+        )
 }
 
 pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {

--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -332,18 +332,20 @@ test_operation_with_data_without_nan_values_compared_using_simple_packing! {
 }
 
 #[test]
-fn test_output_to_stdout() -> Result<(), Box<dyn std::error::Error>> {
+fn test_input_from_stdin_and_output_to_stdout() -> Result<(), Box<dyn std::error::Error>> {
     let input = utils::testdata::grib2::jma_kousa()?;
     let out_path = "-";
     let expected = utils::testdata::flat_binary::jma_kousa_be()?;
 
     let mut cmd = Command::cargo_bin(CMD_NAME)?;
     cmd.arg("decode")
-        .arg(input.path())
+        .arg("-")
         .arg("0.3")
         .arg("-b")
         .arg(&out_path);
-    cmd.assert()
+    let mut cmd = assert_cmd::Command::from_std(cmd);
+    cmd.write_stdin(utils::get_uncompressed(input)?)
+        .assert()
         .success()
         .stdout(predicate::eq(expected))
         .stderr(predicate::str::is_empty());

--- a/cli/tests/cli/commands/decode.rs
+++ b/cli/tests/cli/commands/decode.rs
@@ -331,6 +331,26 @@ test_operation_with_data_without_nan_values_compared_using_simple_packing! {
     ),
 }
 
+#[test]
+fn test_output_to_stdout() -> Result<(), Box<dyn std::error::Error>> {
+    let input = utils::testdata::grib2::jma_kousa()?;
+    let out_path = "-";
+    let expected = utils::testdata::flat_binary::jma_kousa_be()?;
+
+    let mut cmd = Command::cargo_bin(CMD_NAME)?;
+    cmd.arg("decode")
+        .arg(input.path())
+        .arg("0.3")
+        .arg("-b")
+        .arg(&out_path);
+    cmd.assert()
+        .success()
+        .stdout(predicate::eq(expected))
+        .stderr(predicate::str::is_empty());
+
+    Ok(())
+}
+
 macro_rules! test_trial_to_decode_nonexisting_submessage {
     ($(($name:ident, $input:expr, $message_index:expr),)*) => ($(
         #[test]


### PR DESCRIPTION
This PR adds support for standard input/output to CLI.

Previously, `gribber` could only handle file names as input/output targets and could not read/write data via pipes.
Now that standard input/output can be handled, data can be exchanged with external commands through pipes.

The following example reads an xz-compressed GRIB2 file and creates an xz-compressed decoded result without creating a temporary file:

    xzcat testdata/gdas.t00z.sfluxgrbf000.grib2.0.xz | gribber decode - 0.0 -b - | xz > decoded.xz

Note: #117 was an API improvement in preparation for this PR.