### PR TITLE
Time-related information API enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
             with_test: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            features: --features chrono
+            with_test: true
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
             features: --features gridpoints-proj
             with_test: true
           # - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             with_test: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            features: --features chrono
+            features: --features time-calculation
             with_test: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Thumbs.db
 **/*.rs.bk
 Cargo.lock
 /gen/target/
+
+**/.zed/*
+!**/.zed/settings.template.json

--- a/.zed/settings.template.json
+++ b/.zed/settings.template.json
@@ -1,0 +1,13 @@
+// Copy this file to 'settings.json' or merge the contents of this file into
+// your existing settings.
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "cargo": {
+          "features": ["chrono"]
+        }
+      }
+    }
+  }
+}

--- a/.zed/settings.template.json
+++ b/.zed/settings.template.json
@@ -5,7 +5,7 @@
     "rust-analyzer": {
       "initialization_options": {
         "cargo": {
-          "features": ["chrono"]
+          "features": ["time-calculation"]
         }
       }
     }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["science"]
 keywords = ["GRIB", "weather", "meteorology"]
 
 [dependencies]
-chrono = "0.4.23" # `TimeZone::with_ymd_and_hms` needed
+chrono = { version = "0.4.23", optional = true }
 num = "0.4"
 num_enum = "0.7"
 png = "0.17"
@@ -46,6 +46,7 @@ grib-build = { path = "gen", version = "0.4.3" }
 
 [features]
 gridpoints-proj = ["dep:proj"]
+chrono = ["dep:chrono"]
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ grib-build = { path = "gen", version = "0.4.3" }
 
 [features]
 gridpoints-proj = ["dep:proj"]
-chrono = ["dep:chrono"]
+time-calculation = ["dep:chrono"]
 
 [profile.release]
 strip = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-chrono = "0.4.23"
 clap = "4.1"
 clap_complete = "4"
 console = "0.15"

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -3,7 +3,6 @@ use std::{
     path::PathBuf,
 };
 
-use chrono::{DateTime, Utc};
 use clap::{arg, ArgMatches, Command};
 use grib::{
     codetables::{
@@ -40,7 +39,7 @@ pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
                     message_index.0,
                     sect0_body,
                     sect1_body,
-                    sect1_body.ref_time()?
+                    sect1_body.ref_time_unchecked()
                 )
             );
         }
@@ -48,7 +47,7 @@ pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
     Ok(())
 }
 
-struct InfoView<'i>(usize, &'i Indicator, &'i Identification, DateTime<Utc>);
+struct InfoView<'i>(usize, &'i Indicator, &'i Identification, grib::UtcDateTime);
 
 impl<'i> Display for InfoView<'i> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/src/codetables/grib2.rs
+++ b/src/codetables/grib2.rs
@@ -2,6 +2,18 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
+pub enum Table1_2 {
+    Analysis = 0,
+    StartOfForecast,
+    VerifyingTimeOfForecast,
+    ObservationTime,
+    LocalTime,
+    SimulationStart,
+    Missing = 255,
+}
+
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u8)]
 pub enum Table4_4 {
     Minute = 0,
     Hour,

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,7 @@ use std::{
     io::{Cursor, Read, Seek},
 };
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 use crate::TemporalInfo;
 use crate::{
     codetables::{
@@ -558,7 +558,7 @@ Data Representation:                    {}
         TemporalRawInfo::new(ref_time_significance, ref_time_unchecked, forecast_time)
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "time-calculation")]
     /// Returns time-related calculated information associated with the
     /// submessage.
     ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -496,6 +496,7 @@ Data Representation:                    {}
         )
     }
 
+    /// Returns time-related raw information associated with the submessage.
     pub fn temporal_raw_info(&self) -> TemporalRawInfo {
         let ref_time_significance = self.ident().ref_time_significance();
         let ref_time_unchecked = self.ident().ref_time_unchecked();
@@ -504,6 +505,8 @@ Data Representation:                    {}
     }
 
     #[cfg(feature = "chrono")]
+    /// Returns time-related calculated information associated with the
+    /// submessage.
     pub fn temporal_info(&self) -> TemporalInfo {
         let raw_info = self.temporal_raw_info();
         TemporalInfo::from(&raw_info)

--- a/src/context.rs
+++ b/src/context.rs
@@ -392,7 +392,7 @@ impl<'a, R> SubMessage<'a, R> {
         }
     }
 
-    pub fn ident(&self) -> &Identification {
+    fn identification(&self) -> &Identification {
         // panics should not happen if data is correct
         match self.1.body.body.as_ref().unwrap() {
             SectionBody::Section1(data) => data,
@@ -552,8 +552,8 @@ Data Representation:                    {}
     /// }
     /// ```
     pub fn temporal_raw_info(&self) -> TemporalRawInfo {
-        let ref_time_significance = self.ident().ref_time_significance();
-        let ref_time_unchecked = self.ident().ref_time_unchecked();
+        let ref_time_significance = self.identification().ref_time_significance();
+        let ref_time_unchecked = self.identification().ref_time_unchecked();
         let forecast_time = self.prod_def().forecast_time();
         TemporalRawInfo::new(ref_time_significance, ref_time_unchecked, forecast_time)
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -497,6 +497,60 @@ Data Representation:                    {}
     }
 
     /// Returns time-related raw information associated with the submessage.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::{
+    ///     fs::File,
+    ///     io::{BufReader, Read},
+    /// };
+    ///
+    /// use grib::{
+    ///     codetables::grib2::{Table1_2, Table4_4},
+    ///     Code, ForecastTime, TemporalRawInfo, UtcDateTime,
+    /// };
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let f = File::open(
+    ///         "testdata/Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.bin",
+    ///     )?;
+    ///     let f = BufReader::new(f);
+    ///     let grib2 = grib::from_reader(f)?;
+    ///
+    ///     let mut iter = grib2.iter();
+    ///
+    ///     {
+    ///         let (_, message) = iter.next().ok_or_else(|| "first message is not found")?;
+    ///         let actual = message.temporal_raw_info();
+    ///         let expected = TemporalRawInfo {
+    ///             ref_time_significance: Code::Name(Table1_2::Analysis),
+    ///             ref_time_unchecked: UtcDateTime::new(2016, 8, 22, 2, 0, 0),
+    ///             forecast_time_diff: Some(ForecastTime {
+    ///                 unit: Code::Name(Table4_4::Minute),
+    ///                 value: 0,
+    ///             }),
+    ///         };
+    ///         assert_eq!(actual, expected);
+    ///     }
+    ///
+    ///     {
+    ///         let (_, message) = iter.next().ok_or_else(|| "second message is not found")?;
+    ///         let actual = message.temporal_raw_info();
+    ///         let expected = TemporalRawInfo {
+    ///             ref_time_significance: Code::Name(Table1_2::Analysis),
+    ///             ref_time_unchecked: UtcDateTime::new(2016, 8, 22, 2, 0, 0),
+    ///             forecast_time_diff: Some(ForecastTime {
+    ///                 unit: Code::Name(Table4_4::Minute),
+    ///                 value: 10,
+    ///             }),
+    ///         };
+    ///         assert_eq!(actual, expected);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn temporal_raw_info(&self) -> TemporalRawInfo {
         let ref_time_significance = self.ident().ref_time_significance();
         let ref_time_unchecked = self.ident().ref_time_unchecked();
@@ -507,6 +561,53 @@ Data Representation:                    {}
     #[cfg(feature = "chrono")]
     /// Returns time-related calculated information associated with the
     /// submessage.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::{
+    ///     fs::File,
+    ///     io::{BufReader, Read},
+    /// };
+    ///
+    /// use chrono::{TimeZone, Utc};
+    /// use grib::{
+    ///     codetables::grib2::{Table1_2, Table4_4},
+    ///     Code, ForecastTime, TemporalInfo, UtcDateTime,
+    /// };
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let f = File::open(
+    ///         "testdata/Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.bin",
+    ///     )?;
+    ///     let f = BufReader::new(f);
+    ///     let grib2 = grib::from_reader(f)?;
+    ///
+    ///     let mut iter = grib2.iter();
+    ///
+    ///     {
+    ///         let (_, message) = iter.next().ok_or_else(|| "first message is not found")?;
+    ///         let actual = message.temporal_info();
+    ///         let expected = TemporalInfo {
+    ///             ref_time: Some(Utc.with_ymd_and_hms(2016, 8, 22, 2, 0, 0).unwrap()),
+    ///             forecast_time_target: Some(Utc.with_ymd_and_hms(2016, 8, 22, 2, 0, 0).unwrap()),
+    ///         };
+    ///         assert_eq!(actual, expected);
+    ///     }
+    ///
+    ///     {
+    ///         let (_, message) = iter.next().ok_or_else(|| "second message is not found")?;
+    ///         let actual = message.temporal_info();
+    ///         let expected = TemporalInfo {
+    ///             ref_time: Some(Utc.with_ymd_and_hms(2016, 8, 22, 2, 0, 0).unwrap()),
+    ///             forecast_time_target: Some(Utc.with_ymd_and_hms(2016, 8, 22, 2, 10, 0).unwrap()),
+    ///         };
+    ///         assert_eq!(actual, expected);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn temporal_info(&self) -> TemporalInfo {
         let raw_info = self.temporal_raw_info();
         TemporalInfo::from(&raw_info)

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,6 +5,8 @@ use std::{
     io::{Cursor, Read, Seek},
 };
 
+#[cfg(feature = "chrono")]
+use crate::TemporalInfo;
 use crate::{
     codetables::{
         CodeTable3_1, CodeTable4_0, CodeTable4_1, CodeTable4_2, CodeTable4_3, CodeTable5_0, Lookup,
@@ -14,7 +16,7 @@ use crate::{
     grid::GridPointIterator,
     parser::Grib2SubmessageIndexStream,
     reader::{Grib2Read, Grib2SectionStream, SeekableGrib2Reader, SECT8_ES_SIZE},
-    GridPointIndexIterator, TemporalInfo,
+    GridPointIndexIterator, TemporalRawInfo,
 };
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -494,11 +496,17 @@ Data Representation:                    {}
         )
     }
 
-    pub fn temporal_info(&self) -> TemporalInfo {
+    pub fn temporal_raw_info(&self) -> TemporalRawInfo {
         let ref_time_significance = self.ident().ref_time_significance();
         let ref_time_unchecked = self.ident().ref_time_unchecked();
         let forecast_time = self.prod_def().forecast_time();
-        TemporalInfo::new(ref_time_significance, ref_time_unchecked, forecast_time)
+        TemporalRawInfo::new(ref_time_significance, ref_time_unchecked, forecast_time)
+    }
+
+    #[cfg(feature = "chrono")]
+    pub fn temporal_info(&self) -> TemporalInfo {
+        let raw_info = self.temporal_raw_info();
+        TemporalInfo::from(&raw_info)
     }
 
     /// Returns the shape of the grid, i.e. a tuple of the number of grids in

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -1,7 +1,4 @@
-use std::{fmt, slice::Iter};
-
-#[cfg(feature = "chrono")]
-use chrono::{DateTime, LocalResult, TimeZone, Utc};
+use std::slice::Iter;
 
 use crate::{
     codetables::SUPPORTED_PROD_DEF_TEMPLATE_NUMBERS,
@@ -11,6 +8,7 @@ use crate::{
         GaussianGridDefinition, GridPointIterator, LambertGridDefinition, LatLonGridDefinition,
     },
     helpers::{read_as, GribInt},
+    time::UtcDateTime,
     GridPointIndexIterator, PolarStereographicGridDefinition,
 };
 
@@ -111,9 +109,9 @@ impl Identification {
 
     #[cfg(feature = "chrono")]
     /// Reference time of data
-    pub fn ref_time(&self) -> Result<DateTime<Utc>, GribError> {
+    pub fn ref_time(&self) -> Result<chrono::DateTime<chrono::Utc>, GribError> {
         let time = self.ref_time_unchecked();
-        create_date_time(
+        crate::time::create_date_time(
             time.year.into(),
             time.month.into(),
             time.day.into(),
@@ -134,59 +132,6 @@ impl Identification {
     #[inline]
     pub fn data_type(&self) -> u8 {
         self.payload[15]
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct UtcDateTime {
-    pub year: u16,
-    pub month: u8,
-    pub day: u8,
-    pub hour: u8,
-    pub minute: u8,
-    pub second: u8,
-}
-
-impl UtcDateTime {
-    pub fn new(year: u16, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> Self {
-        Self {
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-        }
-    }
-}
-
-impl fmt::Display for UtcDateTime {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{:04}-{:02}-{:02} {:02}:{:02}:{:02} UTC",
-            self.year, self.month, self.day, self.hour, self.minute, self.second
-        )
-    }
-}
-
-#[cfg(feature = "chrono")]
-#[inline]
-fn create_date_time(
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    minute: u32,
-    second: u32,
-) -> Result<DateTime<Utc>, GribError> {
-    let result = Utc.with_ymd_and_hms(year, month, day, hour, minute, second);
-    if let LocalResult::None = result {
-        Err(GribError::InvalidValueError(format!(
-            "invalid date time: {year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"
-        )))
-    } else {
-        Ok(result.unwrap())
     }
 }
 
@@ -591,50 +536,6 @@ pub struct BitMap {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    macro_rules! test_date_time_creation {
-        ($((
-            $name:ident,
-            $year:expr,
-            $month:expr,
-            $day:expr,
-            $hour:expr,
-            $minute:expr,
-            $second:expr,
-            $ok_expected:expr
-        ),)*) => ($(
-            #[cfg(feature = "chrono")]
-            #[test]
-            fn $name() {
-                let result = create_date_time($year, $month, $day, $hour, $minute, $second);
-                assert_eq!(result.is_ok(), $ok_expected);
-            }
-        )*);
-    }
-
-    test_date_time_creation! {
-        (date_time_creation_for_valid_date_time, 2022, 1, 1, 0, 0, 0, true),
-        (date_time_creation_for_invalid_date, 2022, 11, 31, 0, 0, 0, false),
-        (date_time_creation_for_invalid_time, 2022, 1, 1, 0, 61, 0, false),
-    }
-
-    #[cfg(feature = "chrono")]
-    #[test]
-    fn error_in_date_time_creation() {
-        let result = create_date_time(2022, 11, 31, 0, 0, 0);
-        assert_eq!(
-            result,
-            Err(GribError::InvalidValueError(
-                "invalid date time: 2022-11-31 00:00:00".to_owned()
-            ))
-        );
-    }
-
-    #[test]
-    fn test_utc_date_time_string() {
-        let time = UtcDateTime::new(2025, 1, 1, 0, 0, 0);
-        assert_eq!(format!("{time}"), "2025-01-01 00:00:00 UTC".to_owned())
-    }
 
     #[test]
     fn grid_definition_template_0() {

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -107,20 +107,6 @@ impl Identification {
         )
     }
 
-    #[cfg(feature = "chrono")]
-    /// Reference time of data
-    pub fn ref_time(&self) -> Result<chrono::DateTime<chrono::Utc>, GribError> {
-        let time = self.ref_time_unchecked();
-        crate::time::create_date_time(
-            time.year.into(),
-            time.month.into(),
-            time.day.into(),
-            time.hour.into(),
-            time.minute.into(),
-            time.second.into(),
-        )
-    }
-
     /// Production status of processed data in this GRIB message
     /// (see Code Table 1.3)
     #[inline]

--- a/src/datatypes/sections.rs
+++ b/src/datatypes/sections.rs
@@ -1,5 +1,6 @@
 use std::{fmt, slice::Iter};
 
+#[cfg(feature = "chrono")]
 use chrono::{DateTime, LocalResult, TimeZone, Utc};
 
 use crate::{
@@ -108,6 +109,7 @@ impl Identification {
         )
     }
 
+    #[cfg(feature = "chrono")]
     /// Reference time of data
     pub fn ref_time(&self) -> Result<DateTime<Utc>, GribError> {
         let time = self.ref_time_unchecked();
@@ -168,6 +170,7 @@ impl fmt::Display for UtcDateTime {
     }
 }
 
+#[cfg(feature = "chrono")]
 #[inline]
 fn create_date_time(
     year: i32,
@@ -600,6 +603,7 @@ mod tests {
             $second:expr,
             $ok_expected:expr
         ),)*) => ($(
+            #[cfg(feature = "chrono")]
             #[test]
             fn $name() {
                 let result = create_date_time($year, $month, $day, $hour, $minute, $second);
@@ -614,6 +618,7 @@ mod tests {
         (date_time_creation_for_invalid_time, 2022, 1, 1, 0, 61, 0, false),
     }
 
+    #[cfg(feature = "chrono")]
     #[test]
     fn error_in_date_time_creation() {
         let result = create_date_time(2022, 11, 31, 0, 0, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod grid;
 mod helpers;
 mod parser;
 mod reader;
+mod time;
 pub mod utils;
 
 pub use crate::{
@@ -23,6 +24,7 @@ pub use crate::{
     },
     parser::*,
     reader::*,
+    time::*,
 };
 
 #[doc = include_str!("../README.md")]

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 use chrono::{DateTime, LocalResult, TimeDelta, TimeZone, Utc};
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 use crate::codetables::grib2::Table4_4;
 use crate::{codetables::grib2::Table1_2, Code, ForecastTime};
 
@@ -34,7 +34,7 @@ impl TemporalRawInfo {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 #[derive(Debug, PartialEq, Eq)]
 /// Time-related calculated information.
 pub struct TemporalInfo {
@@ -44,7 +44,7 @@ pub struct TemporalInfo {
     pub forecast_time_target: Option<DateTime<Utc>>,
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 impl From<&TemporalRawInfo> for TemporalInfo {
     fn from(value: &TemporalRawInfo) -> Self {
         let ref_time = create_date_time(
@@ -109,7 +109,7 @@ impl fmt::Display for UtcDateTime {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 #[inline]
 fn create_date_time(
     year: i32,
@@ -127,10 +127,10 @@ fn create_date_time(
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 struct BasicTimeDelta(fn(i64) -> Option<TimeDelta>, i64);
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "time-calculation")]
 impl BasicTimeDelta {
     fn new(ft: &ForecastTime) -> Option<Self> {
         match ft.unit {
@@ -166,7 +166,7 @@ mod tests {
             $second:expr,
             $ok_expected:expr
         ),)*) => ($(
-            #[cfg(feature = "chrono")]
+            #[cfg(feature = "time-calculation")]
             #[test]
             fn $name() {
                 let result = create_date_time($year, $month, $day, $hour, $minute, $second);

--- a/src/time.rs
+++ b/src/time.rs
@@ -3,12 +3,12 @@ use std::fmt;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, LocalResult, TimeDelta, TimeZone, Utc};
 
-use crate::ForecastTime;
 #[cfg(feature = "chrono")]
-use crate::{codetables::grib2::Table4_4, Code};
+use crate::codetables::grib2::Table4_4;
+use crate::{codetables::grib2::Table1_2, Code, ForecastTime};
 
 pub struct TemporalRawInfo {
-    pub ref_time_significance: u8,
+    pub ref_time_significance: Code<Table1_2, u8>,
     pub ref_time_unchecked: UtcDateTime,
     pub forecast_time_diff: Option<ForecastTime>,
 }
@@ -19,6 +19,7 @@ impl TemporalRawInfo {
         ref_time_unchecked: UtcDateTime,
         forecast_time_diff: Option<ForecastTime>,
     ) -> Self {
+        let ref_time_significance = Table1_2::try_from(ref_time_significance).into();
         Self {
             ref_time_significance,
             ref_time_unchecked,

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,109 @@
+use std::fmt;
+
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
+
+#[cfg(feature = "chrono")]
+use crate::error::GribError;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct UtcDateTime {
+    pub year: u16,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+}
+
+impl UtcDateTime {
+    pub fn new(year: u16, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> Self {
+        Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        }
+    }
+}
+
+impl fmt::Display for UtcDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:04}-{:02}-{:02} {:02}:{:02}:{:02} UTC",
+            self.year, self.month, self.day, self.hour, self.minute, self.second
+        )
+    }
+}
+
+#[cfg(feature = "chrono")]
+#[inline]
+pub(crate) fn create_date_time(
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> Result<DateTime<Utc>, GribError> {
+    let result = Utc.with_ymd_and_hms(year, month, day, hour, minute, second);
+    if let LocalResult::None = result {
+        Err(GribError::InvalidValueError(format!(
+            "invalid date time: {year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"
+        )))
+    } else {
+        Ok(result.unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_date_time_creation {
+        ($((
+            $name:ident,
+            $year:expr,
+            $month:expr,
+            $day:expr,
+            $hour:expr,
+            $minute:expr,
+            $second:expr,
+            $ok_expected:expr
+        ),)*) => ($(
+            #[cfg(feature = "chrono")]
+            #[test]
+            fn $name() {
+                let result = create_date_time($year, $month, $day, $hour, $minute, $second);
+                assert_eq!(result.is_ok(), $ok_expected);
+            }
+        )*);
+    }
+
+    test_date_time_creation! {
+        (date_time_creation_for_valid_date_time, 2022, 1, 1, 0, 0, 0, true),
+        (date_time_creation_for_invalid_date, 2022, 11, 31, 0, 0, 0, false),
+        (date_time_creation_for_invalid_time, 2022, 1, 1, 0, 61, 0, false),
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn error_in_date_time_creation() {
+        let result = create_date_time(2022, 11, 31, 0, 0, 0);
+        assert_eq!(
+            result,
+            Err(GribError::InvalidValueError(
+                "invalid date time: 2022-11-31 00:00:00".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_utc_date_time_string() {
+        let time = UtcDateTime::new(2025, 1, 1, 0, 0, 0);
+        assert_eq!(format!("{time}"), "2025-01-01 00:00:00 UTC".to_owned())
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -7,9 +7,14 @@ use chrono::{DateTime, LocalResult, TimeDelta, TimeZone, Utc};
 use crate::codetables::grib2::Table4_4;
 use crate::{codetables::grib2::Table1_2, Code, ForecastTime};
 
+/// Time-related raw information.
 pub struct TemporalRawInfo {
+    /// "Significance of reference time" set in Section 1 of the submessage. See
+    /// [Code Table 1.2](crate::codetables::grib2::Table1_2).
     pub ref_time_significance: Code<Table1_2, u8>,
+    /// "Reference time" set in Section 1 of the submessage.
     pub ref_time_unchecked: UtcDateTime,
+    /// "Forecast time" set in Section 3 of the submessage.
     pub forecast_time_diff: Option<ForecastTime>,
 }
 
@@ -29,8 +34,11 @@ impl TemporalRawInfo {
 }
 
 #[cfg(feature = "chrono")]
+/// Time-related calculated information.
 pub struct TemporalInfo {
+    /// "Reference time" represented as [`chrono::DateTime`].
     pub ref_time: Option<DateTime<Utc>>,
+    /// "Forecast time" calculated and represented as [`chrono::DateTime`].
     pub forecast_time_target: Option<DateTime<Utc>>,
 }
 
@@ -60,12 +68,19 @@ impl From<&TemporalRawInfo> for TemporalInfo {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+/// UTC date and time container.
 pub struct UtcDateTime {
+    /// Year.
     pub year: u16,
+    /// Month.
     pub month: u8,
+    /// Day.
     pub day: u8,
+    /// Hour.
     pub hour: u8,
+    /// Minute.
     pub minute: u8,
+    /// Second.
     pub second: u8,
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,6 +5,41 @@ use chrono::{DateTime, LocalResult, TimeZone, Utc};
 
 #[cfg(feature = "chrono")]
 use crate::error::GribError;
+use crate::ForecastTime;
+
+pub struct TemporalInfo {
+    pub ref_time_significance: u8,
+    pub ref_time_unchecked: UtcDateTime,
+    #[cfg(feature = "chrono")]
+    pub ref_time: Option<DateTime<Utc>>,
+    pub forecast_time: Option<ForecastTime>,
+}
+
+impl TemporalInfo {
+    pub(crate) fn new(
+        ref_time_significance: u8,
+        ref_time_unchecked: UtcDateTime,
+        forecast_time: Option<ForecastTime>,
+    ) -> Self {
+        #[cfg(feature = "chrono")]
+        let ref_time = create_date_time(
+            ref_time_unchecked.year.into(),
+            ref_time_unchecked.month.into(),
+            ref_time_unchecked.day.into(),
+            ref_time_unchecked.hour.into(),
+            ref_time_unchecked.minute.into(),
+            ref_time_unchecked.second.into(),
+        )
+        .ok();
+        Self {
+            ref_time_significance,
+            ref_time_unchecked,
+            #[cfg(feature = "chrono")]
+            ref_time,
+            forecast_time,
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct UtcDateTime {
@@ -41,7 +76,7 @@ impl fmt::Display for UtcDateTime {
 
 #[cfg(feature = "chrono")]
 #[inline]
-pub(crate) fn create_date_time(
+fn create_date_time(
     year: i32,
     month: u32,
     day: u32,

--- a/src/time.rs
+++ b/src/time.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, LocalResult, TimeDelta, TimeZone, Utc};
 use crate::codetables::grib2::Table4_4;
 use crate::{codetables::grib2::Table1_2, Code, ForecastTime};
 
+#[derive(Debug, PartialEq, Eq)]
 /// Time-related raw information.
 pub struct TemporalRawInfo {
     /// "Significance of reference time" set in Section 1 of the submessage. See
@@ -34,6 +35,7 @@ impl TemporalRawInfo {
 }
 
 #[cfg(feature = "chrono")]
+#[derive(Debug, PartialEq, Eq)]
 /// Time-related calculated information.
 pub struct TemporalInfo {
     /// "Reference time" represented as [`chrono::DateTime`].


### PR DESCRIPTION
This PR provides following enhancements concerning time-related information APIs.

### Reduction of dependency on chrono crate

Dependency on chrono crate is changed from "always dependent" to "dependent only when chrono feature is enabled".
Raw values of the reference time read from the data are now returned as `grib::UtcDateTime`, and the functionality to return values interpreted as `chrono::DateTime` should be available only when `chrono` feature is enabled.

#### Reasons

- It would be better to have as few dependent crates in the crate core as possible .
- If the data has an invalid reference time set such as "2025-13-32 25:61", an error is currently returned as a reference time.
  This is because the reading of the value and its conversion (interpretation) to `chrono::DateTime` are included in one process.
  It is better to separate the read value from the interpreted value.

### Methods for providing time-related information in batches

Since time-related information in submessages is limited, such as reference time and forecast time, and is often used together, it is more convenient for users to be able to retrieve it all at once.

### Calculation of forecast time

Inside GRIB, forecast time is expressed as a combination of a value and a unit representing the elapsed time from the reference time, and the current grib crate API also expresses it as it is in Rust-style way.
However, since we have a functionality to provide interpreted values for reference time, it would be more convenient for users if the calculation results are also available for forecast time.

At the time of this PR, the calculation results are returned when the unit of the forecast time is up to "day".
This is simply because the calculation is supported by chrono and is easy to implement.
If the unit is "month" or larger, the result would be `None`.

### Support for Code Table 1.2

This PR adds support for Code Table 1.2 (significance of reference time).
