### PR TITLE
Make access to `grib::Identification` from `grib::SubMessage` easier

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -392,7 +392,7 @@ impl<'a, R> SubMessage<'a, R> {
         }
     }
 
-    fn identification(&self) -> &Identification {
+    pub fn identification(&self) -> &Identification {
         // panics should not happen if data is correct
         match self.1.body.body.as_ref().unwrap() {
             SectionBody::Section1(data) => data,


### PR DESCRIPTION
This PR makes access to `grib::Identification` from `grib::SubMessage` easier.
This is just a follow-up to #119.

Closes #110.