### PR TITLE
Generate API documentation for feature-specific APIs as well

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,12 +23,14 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: wasm32-unknown-unknown
 
       - name: Build documentation
-        run: cargo doc --no-deps --release
+        run: cargo doc --all-features --no-deps --release
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
       - name: Stage documentation
         run: mv target/doc dist
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ categories.workspace = true
 keywords.workspace = true
 exclude = ["/.github", "/testdata"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [workspace]
 members = ["gen", "cli", "demo"]
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,8 @@ Since there is a lot of work that needs to be done in the release process, and I
 4. Switch to a clean repository and pull the `master` branch.
    Cloning is better to avoid mistakes, but fast-forward updating of an existing repository is fine as long as it stays clean, so I always have a clean repository for the release operation.
 5. Run `cargo test --workspace --release` to reconfirm that the tests pass.
-6. Run `cargo doc --no-deps --open` in lib crate to reconfirm the generated documentation.
+6. Run `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open` in lib crate to reconfirm the generated documentation.
+   Note that a simple `cargo doc --no-deps` command execution does not generate documentation on feature-specific APIs.
 7. Run the following commands, starting with the dependent packages, i.e. `grib-build`, `grib`, `grib-cli`, in that order.
    - `cargo package`
    - `cargo publish`

--- a/src/context.rs
+++ b/src/context.rs
@@ -568,6 +568,7 @@ Data Representation:                    {}
     }
 
     #[cfg(feature = "time-calculation")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "time-calculation")))]
     /// Returns time-related calculated information associated with the
     /// submessage.
     ///

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -118,6 +118,7 @@ impl LambertGridDefinition {
     /// of iterator iterations is consistent with the number of grid points
     /// defined in the data.
     #[cfg(feature = "gridpoints-proj")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "gridpoints-proj")))]
     pub fn latlons(&self) -> Result<std::vec::IntoIter<(f32, f32)>, GribError> {
         let lad = self.lad as f64 * 1e-6;
         let lov = self.lov as f64 * 1e-6;

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -116,6 +116,7 @@ impl PolarStereographicGridDefinition {
     /// of iterator iterations is consistent with the number of grid points
     /// defined in the data.
     #[cfg(feature = "gridpoints-proj")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "gridpoints-proj")))]
     pub fn latlons(&self) -> Result<std::vec::IntoIter<(f32, f32)>, GribError> {
         let lad = self.lad as f64 * 1e-6;
         let lov = self.lov as f64 * 1e-6;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod codetables;
 mod context;
 pub mod cookbook;

--- a/src/time.rs
+++ b/src/time.rs
@@ -35,6 +35,7 @@ impl TemporalRawInfo {
 }
 
 #[cfg(feature = "time-calculation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time-calculation")))]
 #[derive(Debug, PartialEq, Eq)]
 /// Time-related calculated information.
 pub struct TemporalInfo {


### PR DESCRIPTION
This PR makes API documentation on  [docs.rs] and [GitHub Pages] include descriptions on feature-specific APIs.

[docs.rs]: https://docs.rs/grib/latest/grib/
[GitHub Pages]: https://noritada.github.io/grib-rs/grib/index.html