### PR TITLE
Correct the dependency on chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ categories = ["science"]
 keywords = ["GRIB", "weather", "meteorology"]
 
 [dependencies]
-chrono = { version = "0.4.23", optional = true }
+chrono = { version = "0.4.34", optional = true }
 num = "0.4"
 num_enum = "0.7"
 png = "0.17"


### PR DESCRIPTION
This PR fixes a build failure with older versions of chrono.

### Details of the build failure

The error message is like this:

```
error[E0432]: unresolved import `chrono::TimeDelta`
 --> src/time.rs:4:37
  |
4 | use chrono::{DateTime, LocalResult, TimeDelta, TimeZone, Utc};
  |                                     ^^^^^^^^^ no `TimeDelta` in the root
```

In the above case, we used chrono v0.4.23 for the build.

### Cause

The cause is an error in specifying the dependent version.
`chrono::TimeDelta` has been available since v0.4.34.
Prior to that, it was named `chrono::Duration`.