### PR TITLE
Crate-level documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 categories.workspace = true
 keywords.workspace = true
+build = "build/main.rs"
 exclude = ["/.github", "/testdata"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ xz2 = "0.1"
 
 [build-dependencies]
 grib-build = { path = "gen", version = "0.4.3" }
+toml_edit = "0.23"
 
 [features]
 # Enable computation of latitudes and longitudes of grid points points using

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GRIB format parser for Rust
 
 ## About
 
-This is a GRIB format parser library written in [Rust](https://www.rust-lang.org/) programming language. This project aims to provide a set of library and tools which is simple-to-use, efficient, and educational.
+This is a GRIB format parser library written in Rust programming language. This project aims to provide a set of library and tools which is simple-to-use, efficient, and educational.
 
 GRIB is a concise data format commonly used in meteorology to store historical and forecast weather data. It is intended to be a container of a collection of records of 2D data. GRIB files are huge and binary and should be processed efficiently. Also, since GRIB is designed to support various grid types and data compression using parameters defined in external code tables and templates, some popular existing softwares cannot handle some GRIB data.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The [examples directory](examples) may help you understand the API.
+The [examples directory][examples] in the source repository may help you understand the API.
+
+[examples]: https://github.com/noritada/grib-rs/tree/master/examples
 
 ### Cargo features
 

--- a/build.rs
+++ b/build.rs
@@ -72,6 +72,7 @@ fn read_feature_docs() -> Result<String, Box<dyn std::error::Error>> {
 {features}
 ```"
     );
+    println!("cargo:rerun-if-changed=Cargo.toml");
 
     Ok(new_doc)
 }

--- a/build/doc.rs
+++ b/build/doc.rs
@@ -1,0 +1,40 @@
+use std::{
+    io::{self, Read},
+    str::FromStr,
+};
+
+pub(crate) fn read_manifest() -> io::Result<String> {
+    let mut f = std::fs::File::open("Cargo.toml")?;
+    let mut manifest = String::new();
+    f.read_to_string(&mut manifest)?;
+
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    Ok(manifest)
+}
+
+pub(crate) struct Features(String);
+
+impl Features {
+    pub(crate) fn text(self) -> String {
+        self.0
+    }
+}
+
+impl FromStr for Features {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let doc = s
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|e| e.to_string())?;
+        let features = doc["features"].to_string();
+        let new_doc = format!(
+            "```text
+[features]
+{features}
+```"
+        );
+
+        Ok(Self(new_doc))
+    }
+}

--- a/build/doc.rs
+++ b/build/doc.rs
@@ -1,7 +1,52 @@
 use std::{
+    collections::HashMap,
     io::{self, Read},
     str::FromStr,
 };
+
+pub(crate) fn generate() -> Result<String, String> {
+    let readme = read_readme()
+        .map_err(|e| e.to_string())?
+        .parse::<ReadMeSections>()?;
+    let about = readme.get("About")?;
+    let template_support = readme.get("Template support")?;
+    let gds_template_support = readme.get("Supported grid definition templates")?;
+    let drs_template_support = readme.get("Supported data representation templates")?;
+    let example = readme.get("Usage example")?;
+
+    let manifest = read_manifest()
+        .map_err(|e| e.to_string())?
+        .parse::<Features>()?
+        .text();
+
+    Ok(format!(
+        "{about}
+
+# Template support
+
+{template_support}
+
+## Supported grid definition templates
+
+{gds_template_support}
+
+## Supported data representation templates
+
+{drs_template_support}
+
+# Example
+
+{example}
+
+# Crate features
+
+Following crate features are available in this crate. These descriptions are
+extracted from the manifest of the crate.
+
+{manifest}
+"
+    ))
+}
 
 pub(crate) fn read_manifest() -> io::Result<String> {
     let mut f = std::fs::File::open("Cargo.toml")?;
@@ -36,5 +81,70 @@ impl FromStr for Features {
         );
 
         Ok(Self(new_doc))
+    }
+}
+
+fn read_readme() -> io::Result<String> {
+    let mut f = std::fs::File::open("README.md")?;
+    let mut readme = String::new();
+    f.read_to_string(&mut readme)?;
+
+    println!("cargo:rerun-if-changed=README.md");
+    Ok(readme)
+}
+
+#[derive(Debug)]
+struct ReadMeSections(HashMap<String, String>);
+
+impl ReadMeSections {
+    fn get(&self, key: &str) -> Result<&String, String> {
+        self.0
+            .get(key)
+            .ok_or(format!(r#""{key}" section not found"#))
+    }
+}
+
+impl std::str::FromStr for ReadMeSections {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Line terminators are not included in the lines returned by the iterator from
+        // `str::lines`.
+        let mut lines = s.split_inclusive("\n");
+
+        let mut map = HashMap::<String, String>::new();
+        let mut start = 0;
+        let mut pos = 0;
+        let mut title: Option<&str> = None;
+
+        let push = |map: &mut HashMap<String, String>,
+                    title: Option<&str>,
+                    s: &str,
+                    start: usize,
+                    end: usize| {
+            let Some(title) = title else { return };
+            if end <= start {
+                return;
+            }
+            let content = s[start..end].to_owned();
+            map.insert(title.to_owned(), content);
+        };
+
+        loop {
+            let Some(line) = lines.next() else {
+                push(&mut map, title, s, start, pos);
+                break;
+            };
+            pos += line.len();
+
+            if line.starts_with("#") {
+                push(&mut map, title, s, start, pos - line.len());
+                let s = line.trim_start_matches('#').trim();
+                title = Some(s);
+                start = pos;
+            }
+        }
+
+        Ok(Self(map))
     }
 }

--- a/build/main.rs
+++ b/build/main.rs
@@ -41,9 +41,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     fs::write(output_path, format!("{db}"))?;
 
-    let manifest = doc::read_manifest()?.parse::<doc::Features>()?.text();
-    let output_path = Path::new(&out_dir).join("features.txt");
-    fs::write(output_path, format!("{manifest}"))?;
+    let doc = doc::generate()?;
+    let output_path = Path::new(&out_dir).join("doc.txt");
+    fs::write(output_path, format!("{doc}"))?;
 
     println!("cargo:rerun-if-changed=build/main.rs");
     println!("cargo:rerun-if-changed=build/doc.rs");

--- a/build/main.rs
+++ b/build/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let doc = doc::generate()?;
     let output_path = Path::new(&out_dir).join("doc.txt");
-    fs::write(output_path, format!("{doc}"))?;
+    fs::write(output_path, doc.to_string())?;
 
     println!("cargo:rerun-if-changed=build/main.rs");
     println!("cargo:rerun-if-changed=build/doc.rs");

--- a/build/main.rs
+++ b/build/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output_path = Path::new(&out_dir).join("features.txt");
     fs::write(output_path, format!("{manifest}"))?;
 
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build/main.rs");
     Ok(())
 }
 

--- a/build/main.rs
+++ b/build/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let doc = doc::generate()?;
     let output_path = Path::new(&out_dir).join("doc.txt");
-    fs::write(output_path, doc.to_string())?;
+    fs::write(output_path, &doc)?;
 
     println!("cargo:rerun-if-changed=build/main.rs");
     println!("cargo:rerun-if-changed=build/doc.rs");

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, io::Read, path::Path};
+use std::{env, fs, path::Path};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::var_os("OUT_DIR").unwrap();
@@ -41,11 +41,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     fs::write(output_path, format!("{db}"))?;
 
-    let manifest = read_feature_docs()?;
+    let manifest = doc::read_manifest()?.parse::<doc::Features>()?.text();
     let output_path = Path::new(&out_dir).join("features.txt");
     fs::write(output_path, format!("{manifest}"))?;
 
     println!("cargo:rerun-if-changed=build/main.rs");
+    println!("cargo:rerun-if-changed=build/doc.rs");
     Ok(())
 }
 
@@ -59,20 +60,4 @@ fn check_nonemptiness(dir: &Path) -> Result<(), String> {
         })
 }
 
-fn read_feature_docs() -> Result<String, Box<dyn std::error::Error>> {
-    let mut f = std::fs::File::open("Cargo.toml")?;
-    let mut manifest = String::new();
-    f.read_to_string(&mut manifest)?;
-
-    let doc = manifest.parse::<toml_edit::DocumentMut>()?;
-    let features = doc["features"].to_string();
-    let new_doc = format!(
-        "```text
-[features]
-{features}
-```"
-    );
-    println!("cargo:rerun-if-changed=Cargo.toml");
-
-    Ok(new_doc)
-}
+mod doc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
-//! # Crate features
-//!
-//! Following crate features are available in this crate. These descriptions are
-//! extracted from the manifest of the crate.
-#![doc = include_str!(concat!(env!("OUT_DIR"), "/features.txt"))]
+#![doc = include_str!(concat!(env!("OUT_DIR"), "/doc.txt"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod codetables;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! # Crate features
+//!
+//! Following crate features are available in this crate. These descriptions are
+//! extracted from the manifest of the crate.
+#![doc = include_str!(concat!(env!("OUT_DIR"), "/features.txt"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod codetables;


### PR DESCRIPTION
This PR provides crate-level documentation.

Until now, no doc comments were written at the crate level, and the top page of the documentation contained only automatically generated API information.