### PR TITLE
True Template Support: add a CLI subcommand "dump" to dump the content of a GRIB submessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Usage: gribber [COMMAND]
 Commands:
   completions  Generate shell completions for your shell to stdout
   decode       Export decoded data with latitudes and longitudes
+  dump         Dump the content of a GRIB submessage
   info         Show identification information
   inspect      Inspect and describes the data structure
   list         List layers contained in the data

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4,6 +4,7 @@ pub fn cli() -> Vec<Command> {
     vec![
         completions::cli(),
         decode::cli(),
+        dump::cli(),
         info::cli(),
         inspect::cli(),
         list::cli(),
@@ -14,6 +15,7 @@ pub fn dispatch(matches: ArgMatches) -> anyhow::Result<()> {
     match matches.subcommand() {
         Some(("completions", args)) => completions::exec(args),
         Some(("decode", args)) => decode::exec(args),
+        Some(("dump", args)) => dump::exec(args),
         Some(("info", args)) => info::exec(args),
         Some(("inspect", args)) => inspect::exec(args),
         Some(("list", args)) => list::exec(args),
@@ -23,6 +25,7 @@ pub fn dispatch(matches: ArgMatches) -> anyhow::Result<()> {
 
 pub mod completions;
 pub mod decode;
+pub mod dump;
 pub mod info;
 pub mod inspect;
 pub mod list;

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{ArgMatches, Command, arg};
+
+use crate::cli;
+
+pub fn cli() -> Command {
+    Command::new(crate::cli::module_component!())
+        .about("Dump the content of a GRIB submessage")
+        .arg(
+            arg!(<FILE> "Target file name (or a single dash (`-`) for standard input)")
+                .value_parser(clap::value_parser!(PathBuf)),
+        )
+        .arg(
+            arg!(<INDEX> "Submessage index")
+                .value_parser(clap::value_parser!(cli::CliMessageIndex)),
+        )
+}
+
+pub fn exec(args: &ArgMatches) -> Result<()> {
+    let file_name = args.get_one::<PathBuf>("FILE").unwrap();
+    let grib = cli::grib(file_name)?;
+    let cli::CliMessageIndex(message_index) = args.get_one("INDEX").unwrap();
+    let (_, submessage) = grib
+        .iter()
+        .find(|(index, _)| index == message_index)
+        .ok_or_else(|| anyhow::anyhow!("no such index: {}.{}", message_index.0, message_index.1))?;
+    let mut stream = std::io::stdout();
+    submessage.dump(&mut stream)?;
+    Ok(())
+}

--- a/cli/tests/cli/commands/common.rs
+++ b/cli/tests/cli/commands/common.rs
@@ -30,6 +30,7 @@ macro_rules! test_subcommands_without_args {
 
 test_subcommands_without_args! {
     (decode_without_args, "decode"),
+    (dump_without_args, "dump"),
     (info_without_args, "info"),
     (list_without_args, "list"),
     (inspect_without_args, "inspect"),
@@ -56,6 +57,7 @@ macro_rules! test_subcommands_with_nonexisting_file {
 
 test_subcommands_with_nonexisting_file! {
     (decode_with_nonexisting_file, "decode", vec!["1.1"]),
+    (dump_with_nonexisting_file, "dump", vec!["1.1"]),
     (info_with_nonexisting_file, "info", Vec::<&str>::new()),
     (inspect_with_nonexisting_file, "inspect", Vec::<&str>::new()),
     (list_with_nonexisting_file, "list", Vec::<&str>::new()),
@@ -83,6 +85,13 @@ test_subcommands_with_wrong_input_files! {
     (
         decode_with_non_grib,
         "decode",
+        utils::testdata::non_grib_file()?,
+        vec!["1.1"],
+        predicate::str::diff("error: empty GRIB2 data\n")
+    ),
+    (
+        dump_with_non_grib,
+        "dump",
         utils::testdata::non_grib_file()?,
         vec!["1.1"],
         predicate::str::diff("error: empty GRIB2 data\n")
@@ -116,6 +125,13 @@ test_subcommands_with_wrong_input_files! {
         predicate::str::diff("error: empty GRIB2 data\n")
     ),
     (
+        dump_with_empty_file,
+        "dump",
+        utils::testdata::empty_file()?,
+        vec!["1.1"],
+        predicate::str::diff("error: empty GRIB2 data\n")
+    ),
+    (
         info_with_empty_file,
         "info",
         utils::testdata::empty_file()?,
@@ -139,6 +155,13 @@ test_subcommands_with_wrong_input_files! {
     (
         decode_with_too_small_file,
         "decode",
+        utils::testdata::too_small_file()?,
+        vec!["1.1"],
+        predicate::str::diff("error: empty GRIB2 data\n")
+    ),
+    (
+        dump_with_too_small_file,
+        "dump",
         utils::testdata::too_small_file()?,
         vec!["1.1"],
         predicate::str::diff("error: empty GRIB2 data\n")


### PR DESCRIPTION
This PR adds a CLI subcommand "dump" to dump the content of a GRIB submessage.
This is also part of "True Template Support" (#140).