### PR TITLE
CLI: fix a runtime error due to unsupported regex syntax

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = "1"
 clap = "4.1"
 clap_complete = "4"
 console = "0.16"
-regex = "1.6"
+regex = "1.8"
 
 [target.'cfg(unix)'.dependencies]
 grib = { path = "..", version = "=0.13.2", features = ["gridpoints-proj", "jpeg2000-unpack-with-openjpeg", "png-unpack-with-png-crate", "ccsds-unpack-with-libaec"] }


### PR DESCRIPTION
This PR fixes a runtime error introduced by PR #146, updating the dependency on regex.

Named captures `(?<name>re)` is supported from regex 1.8.0.
Before that, they had to be written as `(?P<name>re)`.