### PR TITLE
Correct wrong multipliers used for latitudes and longitudes

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -5,7 +5,8 @@ pub use self::{gaussian::compute_gaussian_latitudes, rotated_ll::Unrotate};
 use crate::{
     GribError, GridDefinition,
     def::grib2::template::{
-        Template3_0, Template3_1, Template3_20, Template3_30, Template3_40, param_set::ScanningMode,
+        Template3_0, Template3_1, Template3_20, Template3_30, Template3_40,
+        param_set::{Grid, ScanningMode},
     },
 };
 
@@ -365,6 +366,22 @@ impl Iterator for GridPointIndexIterator {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = (self.major_len - self.major_pos) * self.minor_len - self.minor_pos;
         (len, Some(len))
+    }
+}
+
+pub(crate) trait AngleUnit {
+    fn angle_unit(&self) -> f64;
+}
+
+impl AngleUnit for Grid {
+    fn angle_unit(&self) -> f64 {
+        let basic_angle = self.initial_production_domain_basic_angle;
+        let sub_angle = self.basic_angle_subdivisions;
+        if basic_angle == 0 {
+            1e-6
+        } else {
+            basic_angle as f64 / sub_angle as f64
+        }
     }
 }
 

--- a/src/grid/gaussian.rs
+++ b/src/grid/gaussian.rs
@@ -1,5 +1,5 @@
 use super::helpers::{RegularGridIterator, evenly_spaced_longitudes};
-use crate::{GridPointIndex, def::grib2::template::param_set, error::GribError};
+use crate::{GridPointIndex, def::grib2::template::param_set, error::GribError, grid::AngleUnit};
 
 const MAX_ITER: usize = 10;
 
@@ -41,11 +41,18 @@ impl crate::LatLons for param_set::GaussianGrid {
             self.grid.first_point_lon,
             self.grid.last_point_lon,
             (self.grid.ni - 1) as usize,
+            self.angle_unit() as f32,
             self.scanning_mode,
         );
 
         let iter = RegularGridIterator::new(lat, lon, ij);
         Ok(iter)
+    }
+}
+
+impl AngleUnit for param_set::GaussianGrid {
+    fn angle_unit(&self) -> f64 {
+        self.grid.angle_unit()
     }
 }
 

--- a/src/grid/helpers.rs
+++ b/src/grid/helpers.rs
@@ -9,6 +9,7 @@ pub(crate) fn evenly_spaced_longitudes(
     start_microdegree: u32,
     end_microdegree: u32,
     div: usize,
+    angle_units: f32,
     scanning_mode: ScanningMode,
 ) -> Vec<f32> {
     let is_consistent =
@@ -23,7 +24,7 @@ pub(crate) fn evenly_spaced_longitudes(
         (start + 360_000_000_f32, end)
     };
 
-    let lons = evenly_spaced_degrees(start, end, div);
+    let lons = evenly_spaced_degrees(start, end, div, angle_units);
 
     if is_consistent {
         lons
@@ -38,10 +39,11 @@ pub(crate) fn evenly_spaced_degrees(
     start_microdegree: f32,
     end_microdegree: f32,
     div: usize,
+    angle_units: f32,
 ) -> Vec<f32> {
     let delta = (end_microdegree - start_microdegree) / div as f32;
     (0..=div)
-        .map(move |x| (start_microdegree + x as f32 * delta) / 1_000_000_f32)
+        .map(move |x| (start_microdegree + x as f32 * delta) * angle_units)
         .collect()
 }
 

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -4,6 +4,7 @@ use crate::{
     GridPointIndex,
     def::grib2::template::{Template3_30, param_set},
     error::GribError,
+    grid::AngleUnit,
 };
 
 impl crate::GridShortName for Template3_30 {
@@ -28,10 +29,11 @@ impl LatLons for Template3_30 {
     type Iter<'a> = std::vec::IntoIter<(f32, f32)>;
 
     fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
-        let lad = self.lad as f64 * 1e-6;
-        let lov = self.lov as f64 * 1e-6;
-        let latin1 = self.latin1 as f64 * 1e-6;
-        let latin2 = self.latin2 as f64 * 1e-6;
+        let angle_units = self.angle_unit();
+        let lad = self.lad as f64 * angle_units;
+        let lov = self.lov as f64 * angle_units;
+        let latin1 = self.latin1 as f64 * angle_units;
+        let latin2 = self.latin2 as f64 * angle_units;
         let (a, b) = self.earth_shape.radii().ok_or_else(|| {
             GribError::NotSupported(format!(
                 "unknown value of Code Table 3.2 (shape of the Earth): {}",
@@ -58,12 +60,18 @@ impl LatLons for Template3_30 {
         super::helpers::latlons_from_projection_definition_and_first_point(
             &proj_def,
             (
-                self.first_point_lat as f64 * 1e-6,
-                self.first_point_lon as f64 * 1e-6,
+                self.first_point_lat as f64 * angle_units,
+                self.first_point_lon as f64 * angle_units,
             ),
             (dx, dy),
             self.ij()?,
         )
+    }
+}
+
+impl AngleUnit for Template3_30 {
+    fn angle_unit(&self) -> f64 {
+        1e-6
     }
 }
 

--- a/src/grid/latlon.rs
+++ b/src/grid/latlon.rs
@@ -1,5 +1,7 @@
 use super::helpers::{RegularGridIterator, evenly_spaced_degrees, evenly_spaced_longitudes};
-use crate::{GridPointIndex, LatLons, def::grib2::template::param_set, error::GribError};
+use crate::{
+    GridPointIndex, LatLons, def::grib2::template::param_set, error::GribError, grid::AngleUnit,
+};
 
 impl crate::GridShortName for param_set::LatLonGrid {
     fn short_name(&self) -> &'static str {
@@ -29,20 +31,29 @@ impl LatLons for param_set::LatLonGrid {
         }
 
         let ij = self.ij()?;
+        let angle_units = self.angle_unit() as f32;
         let lat = evenly_spaced_degrees(
             self.grid.first_point_lat as f32,
             self.grid.last_point_lat as f32,
             (self.grid.nj - 1) as usize,
+            angle_units,
         );
         let lon = evenly_spaced_longitudes(
             self.grid.first_point_lon,
             self.grid.last_point_lon,
             (self.grid.ni - 1) as usize,
+            angle_units,
             self.scanning_mode,
         );
 
         let iter = RegularGridIterator::new(lat, lon, ij);
         Ok(iter)
+    }
+}
+
+impl AngleUnit for param_set::LatLonGrid {
+    fn angle_unit(&self) -> f64 {
+        self.grid.angle_unit()
     }
 }
 

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -3,6 +3,7 @@ use crate::error::GribError;
 use crate::{
     GridPointIndex, LatLons,
     def::grib2::template::{Template3_20, param_set},
+    grid::AngleUnit,
 };
 
 impl crate::GridShortName for Template3_20 {
@@ -30,8 +31,9 @@ impl LatLons for Template3_20 {
         Self: 'a;
 
     fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
-        let lad = self.lad as f64 * 1e-6;
-        let lov = self.lov as f64 * 1e-6;
+        let angle_units = self.angle_unit();
+        let lad = self.lad as f64 * angle_units;
+        let lov = self.lov as f64 * angle_units;
         let (a, b) = self.earth_shape.radii().ok_or_else(|| {
             GribError::NotSupported(format!(
                 "unknown value of Code Table 3.2 (shape of the Earth): {}",
@@ -71,12 +73,18 @@ impl LatLons for Template3_20 {
         super::helpers::latlons_from_projection_definition_and_first_point(
             &proj_def,
             (
-                self.first_point_lat as f64 * 1e-6,
-                self.first_point_lon as f64 * 1e-6,
+                self.first_point_lat as f64 * angle_units,
+                self.first_point_lon as f64 * angle_units,
             ),
             (dx, dy),
             self.ij()?,
         )
+    }
+}
+
+impl AngleUnit for Template3_20 {
+    fn angle_unit(&self) -> f64 {
+        1e-6
     }
 }
 

--- a/src/grid/rotated_ll.rs
+++ b/src/grid/rotated_ll.rs
@@ -3,7 +3,7 @@ use crate::{
     GridPointIndex, LatLons,
     def::grib2::template::{Template3_1, param_set::Rotation},
     error::GribError,
-    grid::helpers::RegularGridIterator,
+    grid::{AngleUnit, helpers::RegularGridIterator},
 };
 
 impl crate::GridShortName for Template3_1 {
@@ -33,8 +33,18 @@ impl LatLons for Template3_1 {
         Self: 'a;
 
     fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
-        let iter = Unrotate::new(self.rotated.latlons_unchecked()?, &self.rotation);
+        let iter = Unrotate::new(
+            self.rotated.latlons_unchecked()?,
+            &self.rotation,
+            self.angle_unit() as f32,
+        );
         Ok(iter)
+    }
+}
+
+impl AngleUnit for Template3_1 {
+    fn angle_unit(&self) -> f64 {
+        self.rotated.grid.angle_unit()
     }
 }
 
@@ -48,10 +58,10 @@ pub struct Unrotate<I> {
 }
 
 impl<I> Unrotate<I> {
-    fn new(latlons: I, rot: &Rotation) -> Self {
-        let φp = (rot.south_pole_lat as f32 * 1e-6).to_radians();
-        let λp = (rot.south_pole_lon as f32 * 1e-6).to_radians();
-        let gamma = (rot.rot_angle * 1e-6).to_radians();
+    fn new(latlons: I, rot: &Rotation, angle_units: f32) -> Self {
+        let φp = (rot.south_pole_lat as f32 * angle_units).to_radians();
+        let λp = (rot.south_pole_lon as f32 * angle_units).to_radians();
+        let gamma = (rot.rot_angle * angle_units).to_radians();
 
         // south pole to north pole
         let φp = -φp;
@@ -111,7 +121,7 @@ mod tests {
             fn $name() {
                 let rot = $rot;
                 let latlons = vec![$input];
-                let mut iter = Unrotate::new(latlons.into_iter(), &rot);
+                let mut iter = Unrotate::new(latlons.into_iter(), &rot, 1e-6);
                 let actual = iter.next().unwrap();
                 let expected = $expected;
                 dbg!(actual);

--- a/src/grid/rotated_ll.rs
+++ b/src/grid/rotated_ll.rs
@@ -51,7 +51,7 @@ impl<I> Unrotate<I> {
     fn new(latlons: I, rot: &Rotation) -> Self {
         let φp = (rot.south_pole_lat as f32 * 1e-6).to_radians();
         let λp = (rot.south_pole_lon as f32 * 1e-6).to_radians();
-        let gamma = rot.rot_angle.to_radians();
+        let gamma = (rot.rot_angle * 1e-6).to_radians();
 
         // south pole to north pole
         let φp = -φp;


### PR DESCRIPTION
This PR corrects wrong multipliers used for latitudes and longitudes.

- A multiplier (usually $10^{-6}$) was not being applied to `def::grib2::template::param_set::Rotation::rot_angle`.
  The behavior has now been corrected for rotated latitude/longitude grids with that parameter being non-zero.
- The process to change the multiplier from $10^{-6}$ was missing
  when values were set for `initial_production_domain_basic_angle` and `basic_angle_subdivisions`
  in `def::grib2::template::param_set::Grid`.
  The behavior has been corrected
  for latitude/longitude, rotated latitude/longitude, and Gaussian latitude/longitude grids
  with `initial_production_domain_basic_angle` being non-zero.

Closes #170.