### PR TITLE
Consistency check between the number of grid points and the bit-map before decoding

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -185,11 +185,15 @@ impl Grib2SubmessageDecoder {
                 )));
             }
         };
-        let decoder = BitmapDecodeIterator::new(
-            self.sect6_bytes[6..].iter(),
-            decoder,
+
+        let bitmap_slice = &self.sect6_bytes[6..];
+        bitmap::check_consistency(
             self.num_points_total,
+            self.num_encoded_points(),
+            bitmap_slice,
         )?;
+        let decoder =
+            BitmapDecodeIterator::new(bitmap_slice.iter(), decoder, self.num_points_total);
         Ok(Grib2DecodedValues(decoder))
     }
 

--- a/src/decoder/bitmap.rs
+++ b/src/decoder/bitmap.rs
@@ -107,76 +107,76 @@ pub(crate) fn check_consistency(
 mod test {
     use super::*;
 
-    #[test]
-    fn bitmap_iterator_works() {
-        let bitmap = [0b01001100u8, 0b01110000, 0b11110000];
-        let values = (0..10).map(|n| n as f32).collect::<Vec<_>>();
-        let values = values.into_iter();
+    macro_rules! test_bitmap_iterator {
+        ($(($name:ident, $bitmap:expr, $values:expr, $len:expr, $expected:expr,),)*) => ($(
+            #[test]
+            fn $name() {
+                let iter = BitmapDecodeIterator::new($bitmap.iter(), $values.into_iter(), $len);
+                let actual = iter.collect::<Vec<_>>();
+                let expected = $expected;
 
-        let iter = BitmapDecodeIterator::new(bitmap.iter(), values, 24);
-        let actual = iter.collect::<Vec<_>>();
-        let expected = [
-            f32::NAN,
-            0.0,
-            f32::NAN,
-            f32::NAN,
-            1.0,
-            2.0,
-            f32::NAN,
-            f32::NAN,
-            f32::NAN,
-            3.0,
-            4.0,
-            5.0,
-            f32::NAN,
-            f32::NAN,
-            f32::NAN,
-            f32::NAN,
-            6.0,
-            7.0,
-            8.0,
-            9.0,
-            f32::NAN,
-            f32::NAN,
-            f32::NAN,
-            f32::NAN,
-        ];
-
-        assert_eq!(actual.len(), expected.len());
-        actual
-            .iter()
-            .zip(expected.iter())
-            .all(|(a, b)| (a.is_nan() && b.is_nan()) || (a == b));
+                assert_eq!(actual.len(), expected.len());
+                actual
+                    .iter()
+                    .zip(expected.iter())
+                    .all(|(a, b)| (a.is_nan() && b.is_nan()) || (a == b));
+            }
+        )*);
     }
 
-    #[test]
-    fn bitmap_iterator_length() {
-        let bitmap = [0b01001100u8, 0b01110000];
-        let values = (0..6).map(|n| n as f32).collect::<Vec<_>>();
-        let values = values.into_iter();
-
-        let iter = BitmapDecodeIterator::new(bitmap.iter(), values, 12);
-        let actual = iter.collect::<Vec<_>>();
-        let expected = [
-            f32::NAN,
-            0.0,
-            f32::NAN,
-            f32::NAN,
-            1.0,
-            2.0,
-            f32::NAN,
-            f32::NAN,
-            f32::NAN,
-            3.0,
-            4.0,
-            5.0,
-        ];
-
-        assert_eq!(actual.len(), expected.len());
-        actual
-            .iter()
-            .zip(expected.iter())
-            .all(|(a, b)| (a.is_nan() && b.is_nan()) || (a == b));
+    test_bitmap_iterator! {
+        (
+            bitmap_iterator_using_bitmap_without_padding,
+            [0b01001100u8, 0b01110000, 0b11110000],
+            (0..10).map(|n| n as f32).collect::<Vec<_>>(),
+            24,
+            [
+                f32::NAN,
+                0.0,
+                f32::NAN,
+                f32::NAN,
+                1.0,
+                2.0,
+                f32::NAN,
+                f32::NAN,
+                f32::NAN,
+                3.0,
+                4.0,
+                5.0,
+                f32::NAN,
+                f32::NAN,
+                f32::NAN,
+                f32::NAN,
+                6.0,
+                7.0,
+                8.0,
+                9.0,
+                f32::NAN,
+                f32::NAN,
+                f32::NAN,
+                f32::NAN,
+            ],
+        ),
+        (
+            bitmap_iterator_using_bitmap_with_padding,
+            [0b01001100u8, 0b01110000],
+            (0..6).map(|n| n as f32).collect::<Vec<_>>(),
+            12,
+            [
+                f32::NAN,
+                0.0,
+                f32::NAN,
+                f32::NAN,
+                1.0,
+                2.0,
+                f32::NAN,
+                f32::NAN,
+                f32::NAN,
+                3.0,
+                4.0,
+                5.0,
+            ],
+        ),
     }
 
     #[test]

--- a/src/decoder/bitmap.rs
+++ b/src/decoder/bitmap.rs
@@ -13,17 +13,13 @@ impl<'b, B, I> BitmapDecodeIterator<B, I>
 where
     B: Iterator<Item = &'b u8>,
 {
-    pub(crate) fn new(bitmap: B, values: I, len: usize) -> Result<Self, DecodeError> {
-        let (bitmap_len, _) = bitmap.size_hint();
-        if bitmap_len * 8 < len {
-            return Err(DecodeError::LengthMismatch);
-        }
-        Ok(Self {
+    pub(crate) fn new(bitmap: B, values: I, len: usize) -> Self {
+        Self {
             bitmap: bitmap.peekable(),
             values,
             len,
             offset: 0,
-        })
+        }
     }
 }
 
@@ -74,6 +70,39 @@ pub(crate) fn dummy_bitmap_for_nonnullable_data(num_points: usize) -> Vec<u8> {
     vec![0b11111111u8; size]
 }
 
+pub(crate) fn check_consistency(
+    num_points_total: usize,
+    num_points_encoded: usize,
+    bitmap: &[u8],
+) -> Result<(), DecodeError> {
+    let num_main_octets = num_points_total / 8;
+    let num_remaining_bits = num_points_total % 8;
+
+    let num_octets = if num_remaining_bits == 0 {
+        num_main_octets
+    } else {
+        num_main_octets + 1
+    };
+    if bitmap.len() < num_octets {
+        return Err(DecodeError::LengthMismatch);
+    }
+
+    let mut count = bitmap[0..num_main_octets]
+        .iter()
+        .map(|octet| octet.count_ones())
+        .sum::<u32>();
+    if num_remaining_bits != 0 {
+        count += (bitmap[num_main_octets] >> (8 - num_remaining_bits)).count_ones();
+    }
+    if count as usize == num_points_encoded {
+        Ok(())
+    } else {
+        Err(DecodeError::UnclassifiedError(
+            "inconsistent bitmap".to_owned(),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -84,7 +113,7 @@ mod test {
         let values = (0..10).map(|n| n as f32).collect::<Vec<_>>();
         let values = values.into_iter();
 
-        let iter = BitmapDecodeIterator::new(bitmap.iter(), values, 24).unwrap();
+        let iter = BitmapDecodeIterator::new(bitmap.iter(), values, 24);
         let actual = iter.collect::<Vec<_>>();
         let expected = [
             f32::NAN,
@@ -126,7 +155,7 @@ mod test {
         let values = (0..6).map(|n| n as f32).collect::<Vec<_>>();
         let values = values.into_iter();
 
-        let iter = BitmapDecodeIterator::new(bitmap.iter(), values, 12).unwrap();
+        let iter = BitmapDecodeIterator::new(bitmap.iter(), values, 12);
         let actual = iter.collect::<Vec<_>>();
         let expected = [
             f32::NAN,
@@ -156,10 +185,64 @@ mod test {
         let values = (0..10).map(|n| n as f32).collect::<Vec<_>>();
         let values = values.into_iter();
 
-        let mut iter = BitmapDecodeIterator::new(bitmap.iter(), values, 24).unwrap();
+        let mut iter = BitmapDecodeIterator::new(bitmap.iter(), values, 24);
 
         assert_eq!(iter.size_hint(), (24, Some(24)));
         let _ = iter.next();
         assert_eq!(iter.size_hint(), (23, Some(23)));
+    }
+
+    macro_rules! test_bitmap_consistency {
+        ($((
+            $name:ident,
+            $num_points_total:expr,
+            $num_points_encoded:expr,
+            $bitmap:expr,
+            $expected:expr,
+        ),)*) => ($(
+            #[test]
+            fn $name() {
+                let actual = check_consistency($num_points_total, $num_points_encoded, &$bitmap);
+                assert_eq!(actual, $expected);
+            }
+        )*);
+    }
+
+    test_bitmap_consistency! {
+        (
+            bitmap_is_too_short,
+            25,
+            10,
+            [0b01001100u8, 0b01110000, 0b11110000],
+            Err(DecodeError::LengthMismatch),
+        ),
+        (
+            num_points_is_divisible_by_8_and_bitmap_is_consistent,
+            24,
+            10,
+            [0b01001100u8, 0b01110000, 0b11110000],
+            Ok(()),
+        ),
+        (
+            num_points_is_divisible_by_8_and_bitmap_is_inconsistent,
+            24,
+            9,
+            [0b01001100u8, 0b01110000, 0b11110000],
+            Err(DecodeError::UnclassifiedError("inconsistent bitmap".to_owned())),
+        ),
+        (
+            num_points_is_not_divisible_by_8_and_bitmap_is_consistent,
+            17,
+            7,
+            [0b01001100u8, 0b01110000, 0b11110000],
+            Ok(()),
+        ),
+        (
+            num_points_is_not_divisible_by_8_and_bitmap_is_inconsistent,
+            17,
+            6,
+            [0b01001100u8, 0b01110000, 0b11110000],
+            Err(DecodeError::UnclassifiedError("inconsistent bitmap".to_owned())),
+        ),
     }
 }


### PR DESCRIPTION
This PR checks the consistency between the number of grid points and the bit-map before decoding.

#178 introduced an issue where the number of points becomes inconsistent in the generated data containing a bit-map, which has been fixed by #181.
Such issues in the data can be detected by the decoder's consistency check.
This PR provides the check.