### PR TITLE
Prefer rust-aec when both CCSDS backends are enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ For data using the following encoding methods, grid point values can be extracte
 
 For CCSDS/AEC decoding, `ccsds-unpack-with-libaec` uses `libaec` through
 `libaec-sys`, while `ccsds-unpack-with-rust-aec` uses a pure Rust backend.
-When both CCSDS backend features are enabled, `ccsds-unpack-with-libaec` keeps
-priority to preserve the existing default and all-features behavior.
+When both CCSDS backend features are enabled, `ccsds-unpack-with-rust-aec` takes
+priority so it can override the default `libaec` backend.
 
 ## Planned features
 

--- a/src/decoder/ccsds.rs
+++ b/src/decoder/ccsds.rs
@@ -228,18 +228,30 @@ mod tests {
         assert_eq!(rust_aec, libaec);
         Ok(())
     }
+
+    #[test]
+    #[cfg(all(
+        feature = "ccsds-unpack-with-libaec",
+        feature = "ccsds-unpack-with-rust-aec"
+    ))]
+    fn rust_aec_backend_takes_priority_when_both_features_are_enabled() {
+        let stream = backend::Stream::new(8, 8, 128, 0);
+
+        fn assert_rust_aec_stream(_: &rust_aec::Stream) {}
+        assert_rust_aec_stream(&stream);
+    }
 }
 
+#[cfg_attr(feature = "ccsds-unpack-with-rust-aec", allow(dead_code))]
 #[cfg(feature = "ccsds-unpack-with-libaec")]
 mod libaec;
-#[cfg_attr(feature = "ccsds-unpack-with-libaec", allow(dead_code))]
 #[cfg(feature = "ccsds-unpack-with-rust-aec")]
 mod rust_aec;
 
-#[cfg(feature = "ccsds-unpack-with-libaec")]
-use libaec as backend;
 #[cfg(all(
-    not(feature = "ccsds-unpack-with-libaec"),
-    feature = "ccsds-unpack-with-rust-aec"
+    feature = "ccsds-unpack-with-libaec",
+    not(feature = "ccsds-unpack-with-rust-aec")
 ))]
+use libaec as backend;
+#[cfg(feature = "ccsds-unpack-with-rust-aec")]
 use rust_aec as backend;


### PR DESCRIPTION
Closes #187.

Follow-up to #186

This changes the CCSDS backend selection so `ccsds-unpack-with-rust-aec` takes priority when both CCSDS backend features are enabled. That keeps existing `libaec` behavior for default-only users, while allowing users to keep default features and switch only Template 5.42 decoding with:

```
--features ccsds-unpack-with-rust-aec
```

Changes:
- Prefer the `rust-aec` backend when both CCSDS backend features are enabled.
- Keep `libaec` as the backend when only `ccsds-unpack-with-libaec` is enabled.
- Add a compile-time backend-priority regression test for the both-features case.
- Update README wording for the new priority policy.

Review before opening:
- Replaced an initial brittle type-name string assertion with a compile-time type check against `rust_aec::Stream`.

Verification:
- `cargo +nightly fmt --all -- --check`
- `cargo test -p grib --no-default-features --features ccsds-unpack-with-libaec,ccsds-unpack-with-rust-aec`
- `cargo +nightly clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo test -p grib --all-features`