### PR TITLE
Scale large simple packing ranges

### DIFF
--- a/src/decoder/complex.rs
+++ b/src/decoder/complex.rs
@@ -299,7 +299,7 @@ where
                 // associated field width is 0, and no incremental data are physically present."
                 let _ref = _ref.to_i32().unwrap();
                 let length = length.to_usize().unwrap();
-                let missing1 = (1 << self.num_bits) - 1;
+                let missing1 = ((1_u32 << self.num_bits) - 1) as i32;
                 let missing2 = missing1 - 1;
 
                 if self.missing_value_management > 0 && _ref == missing1 {
@@ -319,7 +319,7 @@ where
                 let bits = self.start_offset_bits + width * length;
                 let (pos_end, offset_bits) = (self.pos + bits / 8, bits % 8);
                 let offset_byte = usize::from(offset_bits > 0);
-                let missing1 = (1 << width) - 1;
+                let missing1 = (1_u32 << width) - 1;
                 let missing2 = missing1 - 1;
                 let group_values =
                     NBitwiseIterator::new(&self.data[self.pos..pos_end + offset_byte], width)

--- a/src/encoder/complex.rs
+++ b/src/encoder/complex.rs
@@ -588,6 +588,10 @@ mod tests {
             (2..5).map(|val| val as f64).collect::<Vec<_>>()
         ),
         (
+            grib2_coded_values_roundtrip_test_with_large_finite_range,
+            vec![0.0, 1.0e20]
+        ),
+        (
             grib2_coded_values_roundtrip_test_with_unique_values,
             vec![10.0_f64; 256]
         ),

--- a/src/encoder/simple.rs
+++ b/src/encoder/simple.rs
@@ -6,6 +6,9 @@ use crate::{
     encoder::{Encode, bitmap::Bitmap, helpers::BitsRequired, writer},
 };
 
+// Complex packing decodes group reference values as `i32`.
+const MAX_ENCODED_VALUE: u32 = i32::MAX as u32;
+
 /// Strategies applied when performing simple packing on numerical sequences.
 /// Simple packing is a method for discretizing continuous numerical values as
 /// integers, and various approaches can be taken during this process.
@@ -185,10 +188,14 @@ pub(crate) fn determine_simple_packing_params(
             num_bits: 0,
         }
     } else {
-        let range = max - min;
-        let exp = 0;
-        let num_bits = range.bits_required();
-        // TODO: if `num_bits` is too large, increase `exp` to reduce `num_bits`.
+        let max_diff = max - f64::from(ref_val);
+        let exp = if max_diff <= f64::from(MAX_ENCODED_VALUE) {
+            0
+        } else {
+            (max_diff / f64::from(MAX_ENCODED_VALUE)).log2().ceil() as i16
+        };
+        let max_code = (max_diff / 2_f64.powi(i32::from(exp))).round() as u32;
+        let num_bits = max_code.bits_required();
         SimplePacking {
             ref_val,
             exp,
@@ -273,6 +280,21 @@ mod tests {
                 num_bits: 0,
             },
         ),
+    }
+
+    #[test]
+    fn simple_packing_scales_large_finite_ranges_to_u32() -> Result<(), &'static str> {
+        let values = [0.0, 1.0e20];
+        let encoder = Encoder::new(&values, SimplePackingStrategy::Decimal(0));
+        let encoded = encoder.encode();
+
+        assert!(encoded.params().num_bits <= i32::BITS as u8);
+
+        let mut sect7 = vec![0; encoded.section7_len()];
+        let pos = encoded.write_section7(&mut sect7)?;
+        assert_eq!(pos, sect7.len());
+
+        Ok(())
     }
 
     macro_rules! grib2_coded_values_roundtrip_tests {


### PR DESCRIPTION
Fixes #189.

This scales wide ranges before writing values so the emitted codes stay within the range shared by simple and complex packing. It also makes the complex missing-value masks safe at the 31-bit boundary.

Added simple and complex packing regressions for `[0.0, 1.0e20]`.
