### PR TITLE
Add a pure Rust JPEG 2000 decoder backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,21 @@ jobs:
       - name: Run Rust AEC CCSDS tests
         run: cargo test --verbose -p grib --no-default-features --features ccsds-unpack-with-rust-aec
 
+  test_hayro_jpeg2000:
+    name: Test hayro JPEG 2000 backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run hayro JPEG 2000 tests
+        run: cargo test --verbose -p grib --no-default-features --features jpeg2000-unpack-with-hayro
+      - name: Verify hayro JPEG 2000 priority over OpenJPEG
+        run: cargo test --verbose -p grib --no-default-features --features jpeg2000-unpack-with-openjpeg,jpeg2000-unpack-with-hayro
+
   build_wasm:
     name: Building library for wasm
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ num_enum = "0.7"
 proj = { version = "0.31", optional = true }
 
 libaec-sys = { version = "0.1.1", optional = true }
+hayro-jpeg2000 = { version = "0.4", default-features = false, features = ["std", "simd"], optional = true }
 openjpeg-sys = { version = "1.0.5", optional = true }
 png = { version = "0.18", optional = true }
 rust-aec = { version = "0.1", optional = true }
@@ -64,6 +65,10 @@ default = [
 # Enable JPEG 2000 code stream format support in the GPV decoder with the help
 # of OpenJPEG written in C.
 jpeg2000-unpack-with-openjpeg = ["dep:openjpeg-sys"]
+
+# Enable JPEG 2000 code stream format support in the GPV decoder with the
+# experimental pure Rust hayro-jpeg2000 backend.
+jpeg2000-unpack-with-hayro = ["dep:hayro-jpeg2000"]
 
 # Enable Portable Network Graphics (PNG) support in the GPV decoder with the
 # help of png crate.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For data using the following encoding methods, grid point values can be extracte
 | 5.0 | simple packing ||
 | 5.2 | complex packing ||
 | 5.3 | complex packing and spatial differencing ||
-| 5.40 | JPEG 2000 code stream format | enabling feature `jpeg2000-unpack-with-openjpeg` required |
+| 5.40 | JPEG 2000 code stream format | enabling feature `jpeg2000-unpack-with-openjpeg` or `jpeg2000-unpack-with-hayro` required |
 | 5.41 | Portable Network Graphics (PNG) | enabling feature `png-unpack-with-png-crate` required |
 | 5.42 | CCSDS recommended lossless compression | enabling feature `ccsds-unpack-with-libaec` or `ccsds-unpack-with-rust-aec` required |
 | 5.200 | run length packing with level values ||
@@ -85,6 +85,10 @@ For CCSDS/AEC decoding, `ccsds-unpack-with-libaec` uses `libaec` through
 `libaec-sys`, while `ccsds-unpack-with-rust-aec` uses a pure Rust backend.
 When both CCSDS backend features are enabled, `ccsds-unpack-with-libaec` keeps
 priority to preserve the existing default and all-features behavior.
+
+For JPEG 2000 decoding, `jpeg2000-unpack-with-openjpeg` uses OpenJPEG through
+`openjpeg-sys`, while `jpeg2000-unpack-with-hayro` uses a pure Rust backend.
+When both JPEG 2000 backend features are enabled, hayro takes priority.
 
 ## Planned features
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -162,7 +162,10 @@ impl Grib2SubmessageDecoder {
             DataRepresentationTemplate::_5_3(template) => {
                 Grib2ValueIterator::SigSSCI(complex::ComplexSpatial(self, template).iter()?)
             }
-            #[cfg(feature = "jpeg2000-unpack-with-openjpeg")]
+            #[cfg(any(
+                feature = "jpeg2000-unpack-with-openjpeg",
+                feature = "jpeg2000-unpack-with-hayro"
+            ))]
             DataRepresentationTemplate::_5_40(template) => {
                 Grib2ValueIterator::SigSIm(jpeg2000::Jpeg2000(self, template).iter()?)
             }
@@ -292,7 +295,10 @@ enum Grib2ValueIterator<'d> {
     ),
     #[allow(dead_code)]
     SigSI(SimplePackingDecoder<IntoIter<i32>>),
-    #[cfg(feature = "jpeg2000-unpack-with-openjpeg")]
+    #[cfg(any(
+        feature = "jpeg2000-unpack-with-openjpeg",
+        feature = "jpeg2000-unpack-with-hayro"
+    ))]
     SigSIm(SimplePackingDecoder<self::jpeg2000::ImageIntoIter>),
     #[allow(dead_code)]
     SigSNV(SimplePackingDecoder<NBitwiseIterator<Vec<u8>>>),
@@ -308,7 +314,10 @@ impl<'d> Iterator for Grib2ValueIterator<'d> {
             Self::SigSC(inner) => inner.next(),
             Self::SigSSCI(inner) => inner.next(),
             Self::SigSI(inner) => inner.next(),
-            #[cfg(feature = "jpeg2000-unpack-with-openjpeg")]
+            #[cfg(any(
+                feature = "jpeg2000-unpack-with-openjpeg",
+                feature = "jpeg2000-unpack-with-hayro"
+            ))]
             Self::SigSIm(inner) => inner.next(),
             Self::SigSNV(inner) => inner.next(),
             Self::SigI(inner) => inner.next(),
@@ -321,7 +330,10 @@ impl<'d> Iterator for Grib2ValueIterator<'d> {
             Self::SigSC(inner) => inner.size_hint(),
             Self::SigSSCI(inner) => inner.size_hint(),
             Self::SigSI(inner) => inner.size_hint(),
-            #[cfg(feature = "jpeg2000-unpack-with-openjpeg")]
+            #[cfg(any(
+                feature = "jpeg2000-unpack-with-openjpeg",
+                feature = "jpeg2000-unpack-with-hayro"
+            ))]
             Self::SigSIm(inner) => inner.size_hint(),
             Self::SigSNV(inner) => inner.size_hint(),
             Self::SigI(inner) => inner.size_hint(),
@@ -364,7 +376,10 @@ mod bitmap;
 mod ccsds;
 mod complex;
 mod helpers;
-#[cfg(feature = "jpeg2000-unpack-with-openjpeg")]
+#[cfg(any(
+    feature = "jpeg2000-unpack-with-openjpeg",
+    feature = "jpeg2000-unpack-with-hayro"
+))]
 mod jpeg2000;
 #[cfg(feature = "png-unpack-with-png-crate")]
 mod png;

--- a/src/decoder/jpeg2000.rs
+++ b/src/decoder/jpeg2000.rs
@@ -1,10 +1,18 @@
+#[cfg(feature = "jpeg2000-unpack-with-hayro")]
+pub(crate) type ImageIntoIter = std::vec::IntoIter<i32>;
+#[cfg(all(
+    feature = "jpeg2000-unpack-with-openjpeg",
+    any(not(feature = "jpeg2000-unpack-with-hayro"), test)
+))]
+use self::decoder::DecodeParams;
+#[cfg(all(
+    not(feature = "jpeg2000-unpack-with-hayro"),
+    feature = "jpeg2000-unpack-with-openjpeg"
+))]
 pub(crate) use self::image::ImageIntoIter;
 use crate::{
     Grib2GpvUnpack,
-    decoder::{
-        DecodeError, Grib2SubmessageDecoder, jpeg2000::decoder::DecodeParams, simple::*,
-        stream::FixedValueIterator,
-    },
+    decoder::{DecodeError, Grib2SubmessageDecoder, simple::*, stream::FixedValueIterator},
 };
 
 pub(crate) struct Jpeg2000<'d>(
@@ -14,7 +22,7 @@ pub(crate) struct Jpeg2000<'d>(
 
 impl<'d> Grib2GpvUnpack for Jpeg2000<'d> {
     type Iter<'a>
-        = SimplePackingDecoder<Jpeg2000Iter>
+        = SimplePackingDecoder<ImageIntoIter>
     where
         Self: 'a;
 
@@ -32,16 +40,48 @@ impl<'d> Grib2GpvUnpack for Jpeg2000<'d> {
             return Ok(decoder);
         };
 
-        let jp2_unpacked = decode_j2k(target.sect7_payload())?;
-        let decoder = NonZeroSimplePackingDecoder::new(jp2_unpacked, &template.simple);
-        let decoder = SimplePackingDecoder::NonZeroLength(decoder);
-        Ok(decoder)
+        let unpacked = decode_j2k(target.sect7_payload())?;
+        let decoder = NonZeroSimplePackingDecoder::new(unpacked, &template.simple);
+        Ok(SimplePackingDecoder::NonZeroLength(decoder))
     }
 }
 
-type Jpeg2000Iter = ImageIntoIter;
+#[cfg(all(
+    feature = "jpeg2000-unpack-with-openjpeg",
+    any(not(feature = "jpeg2000-unpack-with-hayro"), test)
+))]
+mod decoder;
+#[cfg(feature = "jpeg2000-unpack-with-hayro")]
+mod hayro;
+#[cfg(all(
+    feature = "jpeg2000-unpack-with-openjpeg",
+    any(not(feature = "jpeg2000-unpack-with-hayro"), test)
+))]
+mod image;
+#[cfg(all(
+    feature = "jpeg2000-unpack-with-openjpeg",
+    any(not(feature = "jpeg2000-unpack-with-hayro"), test)
+))]
+mod stream;
 
-fn decode_j2k(bytes: &[u8]) -> Result<Jpeg2000Iter, DecodeError> {
+#[cfg(feature = "jpeg2000-unpack-with-hayro")]
+fn decode_j2k(bytes: &[u8]) -> Result<ImageIntoIter, DecodeError> {
+    hayro::decode_j2k(bytes)
+}
+
+#[cfg(all(
+    not(feature = "jpeg2000-unpack-with-hayro"),
+    feature = "jpeg2000-unpack-with-openjpeg"
+))]
+fn decode_j2k(bytes: &[u8]) -> Result<ImageIntoIter, DecodeError> {
+    decode_j2k_with_openjpeg(bytes)
+}
+
+#[cfg(all(
+    feature = "jpeg2000-unpack-with-openjpeg",
+    any(not(feature = "jpeg2000-unpack-with-hayro"), test)
+))]
+fn decode_j2k_with_openjpeg(bytes: &[u8]) -> Result<image::ImageIntoIter, DecodeError> {
     let stream = stream::Stream::from_bytes(bytes)?;
     let decoder = decoder::Decoder::new(stream)?;
     decoder.setup(DecodeParams::default())?;
@@ -51,6 +91,43 @@ fn decode_j2k(bytes: &[u8]) -> Result<Jpeg2000Iter, DecodeError> {
     image.try_into_iter()
 }
 
-mod decoder;
-mod image;
-mod stream;
+#[cfg(test)]
+mod tests {
+    #[cfg(all(
+        feature = "jpeg2000-unpack-with-hayro",
+        feature = "jpeg2000-unpack-with-openjpeg"
+    ))]
+    use std::{fs::File, io::BufReader};
+
+    #[cfg(all(
+        feature = "jpeg2000-unpack-with-hayro",
+        feature = "jpeg2000-unpack-with-openjpeg"
+    ))]
+    use super::{decode_j2k, decode_j2k_with_openjpeg, hayro};
+
+    #[test]
+    #[cfg(all(
+        feature = "jpeg2000-unpack-with-hayro",
+        feature = "jpeg2000-unpack-with-openjpeg"
+    ))]
+    fn hayro_has_priority_and_matches_openjpeg() -> Result<(), Box<dyn std::error::Error>> {
+        let f = File::open("testdata/CMC_glb_TMP_ISBL_1_latlon.24x.24_2021051800_P000.grib2")?;
+        let grib2 = crate::from_reader(BufReader::new(f))?;
+        let (_index, submessage) = grib2.iter().next().ok_or("GRIB file has no submessages")?;
+        let decoder = crate::Grib2SubmessageDecoder::from(submessage)?;
+        let payload = decoder.sect7_payload();
+
+        let openjpeg = decode_j2k_with_openjpeg(payload)
+            .map_err(|err| format!("{err:?}"))?
+            .collect::<Vec<_>>();
+        let hayro = hayro::decode_j2k(payload)
+            .map_err(|err| format!("{err:?}"))?
+            .collect::<Vec<_>>();
+        let selected: hayro::ImageIntoIter =
+            decode_j2k(payload).map_err(|err| format!("{err:?}"))?;
+
+        assert_eq!(hayro, openjpeg);
+        assert_eq!(selected.collect::<Vec<_>>(), hayro);
+        Ok(())
+    }
+}

--- a/src/decoder/jpeg2000/hayro.rs
+++ b/src/decoder/jpeg2000/hayro.rs
@@ -1,0 +1,38 @@
+use hayro_jpeg2000::{DecodeSettings, DecoderContext, Image};
+
+use crate::DecodeError;
+
+pub(crate) type ImageIntoIter = std::vec::IntoIter<i32>;
+
+pub(crate) fn decode_j2k(bytes: &[u8]) -> Result<ImageIntoIter, DecodeError> {
+    let image = Image::new(bytes, &DecodeSettings::default())
+        .map_err(|err| DecodeError::from(format!("parsing JPEG 2000 image failed: {err}")))?;
+    let mut context = DecoderContext::default();
+    let decoded = image
+        .decode(&mut context)
+        .map_err(|err| DecodeError::from(format!("decoding JPEG 2000 image failed: {err}")))?;
+    let [component] = decoded.components() else {
+        return Err(DecodeError::from(
+            "unexpected non-gray-scale image components",
+        ));
+    };
+
+    let samples = component
+        .samples()
+        .iter()
+        .map(|&sample| {
+            if !sample.is_finite()
+                || sample.fract() != 0.0
+                || sample < i32::MIN as f32
+                || sample >= i32::MAX as f32
+            {
+                return Err(DecodeError::from(
+                    "JPEG 2000 component contains an invalid integer sample",
+                ));
+            }
+            Ok(sample as i32)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(samples.into_iter())
+}

--- a/tests/jpeg2000_hayro.rs
+++ b/tests/jpeg2000_hayro.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "jpeg2000-unpack-with-hayro")]
+
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+};
+
+fn read_xz(path: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let f = File::open(path)?;
+    let f = BufReader::new(f);
+    let mut f = xz2::bufread::XzDecoder::new(f);
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+#[test]
+fn decodes_cmc_jpeg2000_values_within_one_ulp_of_wgrib2_fixture()
+-> Result<(), Box<dyn std::error::Error>> {
+    let f = File::open("testdata/CMC_glb_TMP_ISBL_1_latlon.24x.24_2021051800_P000.grib2")?;
+    let grib2 = grib::from_reader(BufReader::new(f))?;
+    let (_index, submessage) = grib2.iter().next().ok_or("GRIB file has no submessages")?;
+    let decoder = grib::Grib2SubmessageDecoder::from(submessage)?;
+
+    let actual = decoder.dispatch()?.collect::<Vec<_>>();
+    let expected = read_xz("testdata/gen/cmc-glb-wgrib2-le.bin.xz")?
+        .chunks_exact(4)
+        .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("four-byte float")))
+        .collect::<Vec<_>>();
+
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.into_iter().zip(expected).enumerate() {
+        let max_error = f32::EPSILON * expected.abs().max(1.0);
+        assert!(
+            (actual - expected).abs() <= max_error,
+            "decoded value differs at index {index}: {actual} != {expected}"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #191

Template 5.40 can now use `hayro-jpeg2000` through the opt-in `jpeg2000-unpack-with-hayro` feature. This gives consumers a pure Rust path while retaining OpenJPEG as the existing backend.

When both features are enabled, Hayro is selected. That makes the pure Rust feature usable without asking downstream users to turn off default features. The backend is checked against the CMC fixture, compared with OpenJPEG at the raw sample level, and covered in CI both alone and alongside OpenJPEG.

Checks run:

- `cargo test -p grib --no-default-features --features jpeg2000-unpack-with-hayro`
- `cargo test -p grib --no-default-features --features jpeg2000-unpack-with-openjpeg,jpeg2000-unpack-with-hayro`
- `cargo test --workspace`
- `cargo +nightly clippy --workspace -- -D warnings`
- `cargo +nightly fmt --all -- --check`