### PR TITLE
Make public enums extensible without breaking backward compatibility

### DIFF
--- a/grib-template-derive/tests/runner.rs
+++ b/grib-template-derive/tests/runner.rs
@@ -6,6 +6,7 @@ fn tests() {
     t.pass("tests/dump_for_option.rs");
     t.pass("tests/try_from_slice.rs");
     t.pass("tests/try_from_slice_standalone.rs");
+    t.pass("tests/try_from_slice_for_enum.rs");
     t.pass("tests/try_from_slice_for_option.rs");
     t.pass("tests/write_to_buffer.rs");
 }

--- a/grib-template-derive/tests/try_from_slice_for_enum.rs
+++ b/grib-template-derive/tests/try_from_slice_for_enum.rs
@@ -1,0 +1,75 @@
+use grib_template_helpers::TryFromSlice;
+
+#[derive(Debug, PartialEq, grib_template_derive::TryFromSlice)]
+pub struct StructWithExhaustiveEnum {
+    field1: u8,
+    #[grib_template(variant = "field1")]
+    field2: ExhaustiveEnum,
+}
+
+#[derive(Debug, PartialEq, grib_template_derive::TryFromSlice)]
+pub struct StructWithNonExhaustiveEnum {
+    field1: u8,
+    #[grib_template(variant = "field1")]
+    field2: NonExhaustiveEnum,
+}
+
+#[derive(Debug, PartialEq, grib_template_derive::TryFromSlice)]
+#[repr(u8)]
+pub enum ExhaustiveEnum {
+    Var1(EnumVar1) = 1,
+    Var2(EnumVar2) = 2,
+}
+
+#[derive(Debug, PartialEq, grib_template_derive::TryFromSlice)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum NonExhaustiveEnum {
+    Var1(EnumVar1) = 1,
+    Var2(EnumVar2) = 2,
+}
+
+#[derive(Debug, PartialEq, grib_template_derive::TryFromSlice)]
+pub struct EnumVar1 {
+    field1: u16,
+}
+
+#[derive(Debug, PartialEq, grib_template_derive::TryFromSlice)]
+pub struct EnumVar2 {
+    field1: i16,
+}
+
+macro_rules! test {
+    ($((
+        $buf:expr,
+        $ty:ident,
+        $expected:expr,
+    ),)*) => ($(
+        let buf: [u8; _] = $buf;
+        let mut pos = 0;
+        let actual = $ty::try_from_slice(&buf, &mut pos);
+        let expected = $expected;
+        assert_eq!(actual, expected);
+    )*);
+}
+
+fn main() {
+    test![
+        (
+            [0x02, 0x80, 0x02],
+            StructWithExhaustiveEnum,
+            Ok(StructWithExhaustiveEnum {
+                field1: 2,
+                field2: ExhaustiveEnum::Var2(EnumVar2 { field1: -0x0002 }),
+            }),
+        ),
+        (
+            [0x02, 0x80, 0x02],
+            StructWithNonExhaustiveEnum,
+            Ok(StructWithNonExhaustiveEnum {
+                field1: 2,
+                field2: NonExhaustiveEnum::Var2(EnumVar2 { field1: -0x0002 }),
+            }),
+        ),
+    ];
+}

--- a/src/codetables/grib2.rs
+++ b/src/codetables/grib2.rs
@@ -1,6 +1,7 @@
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum Table1_2 {
     Analysis = 0,
@@ -13,6 +14,7 @@ pub enum Table1_2 {
 }
 
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum Table4_4 {
     Minute = 0,
@@ -51,6 +53,7 @@ impl Table4_4 {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum Table5_6 {
     FirstOrderSpatialDifferencing = 1,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -327,6 +327,7 @@ impl<'d> Iterator for Grib2ValueIterator<'d> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum DecodeError {
     NotSupported(&'static str, u16),
     LengthMismatch,

--- a/src/def/grib2.rs
+++ b/src/def/grib2.rs
@@ -74,6 +74,7 @@ pub struct Section1PayloadOptional {
 }
 
 #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[non_exhaustive]
 #[repr(u16)]
 pub enum IdentificationTemplate {
     _1_0(template1::Template1_0) = 0,
@@ -103,6 +104,7 @@ pub struct Section3Payload {
 }
 
 #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[non_exhaustive]
 #[repr(u16)]
 pub enum GridDefinitionTemplate {
     _3_0(template3::Template3_0) = 0,
@@ -143,6 +145,7 @@ pub struct Section5Payload {
 }
 
 #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[non_exhaustive]
 #[repr(u16)]
 pub enum DataRepresentationTemplate {
     _5_0(template5::Template5_0) = 0,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -25,6 +25,7 @@ pub fn encode_gpv(data: &[f64], method: EncodingMethod) -> EncodeOutput {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum EncodingMethod {
     /// Simple packing.
     SimplePacking(SimplePackingStrategy),
@@ -100,6 +101,7 @@ impl WriteGrib2DataSections for EncodeOutput {
     }
 }
 
+#[non_exhaustive]
 pub enum EncodeOutputParams<'a> {
     SimplePacking(&'a param_set::SimplePacking),
     ComplexPacking(&'a param_set::SimplePacking, &'a param_set::ComplexPacking),

--- a/src/encoder/complex.rs
+++ b/src/encoder/complex.rs
@@ -11,6 +11,7 @@ use crate::{
 /// and efficiently compresses each group to improve the overall compression
 /// ratio of the data.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum ComplexPackingStrategy {
     /// A strategy that pre-reads a specified number of elements to determine
     /// whether to add an element to the current group.
@@ -18,6 +19,7 @@ pub enum ComplexPackingStrategy {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum SpatialDifferencingOption {
     None,
 }

--- a/src/encoder/simple.rs
+++ b/src/encoder/simple.rs
@@ -10,6 +10,7 @@ use crate::{
 /// Simple packing is a method for discretizing continuous numerical values as
 /// integers, and various approaches can be taken during this process.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum SimplePackingStrategy {
     /// A strategy specifying how many decimal places to consider valid for the
     /// numbers. This strategy is effective for various types of data, such as

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::decoder::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum GribError {
     InternalDataError,
     ParseError(ParseError),
@@ -54,6 +55,7 @@ impl Display for GribError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ParseError {
     ReadError(String),
     #[deprecated(
@@ -112,6 +114,7 @@ impl From<BuildError> for ParseError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum BuildError {
     SectionSizeTooSmall(usize),
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum GridDefinitionTemplateValues {
     Template0(Template3_0),
     Template1(Template3_1),


### PR DESCRIPTION
This PR allows variants to be added to public enums without breaking backward compatibility.

### Motivation

Adding variants to a Rust enum is typically treated as a backward-incompatible change, because pattern-matching code that includes all variant patterns as arms will no longer work.
However, for enums with the `non_exhaustive` attribute, users are required to include a wildcard arm in their pattern matches, so adding variants does not result in a backward-incompatible change.

This PR reduces the likelihood of changes that break backward compatibility by applying the `non_exhaustive` attribute to enums where variants may be added later.
Such enums include error types, supported templates, and user options.