### PR TITLE
Follow-ups to the encoder API enhancements

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,7 @@
 use std::cell::{Ref, RefCell};
 
 pub use complex::*;
+pub use grid::*;
 pub use message::*;
 pub use simple::*;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,3 +1,81 @@
+//! GRIB2 data encoder.
+//!
+//! # The complexity of GRIB2
+//!
+//! GRIB2 is a data format specifically designed to store grid-point values
+//! related to meteorological data. Therefore, it is easy to imagine that, in
+//! addition to the values at each grid point, information such as the latitude
+//! and longitude of each point, the date and time, and meteorological elements
+//! must also be included as metadata. Furthermore, even for grid-point values
+//! represented as arrays of real numbers, GRIB2 generally does not store
+//! floating-point values as-is. Instead, the values are rounded based on their
+//! precision and then compressed and stored as an array of integers--that is,
+//! discrete numerical values.
+//!
+//! Consequently, unlike highly versatile formats such as NetCDF and HDF, which
+//! allow for the flexible serialization of large amounts of numerical data, or
+//! Gzip and Xz, which can freely compress arbitrary data, GRIB2 is a format
+//! with specific constraints. On the other hand, GRIB2 is a format whose
+//! specifications prevent situations where "a value has been obtained but its
+//! meaning is unclear." It can also be described as a format capable of
+//! "representing" meteorological data by incorporating not only raw numerical
+//! values but also the complexities of the real world, such as missing values
+//! and precision information.
+//!
+//! # Goal of this module
+//!
+//! The goal of this module is to enable users to create GRIB2 data--which
+//! has many parameters and some configurable options within its
+//! constraints--using an API that is as user-friendly as possible (although
+//! some parts are currently not user-friendly).
+//!
+//! Internally, a single GRIB2 dataset (message) is composed of a collection of
+//! blocks called "sections." However, this module's high-level API avoids using
+//! the term "section" and instead focuses on "what information needs to be
+//! configured" and "how you want to represent the meteorological data."
+//!
+//! # High-level and low-level APIs
+//!
+//! This module provides 3 structs: [`SingleGrib2Message`],
+//! [`MultiGridGrib2Message`], and [`MultiProductGrib2Message`]. By providing
+//! all the necessary information to these structs (which may be a bit of a
+//! challenge), you can create GRIB2 messages. These structs constitute a
+//! high-level API designed to accommodate the most common use cases.
+//! If your use case does not fit these scenarios, you will need to implement
+//! the low-level API [`WriteGrib2Message`] and its sub-traits:
+//! [`WriteGrib2MessageIterL1`], [`WriteGrib2MessageIterL2`], and
+//! [`WriteGrib2MessageIterL3`].
+//!
+//! # Generating data sets comprising multiple elements
+//!
+//! It is rare to have only one type of grid point value data for a given time
+//! that you want to generate and provide. As shown below, in many cases, you
+//! will likely want to generate and provide multiple types of grid point value
+//! data together.
+//!
+//! - Different meteorological elements (temperature, pressure, humidity, wind
+//!   speed in 2 directions)
+//! - Different forecast times (1 hour later, 2 hours later, 3 hours later)
+//! - Different altitude levels (1000 hPa, 925 hPa, 850 hPa)
+//!
+//! We will refer to this type of data here as "data sets comprising multiple
+//! elements." The term "element" here is used in a general sense and is not
+//! limited to meteorological elements.
+//!
+//! When representing data sets comprising multiple elements in GRIB2, there are
+//! 2 main options, or 3 when broken down in detail:
+//!
+//! - A. Include them in a single message
+//! - B. Create separate messages (but store them in a single file)
+//! - C. Create separate messages (and store them in separate files)
+//!
+//! If you wish to use option A, use [`MultiGridGrib2Message`] or
+//! [`MultiProductGrib2Message`] (or the low-level API) to include the set of
+//! multiple elements in a single message. If you want to implement options B or
+//! C, simply use [`SingleGrib2Message`] for each element. You can implement
+//! option B by writing to the same output destination consecutively, and option
+//! C by writing to separate output destinations.
+
 use std::cell::{Ref, RefCell};
 
 pub use complex::*;

--- a/src/encoder/complex.rs
+++ b/src/encoder/complex.rs
@@ -1,7 +1,10 @@
 use crate::{
-    SimplePackingStrategy, WriteGrib2DataSections, WriteToBuffer,
+    WriteToBuffer,
     def::grib2::template::param_set::{ComplexPacking, SimplePacking},
-    encoder::{Encode, bitmap::Bitmap, helpers::BitsRequired, writer},
+    encoder::{
+        Encode, SimplePackingStrategy, WriteGrib2DataSections, bitmap::Bitmap,
+        helpers::BitsRequired, writer,
+    },
 };
 
 /// Strategies applied when performing complex packing on numerical sequences.

--- a/src/encoder/message.rs
+++ b/src/encoder/message.rs
@@ -159,6 +159,121 @@ pub trait WriteGrib2MessageIterL3 {
 
 /// A functionality to write the byte sequence of Section 1 (Identification
 /// Section) of a GRIB2 message.
+///
+/// # Examples
+///
+/// This trait is implemented for the payload struct of Section 1
+/// ([`def::grib2::Section1Payload`](crate::def::grib2::Section1Payload)).
+///
+/// ```
+/// use grib::{TryFromSlice, def::grib2, encoder::WriteGrib2Ident};
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let sect = grib2::Section1 {
+///         header: grib2::SectionHeader {
+///             len: 21,
+///             sect_num: 1,
+///         },
+///         payload: grib2::Section1Payload {
+///             centre_id: 0xffff,
+///             subcentre_id: 0,
+///             master_table_version: 29,
+///             local_table_version: 0,
+///             ref_time_significance: 0,
+///             ref_time: grib2::RefTime {
+///                 year: 2026,
+///                 month: 1,
+///                 day: 2,
+///                 hour: 3,
+///                 minute: 4,
+///                 second: 5,
+///             },
+///             prod_status: 0,
+///             data_type: 0,
+///             optional: None,
+///         },
+///     };
+///     let mut buf = vec![0; sect.payload.section1_len()];
+///     sect.payload.write_section1(&mut buf)?;
+///     let decoded = grib2::Section1::try_from_slice(&buf, &mut 0);
+///     assert_eq!(decoded, Ok(sect));
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// This trait is also implemented for the byte sequence of the payload of
+/// Section 1.
+///
+/// ```
+/// use grib::{TryFromSlice, def::grib2, encoder::WriteGrib2Ident};
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut input = [
+///         0xff, 0xff, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x07, 0xea, 0x01, 0x02, 0x03, 0x04, 0x05,
+///         0x00, 0x00,
+///     ];
+///     let mut buf = vec![0; input.section1_len()];
+///     input.write_section1(&mut buf)?;
+///
+///     // The output is simply the input byte sequence with a section header appended to it.
+///     assert_eq!(&buf[5..], input);
+///
+///     let decoded = grib2::Section1::try_from_slice(&buf, &mut 0);
+///     let expected = Ok(grib2::Section1 {
+///         header: grib2::SectionHeader {
+///             len: 21,
+///             sect_num: 1,
+///         },
+///         payload: grib2::Section1Payload {
+///             centre_id: 0xffff,
+///             subcentre_id: 0,
+///             master_table_version: 29,
+///             local_table_version: 0,
+///             ref_time_significance: 0,
+///             ref_time: grib2::RefTime {
+///                 year: 2026,
+///                 month: 1,
+///                 day: 2,
+///                 hour: 3,
+///                 minute: 4,
+///                 second: 5,
+///             },
+///             prod_status: 0,
+///             data_type: 0,
+///             optional: None,
+///         },
+///     });
+///     assert_eq!(decoded, expected);
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// Since no constraints can be placed on the byte sequence, `write_section1`
+/// can, of course, be executed on any byte sequence; however, if it is executed
+/// on an inappropriate byte sequence, the resulting byte sequence will not be
+/// correctly interpreted as Section 1.
+///
+/// ```
+/// use grib::{TryFromSlice, def::grib2, encoder::WriteGrib2Ident};
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut input = [0xff, 0xff];
+///     let mut buf = vec![0; input.section1_len()];
+///     input.write_section1(&mut buf)?;
+///
+///     // The output is simply the input byte sequence with a section header appended to it.
+///     assert_eq!(&buf[5..], input);
+///
+///     // The output cannot be correctly interpreted as Section 1.
+///     let decoded = grib2::Section1::try_from_slice(&buf, &mut 0);
+///     let expected = Err("slice length is too short");
+///     assert_eq!(decoded, expected);
+///
+///     Ok(())
+/// }
+/// ```
 pub trait WriteGrib2Ident {
     fn section1_len(&self) -> usize;
 

--- a/src/encoder/message.rs
+++ b/src/encoder/message.rs
@@ -1,12 +1,9 @@
-mod multigrid;
-mod multiproduct;
-mod single;
-
 pub use multigrid::*;
 pub use multiproduct::*;
 pub use single::*;
 
-use crate::{Encoder, WriteToBuffer};
+use super::Encoder;
+use crate::WriteToBuffer;
 
 const SECT0_LEN: usize = 16;
 
@@ -365,3 +362,7 @@ mod tests {
         Ok(())
     }
 }
+
+mod multigrid;
+mod multiproduct;
+mod single;

--- a/src/encoder/message.rs
+++ b/src/encoder/message.rs
@@ -12,7 +12,7 @@ pub trait WriteGrib2Message {
     where
         Self: 'a;
 
-    type Item<'a>: WriteGrib2SubmessageL1
+    type Item<'a>: WriteGrib2MessageIterL1
     where
         Self: 'a;
 
@@ -56,12 +56,12 @@ pub trait WriteGrib2Message {
     }
 }
 
-pub trait WriteGrib2SubmessageL1 {
+pub trait WriteGrib2MessageIterL1 {
     type S2<'a>: WriteGrib2LocalUse
     where
         Self: 'a;
 
-    type Item<'a>: WriteGrib2SubmessageL2
+    type Item<'a>: WriteGrib2MessageIterL2
     where
         Self: 'a;
 
@@ -89,12 +89,12 @@ pub trait WriteGrib2SubmessageL1 {
     }
 }
 
-pub trait WriteGrib2SubmessageL2 {
+pub trait WriteGrib2MessageIterL2 {
     type S3<'a>: WriteGrib2GridDef
     where
         Self: 'a;
 
-    type Item<'a>: WriteGrib2SubmessageL3
+    type Item<'a>: WriteGrib2MessageIterL3
     where
         Self: 'a;
 
@@ -119,7 +119,7 @@ pub trait WriteGrib2SubmessageL2 {
     }
 }
 
-pub trait WriteGrib2SubmessageL3 {
+pub trait WriteGrib2MessageIterL3 {
     type S4<'a>: WriteGrib2ProductDef
     where
         Self: 'a;
@@ -301,7 +301,7 @@ pub(crate) fn write_section_header(
     crate::def::grib2::SectionHeader { len, sect_num }.write_to_buffer(buf)
 }
 
-impl<'a, 'd, P> WriteGrib2SubmessageL3 for (&'a P, &'a Encoder<'d>)
+impl<'a, 'd, P> WriteGrib2MessageIterL3 for (&'a P, &'a Encoder<'d>)
 where
     P: WriteGrib2ProductDef,
 {

--- a/src/encoder/message.rs
+++ b/src/encoder/message.rs
@@ -7,6 +7,9 @@ use crate::WriteToBuffer;
 
 const SECT0_LEN: usize = 16;
 
+/// A functionality to write an entire GRIB2 message. This trait works in
+/// conjunction with [`WriteGrib2MessageIterL1`], [`WriteGrib2MessageIterL2`],
+/// and [`WriteGrib2MessageIterL3`] to write the message.
 pub trait WriteGrib2Message {
     type S1<'a>: WriteGrib2Ident
     where
@@ -56,6 +59,10 @@ pub trait WriteGrib2Message {
     }
 }
 
+/// A functionality to write elements of the L1 iterator in a GRIB2 message.
+/// This trait works in conjunction with [`WriteGrib2Message`],
+/// [`WriteGrib2MessageIterL2`], and [`WriteGrib2MessageIterL3`] to write the
+/// message.
 pub trait WriteGrib2MessageIterL1 {
     type S2<'a>: WriteGrib2LocalUse
     where
@@ -89,6 +96,10 @@ pub trait WriteGrib2MessageIterL1 {
     }
 }
 
+/// A functionality to write elements of the L2 iterator in a GRIB2 message.
+/// This trait works in conjunction with [`WriteGrib2Message`],
+/// [`WriteGrib2MessageIterL1`], and [`WriteGrib2MessageIterL3`] to write the
+/// message.
 pub trait WriteGrib2MessageIterL2 {
     type S3<'a>: WriteGrib2GridDef
     where
@@ -119,6 +130,10 @@ pub trait WriteGrib2MessageIterL2 {
     }
 }
 
+/// A functionality to write elements of the L3 iterator in a GRIB2 message.
+/// This trait works in conjunction with [`WriteGrib2Message`],
+/// [`WriteGrib2MessageIterL1`], and [`WriteGrib2MessageIterL2`] to write the
+/// message.
 pub trait WriteGrib2MessageIterL3 {
     type S4<'a>: WriteGrib2ProductDef
     where
@@ -142,30 +157,41 @@ pub trait WriteGrib2MessageIterL3 {
     }
 }
 
+/// A functionality to write the byte sequence of Section 1 (Identification
+/// Section) of a GRIB2 message.
 pub trait WriteGrib2Ident {
     fn section1_len(&self) -> usize;
 
     fn write_section1(&self, buf: &mut [u8]) -> Result<usize, &'static str>;
 }
 
+/// A functionality to write the byte sequence of Section 2 (Local Use Section)
+/// of a GRIB2 message.
 pub trait WriteGrib2LocalUse {
     fn section2_len(&self) -> usize;
 
     fn write_section2(&self, buf: &mut [u8]) -> Result<usize, &'static str>;
 }
 
+/// A functionality to write the byte sequence of Section 3 (Grid Definition
+/// Section) of a GRIB2 message.
 pub trait WriteGrib2GridDef {
     fn section3_len(&self) -> usize;
 
     fn write_section3(&self, buf: &mut [u8]) -> Result<usize, &'static str>;
 }
 
+/// A functionality to write the byte sequence of Section 4 (Product Definition
+/// Section) of a GRIB2 message.
 pub trait WriteGrib2ProductDef {
     fn section4_len(&self) -> usize;
 
     fn write_section4(&self, buf: &mut [u8]) -> Result<usize, &'static str>;
 }
 
+/// A functionality to write the byte sequence of Section 5 (Data
+/// Representation Section), Section 6 (Bit-map section), and Section 7 (Data
+/// Section) of a GRIB2 message.
 pub trait WriteGrib2PointValues {
     fn data_sections_len(&self) -> usize;
 

--- a/src/encoder/message/multigrid.rs
+++ b/src/encoder/message/multigrid.rs
@@ -2,7 +2,7 @@ use std::iter::{Once, once};
 
 use super::{
     Encoder, WriteGrib2GridDef, WriteGrib2Ident, WriteGrib2LocalUse, WriteGrib2Message,
-    WriteGrib2ProductDef, WriteGrib2SubmessageL1, WriteGrib2SubmessageL2,
+    WriteGrib2MessageIterL1, WriteGrib2MessageIterL2, WriteGrib2ProductDef,
 };
 
 pub struct MultiGridGrib2Message<'d, I, L, G, P> {
@@ -63,7 +63,7 @@ where
     }
 }
 
-impl<'a, 'd, L, G, P> WriteGrib2SubmessageL1 for (&'a Option<L>, &'a Vec<(G, P, Encoder<'d>)>)
+impl<'a, 'd, L, G, P> WriteGrib2MessageIterL1 for (&'a Option<L>, &'a Vec<(G, P, Encoder<'d>)>)
 where
     L: WriteGrib2LocalUse,
     G: WriteGrib2GridDef,
@@ -93,7 +93,7 @@ where
     }
 }
 
-impl<'a, 'd, G, P> WriteGrib2SubmessageL2 for &'a (G, P, Encoder<'d>)
+impl<'a, 'd, G, P> WriteGrib2MessageIterL2 for &'a (G, P, Encoder<'d>)
 where
     G: WriteGrib2GridDef,
     P: WriteGrib2ProductDef,

--- a/src/encoder/message/multigrid.rs
+++ b/src/encoder/message/multigrid.rs
@@ -5,6 +5,8 @@ use super::{
     WriteGrib2MessageIterL1, WriteGrib2MessageIterL2, WriteGrib2ProductDef,
 };
 
+/// A writer for GRIB2 messages containing multiple submessages with different
+/// grids.
 pub struct MultiGridGrib2Message<'d, I, L, G, P> {
     discipline: u8,
     ident: I,

--- a/src/encoder/message/multigrid.rs
+++ b/src/encoder/message/multigrid.rs
@@ -1,6 +1,6 @@
 use std::iter::{Once, once};
 
-use crate::{
+use super::{
     Encoder, WriteGrib2GridDef, WriteGrib2Ident, WriteGrib2LocalUse, WriteGrib2Message,
     WriteGrib2ProductDef, WriteGrib2SubmessageL1, WriteGrib2SubmessageL2,
 };

--- a/src/encoder/message/multiproduct.rs
+++ b/src/encoder/message/multiproduct.rs
@@ -1,6 +1,6 @@
 use std::iter::{Once, once};
 
-use crate::{
+use super::{
     Encoder, WriteGrib2GridDef, WriteGrib2Ident, WriteGrib2LocalUse, WriteGrib2Message,
     WriteGrib2ProductDef, WriteGrib2SubmessageL1, WriteGrib2SubmessageL2, WriteGrib2SubmessageL3,
 };

--- a/src/encoder/message/multiproduct.rs
+++ b/src/encoder/message/multiproduct.rs
@@ -2,7 +2,8 @@ use std::iter::{Once, once};
 
 use super::{
     Encoder, WriteGrib2GridDef, WriteGrib2Ident, WriteGrib2LocalUse, WriteGrib2Message,
-    WriteGrib2ProductDef, WriteGrib2SubmessageL1, WriteGrib2SubmessageL2, WriteGrib2SubmessageL3,
+    WriteGrib2MessageIterL1, WriteGrib2MessageIterL2, WriteGrib2MessageIterL3,
+    WriteGrib2ProductDef,
 };
 
 pub struct MultiProductGrib2Message<'d, I, L, G, P> {
@@ -66,7 +67,7 @@ where
     }
 }
 
-impl<'a, 'd, L, G, P> WriteGrib2SubmessageL1 for (&'a Option<L>, &'a G, &'a Vec<(P, Encoder<'d>)>)
+impl<'a, 'd, L, G, P> WriteGrib2MessageIterL1 for (&'a Option<L>, &'a G, &'a Vec<(P, Encoder<'d>)>)
 where
     L: WriteGrib2LocalUse,
     G: WriteGrib2GridDef,
@@ -96,7 +97,7 @@ where
     }
 }
 
-impl<'a, 'd, G, P> WriteGrib2SubmessageL2 for (&'a G, &'a Vec<(P, Encoder<'d>)>)
+impl<'a, 'd, G, P> WriteGrib2MessageIterL2 for (&'a G, &'a Vec<(P, Encoder<'d>)>)
 where
     G: WriteGrib2GridDef,
     P: WriteGrib2ProductDef,
@@ -125,7 +126,7 @@ where
     }
 }
 
-impl<'d, P> WriteGrib2SubmessageL3 for &(P, Encoder<'d>)
+impl<'d, P> WriteGrib2MessageIterL3 for &(P, Encoder<'d>)
 where
     P: WriteGrib2ProductDef,
 {

--- a/src/encoder/message/multiproduct.rs
+++ b/src/encoder/message/multiproduct.rs
@@ -6,6 +6,8 @@ use super::{
     WriteGrib2ProductDef,
 };
 
+/// A writer for GRIB2 messages containing multiple submessages that share a
+/// grid.
 pub struct MultiProductGrib2Message<'d, I, L, G, P> {
     pub(crate) discipline: u8,
     pub(crate) ident: I,

--- a/src/encoder/message/single.rs
+++ b/src/encoder/message/single.rs
@@ -5,6 +5,7 @@ use super::{
     WriteGrib2MessageIterL1, WriteGrib2MessageIterL2, WriteGrib2ProductDef,
 };
 
+/// A writer for GRIB2 messages that contain only one submessage.
 pub struct SingleGrib2Message<'d, I, L, G, P> {
     pub(crate) discipline: u8,
     pub(crate) ident: I,

--- a/src/encoder/message/single.rs
+++ b/src/encoder/message/single.rs
@@ -2,7 +2,7 @@ use std::iter::{Once, once};
 
 use super::{
     Encoder, WriteGrib2GridDef, WriteGrib2Ident, WriteGrib2LocalUse, WriteGrib2Message,
-    WriteGrib2ProductDef, WriteGrib2SubmessageL1, WriteGrib2SubmessageL2,
+    WriteGrib2MessageIterL1, WriteGrib2MessageIterL2, WriteGrib2ProductDef,
 };
 
 pub struct SingleGrib2Message<'d, I, L, G, P> {
@@ -69,7 +69,7 @@ where
     }
 }
 
-impl<'a, 'd, L, G, P> WriteGrib2SubmessageL1 for (&'a Option<L>, &'a G, &'a P, &'a Encoder<'d>)
+impl<'a, 'd, L, G, P> WriteGrib2MessageIterL1 for (&'a Option<L>, &'a G, &'a P, &'a Encoder<'d>)
 where
     L: WriteGrib2LocalUse,
     G: WriteGrib2GridDef,
@@ -99,7 +99,7 @@ where
     }
 }
 
-impl<'a, 'd, G, P> WriteGrib2SubmessageL2 for (&'a G, &'a P, &'a Encoder<'d>)
+impl<'a, 'd, G, P> WriteGrib2MessageIterL2 for (&'a G, &'a P, &'a Encoder<'d>)
 where
     G: WriteGrib2GridDef,
     P: WriteGrib2ProductDef,

--- a/src/encoder/message/single.rs
+++ b/src/encoder/message/single.rs
@@ -1,6 +1,6 @@
 use std::iter::{Once, once};
 
-use crate::{
+use super::{
     Encoder, WriteGrib2GridDef, WriteGrib2Ident, WriteGrib2LocalUse, WriteGrib2Message,
     WriteGrib2ProductDef, WriteGrib2SubmessageL1, WriteGrib2SubmessageL2,
 };

--- a/src/encoder/message/single.rs
+++ b/src/encoder/message/single.rs
@@ -5,7 +5,7 @@ use crate::{
     WriteGrib2ProductDef, WriteGrib2SubmessageL1, WriteGrib2SubmessageL2,
 };
 
-pub struct Single<'d, I, L, G, P> {
+pub struct SingleGrib2Message<'d, I, L, G, P> {
     pub(crate) discipline: u8,
     pub(crate) ident: I,
     pub(crate) local_use: Option<L>,
@@ -14,7 +14,7 @@ pub struct Single<'d, I, L, G, P> {
     pub(crate) values: Encoder<'d>,
 }
 
-impl<'d, I, L, G, P> Single<'d, I, L, G, P> {
+impl<'d, I, L, G, P> SingleGrib2Message<'d, I, L, G, P> {
     pub fn new(
         discipline: u8,
         ident: I,
@@ -34,7 +34,7 @@ impl<'d, I, L, G, P> Single<'d, I, L, G, P> {
     }
 }
 
-impl<'d, I, L, G, P> WriteGrib2Message for Single<'d, I, L, G, P>
+impl<'d, I, L, G, P> WriteGrib2Message for SingleGrib2Message<'d, I, L, G, P>
 where
     I: WriteGrib2Ident,
     L: WriteGrib2LocalUse,

--- a/src/encoder/simple.rs
+++ b/src/encoder/simple.rs
@@ -1,7 +1,7 @@
 use crate::{
-    WriteGrib2DataSections, WriteToBuffer,
+    WriteToBuffer,
     def::grib2::template::param_set::SimplePacking,
-    encoder::{Encode, bitmap::Bitmap, helpers::BitsRequired, writer},
+    encoder::{Encode, WriteGrib2DataSections, bitmap::Bitmap, helpers::BitsRequired, writer},
 };
 
 /// Strategies applied when performing simple packing on numerical sequences.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod cookbook;
 mod datatypes;
 mod decoder;
 pub mod def;
-mod encoder;
+pub mod encoder;
 mod error;
 mod grid;
 mod helpers;
@@ -25,7 +25,6 @@ pub use crate::{
     context::*,
     datatypes::*,
     decoder::*,
-    encoder::*,
     error::*,
     grid::{
         GridDefinitionTemplateValues, GridPointIndex, GridPointIndexIterator, GridPointLatLons,


### PR DESCRIPTION
This PR provides follow-ups to the encoder API enhancements (#199 and #200), including trait naming improvements, the documentation, examples, and corrections.
In addition, to avoid namespace clutter, this PR separates the encoder API from the main module into a separate `encoder` module.