### PR TITLE
grib-template-derive: enable overriding the description of each field when dumping

### DIFF
--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -46,9 +46,11 @@ pub(crate) fn impl_for_struct(
         let ident = field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        let doc = get_doc(&field.attrs)
-            .map(|s| format!("  // {}", s.trim()))
-            .unwrap_or_default();
+        let doc = if let Some(s) = get_doc(&field.attrs) {
+            quote! { Some(#s) }
+        } else {
+            quote! { None }
+        };
 
         let doc_overrides = field
             .attrs

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -19,9 +19,10 @@ pub(crate) fn impl_for_struct(
 
         return quote! {
             impl #impl_generics grib_template_helpers::Dump for #name #type_generics #where_clause {
-                fn dump<W: std::io::Write>(
+                fn dump<'d, W: std::io::Write>(
                     &self,
                     parent: Option<&std::borrow::Cow<str>>,
+                    doc_overrides: Option<grib_template_helpers::DocOverrides<'d>>,
                     pos: &mut usize,
                     output: &mut W,
                 ) -> Result<(), std::io::Error> {
@@ -49,6 +50,16 @@ pub(crate) fn impl_for_struct(
             .map(|s| format!("  // {}", s.trim()))
             .unwrap_or_default();
 
+        let doc_overrides = field
+            .attrs
+            .iter()
+            .find_map(|attr| DocOverrides::try_from(attr).ok());
+        let doc_overrides = if let Some(inner) = doc_overrides {
+            quote! { Some(grib_template_helpers::DocOverrides::new(#inner)) }
+        } else {
+            quote! { None }
+        };
+
         let num_octets_attr = field
             .attrs
             .iter()
@@ -60,6 +71,7 @@ pub(crate) fn impl_for_struct(
                     stringify!(#ident),
                     parent,
                     #doc,
+                    #doc_overrides,
                     pos,
                     output,
                 )?;
@@ -73,6 +85,7 @@ pub(crate) fn impl_for_struct(
                 stringify!(#ident),
                 parent,
                 #doc,
+                #doc_overrides,
                 pos,
                 output,
             )?;
@@ -81,9 +94,10 @@ pub(crate) fn impl_for_struct(
 
     quote! {
         impl #impl_generics grib_template_helpers::Dump for #name #type_generics #where_clause {
-            fn dump<W: std::io::Write>(
+            fn dump<'d, W: std::io::Write>(
                 &self,
                 parent: Option<&std::borrow::Cow<str>>,
+                doc_overrides: Option<grib_template_helpers::DocOverrides<'d>>,
                 pos: &mut usize,
                 output: &mut W,
             ) -> Result<(), std::io::Error> {
@@ -114,6 +128,7 @@ pub(crate) fn impl_for_enum(
                 #name::#variant_ident(inner) => <#inner_ty as grib_template_helpers::Dump>::dump(
                     inner,
                     parent,
+                    None,
                     pos,
                     output
                 )
@@ -125,9 +140,10 @@ pub(crate) fn impl_for_enum(
 
     quote! {
         impl #impl_generics grib_template_helpers::Dump for #name #type_generics #where_clause {
-            fn dump<W: std::io::Write>(
+            fn dump<'d, W: std::io::Write>(
                 &self,
                 parent: Option<&std::borrow::Cow<str>>,
+                doc_overrides: Option<grib_template_helpers::DocOverrides<'d>>,
                 pos: &mut usize,
                 output: &mut W,
             ) -> Result<(), std::io::Error> {

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use quote::quote;
 
 pub(crate) fn impl_for_struct(
@@ -154,4 +156,77 @@ pub(crate) fn get_doc(attrs: &[syn::Attribute]) -> Option<String> {
         }
     }
     if doc.is_empty() { None } else { Some(doc) }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct DocOverrides(HashMap<String, String>);
+
+impl TryFrom<&syn::Attribute> for DocOverrides {
+    type Error = &'static str;
+
+    fn try_from(value: &syn::Attribute) -> Result<Self, Self::Error> {
+        const MESSAGE: &str = "error";
+        if !value.path().is_ident("dump") {
+            return Err(MESSAGE);
+        }
+        let meta = value.parse_args::<syn::Meta>().map_err(|_| MESSAGE)?;
+        if let syn::Meta::List(list) = meta {
+            if !list.path.is_ident("doc") {
+                return Err(MESSAGE);
+            }
+            let items = list
+                .parse_args_with(
+                    syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated,
+                )
+                .map_err(|_| MESSAGE)?;
+
+            let mut map = HashMap::new();
+            for item in items {
+                if let syn::Meta::NameValue(nv) = item {
+                    let k = nv
+                        .path
+                        .get_ident()
+                        .map(|i| i.to_string())
+                        .unwrap_or_default();
+                    let v = if let syn::Expr::Lit(lit) = &nv.value
+                        && let syn::Lit::Str(s) = &lit.lit
+                    {
+                        s.value()
+                    } else {
+                        return Err(MESSAGE);
+                    };
+                    map.insert(k, v);
+                } else {
+                    return Err(MESSAGE);
+                }
+            }
+            Ok(Self(map))
+        } else {
+            Err(MESSAGE)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parsing_doc_attr() -> Result<(), Box<dyn std::error::Error>> {
+        let attr: syn::Attribute = syn::parse_quote! {
+            #[dump(doc(
+                key1 = "val1",
+                key2 = "val2",
+            ))]
+        };
+        let actual = DocOverrides::try_from(&attr)?;
+        let expected = vec![("key1", "val1"), ("key2", "val2")]
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect::<HashMap<_, _>>();
+        let expected = DocOverrides(expected);
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
 }

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -52,6 +52,17 @@ pub(crate) fn impl_for_struct(
             quote! { None }
         };
 
+        dumps.push(quote! {
+            let name = stringify!(#ident);
+            let doc = if let Some(doc_overrides) = &doc_overrides
+                && let Some(val) = doc_overrides.get(name)
+            {
+                Some(*val)
+            } else {
+                #doc
+            };
+        });
+
         let doc_overrides = field
             .attrs
             .iter()
@@ -70,9 +81,9 @@ pub(crate) fn impl_for_struct(
             dumps.push(quote! {
                 <grib_template_helpers::NonStdLenUint<#ty> as grib_template_helpers::DumpField>::dump_field(
                     &grib_template_helpers::NonStdLenUint::new(self.#ident, #num_octets),
-                    stringify!(#ident),
+                    name,
                     parent,
-                    #doc,
+                    doc,
                     #doc_overrides,
                     pos,
                     output,
@@ -84,9 +95,9 @@ pub(crate) fn impl_for_struct(
         dumps.push(quote! {
             <#ty as grib_template_helpers::DumpField>::dump_field(
                 &self.#ident,
-                stringify!(#ident),
+                name,
                 parent,
-                #doc,
+                doc,
                 #doc_overrides,
                 pos,
                 output,

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -47,6 +47,7 @@ pub(crate) fn impl_for_struct(
         let ty = &field.ty;
 
         let doc = if let Some(s) = get_doc(&field.attrs) {
+            let s = s.trim();
             quote! { Some(#s) }
         } else {
             quote! { None }

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use quote::quote;
 
 pub(crate) fn impl_for_struct(
@@ -159,7 +157,7 @@ pub(crate) fn get_doc(attrs: &[syn::Attribute]) -> Option<String> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct DocOverrides(HashMap<String, String>);
+struct DocOverrides(Vec<(String, String)>);
 
 impl TryFrom<&syn::Attribute> for DocOverrides {
     type Error = &'static str;
@@ -180,7 +178,7 @@ impl TryFrom<&syn::Attribute> for DocOverrides {
                 )
                 .map_err(|_| MESSAGE)?;
 
-            let mut map = HashMap::new();
+            let mut map = Vec::with_capacity(items.len());
             for item in items {
                 if let syn::Meta::NameValue(nv) = item {
                     let k = nv
@@ -195,7 +193,7 @@ impl TryFrom<&syn::Attribute> for DocOverrides {
                     } else {
                         return Err(MESSAGE);
                     };
-                    map.insert(k, v);
+                    map.push((k, v));
                 } else {
                     return Err(MESSAGE);
                 }
@@ -207,8 +205,24 @@ impl TryFrom<&syn::Attribute> for DocOverrides {
     }
 }
 
+impl quote::ToTokens for DocOverrides {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self(inner) = self;
+        let iter = inner
+            .iter()
+            .map(|(k, v)| quote! { (#k, #v) })
+            .collect::<Vec<_>>();
+        let tok = quote! {
+            vec![#(#iter),*]
+        };
+        tokens.extend(tok);
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use quote::ToTokens;
+
     use super::*;
 
     #[test]
@@ -223,9 +237,13 @@ mod tests {
         let expected = vec![("key1", "val1"), ("key2", "val2")]
             .into_iter()
             .map(|(k, v)| (k.to_owned(), v.to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<Vec<_>>();
         let expected = DocOverrides(expected);
         assert_eq!(actual, expected);
+
+        let actual_stream = actual.to_token_stream().to_string();
+        let expected_stream = r#"vec ! [("key1" , "val1") , ("key2" , "val2")]"#;
+        assert_eq!(actual_stream, expected_stream);
 
         Ok(())
     }

--- a/grib-template-derive/src/lib.rs
+++ b/grib-template-derive/src/lib.rs
@@ -29,7 +29,7 @@ pub fn derive_write_to_buffer(input: TokenStream) -> TokenStream {
 }
 
 /// Derive macro generating an impl of the trait `grib_template_helpers::Dump`.
-#[proc_macro_derive(Dump, attributes(grib_template))]
+#[proc_macro_derive(Dump, attributes(grib_template, dump))]
 pub fn derive_dump(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
 

--- a/grib-template-derive/tests/dump.rs
+++ b/grib-template-derive/tests/dump.rs
@@ -95,7 +95,7 @@ fn main() {
 
     let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
     let mut pos = 1;
-    params.dump(None, &mut pos, &mut buf).unwrap();
+    params.dump(None, None, &mut pos, &mut buf).unwrap();
     assert_eq!(
         String::from_utf8_lossy(buf.get_ref()),
         "\

--- a/grib-template-derive/tests/dump_for_option.rs
+++ b/grib-template-derive/tests/dump_for_option.rs
@@ -50,7 +50,7 @@ macro_rules! test {
     ),)*) => ($(
         let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
         let mut pos = 1;
-        $input.dump(None, &mut pos, &mut buf).unwrap();
+        $input.dump(None, None, &mut pos, &mut buf).unwrap();
         assert_eq!(String::from_utf8_lossy(buf.get_ref()), $expected);
     )*);
 }

--- a/grib-template-derive/tests/dump_with_doc_overrides.rs
+++ b/grib-template-derive/tests/dump_with_doc_overrides.rs
@@ -1,0 +1,53 @@
+use grib_template_helpers::Dump;
+
+#[derive(grib_template_derive::Dump)]
+pub struct Params {
+    /// Field 1
+    field1: ReusableType,
+    #[dump(doc(
+        element_id = "Id of the second element",
+        factor = "Scale factor of the second element",
+    ))]
+    /// Field 2
+    field2: ReusableType,
+}
+
+#[derive(grib_template_derive::Dump)]
+pub struct ReusableType {
+    /// Id
+    element_id: u8,
+    /// Scale factor
+    factor: u8,
+    /// Scaled value
+    value: u32,
+}
+
+fn main() {
+    let params = Params {
+        field1: ReusableType {
+            element_id: 1,
+            factor: 1,
+            value: 1,
+        },
+        field2: ReusableType {
+            element_id: 2,
+            factor: 2,
+            value: 2,
+        },
+    };
+
+    let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
+    let mut pos = 1;
+    params.dump(None, None, &mut pos, &mut buf).unwrap();
+    assert_eq!(
+        String::from_utf8_lossy(buf.get_ref()),
+        "\
+1         field1.element_id = 1  // Id
+2         field1.factor = 1  // Scale factor
+3-6       field1.value = 1  // Scaled value
+7         field2.element_id = 2  // Id of the second element
+8         field2.factor = 2  // Scale factor of the second element
+9-12      field2.value = 2  // Scaled value
+"
+    )
+}

--- a/grib-template-derive/tests/runner.rs
+++ b/grib-template-derive/tests/runner.rs
@@ -4,6 +4,7 @@ fn tests() {
     t.pass("tests/dump.rs");
     t.pass("tests/dump_standalone.rs");
     t.pass("tests/dump_for_option.rs");
+    t.pass("tests/dump_with_doc_overrides.rs");
     t.pass("tests/try_from_slice.rs");
     t.pass("tests/try_from_slice_standalone.rs");
     t.pass("tests/try_from_slice_for_option.rs");

--- a/grib-template-helpers/src/dump.rs
+++ b/grib-template-helpers/src/dump.rs
@@ -90,7 +90,7 @@ macro_rules! add_impl_of_dump_field_for_number_types {
                     write!(output, "{}.", parent)?;
                 }
                 let doc = doc
-                    .map(|s| format!("  // {}", s.trim()))
+                    .map(|s| format!("  // {}", s))
                     .unwrap_or_default();
                 writeln!(output, "{} = {:?}{}",
                     name,
@@ -140,9 +140,7 @@ impl<const N: usize> DumpField for [u8; N] {
         if let Some(parent) = parent {
             write!(output, "{}.", parent)?;
         }
-        let doc = doc
-            .map(|s| format!("  // {}", s.trim()))
-            .unwrap_or_default();
+        let doc = doc.map(|s| format!("  // {}", s)).unwrap_or_default();
         writeln!(output, "{} = {:?}{}", name, self, doc,)
     }
 }
@@ -182,9 +180,7 @@ impl<T: std::fmt::Debug> DumpField for crate::NonStdLenUint<T> {
         if let Some(parent) = parent {
             write!(output, "{}.", parent)?;
         }
-        let doc = doc
-            .map(|s| format!("  // {}", s.trim()))
-            .unwrap_or_default();
+        let doc = doc.map(|s| format!("  // {}", s)).unwrap_or_default();
         writeln!(output, "{} = {:?}{}", name, self.val(), doc,)
     }
 }

--- a/grib-template-helpers/src/dump.rs
+++ b/grib-template-helpers/src/dump.rs
@@ -65,7 +65,7 @@ pub trait DumpField: OctetSize {
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
-        doc: &str,
+        doc: Option<&str>,
         doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
@@ -79,7 +79,7 @@ macro_rules! add_impl_of_dump_field_for_number_types {
                 &self,
                 name: &str,
                 parent: Option<&Cow<str>>,
-                doc: &str,
+                doc: Option<&str>,
                 _doc_overrides: Option<DocOverrides<'d>>,
                 pos: &mut usize,
                 output: &mut W,
@@ -89,6 +89,9 @@ macro_rules! add_impl_of_dump_field_for_number_types {
                 if let Some(parent) = parent {
                     write!(output, "{}.", parent)?;
                 }
+                let doc = doc
+                    .map(|s| format!("  // {}", s.trim()))
+                    .unwrap_or_default();
                 writeln!(output, "{} = {:?}{}",
                     name,
                     self,
@@ -127,7 +130,7 @@ impl<const N: usize> DumpField for [u8; N] {
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
-        doc: &str,
+        doc: Option<&str>,
         _doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
@@ -137,6 +140,9 @@ impl<const N: usize> DumpField for [u8; N] {
         if let Some(parent) = parent {
             write!(output, "{}.", parent)?;
         }
+        let doc = doc
+            .map(|s| format!("  // {}", s.trim()))
+            .unwrap_or_default();
         writeln!(output, "{} = {:?}{}", name, self, doc,)
     }
 }
@@ -149,7 +155,7 @@ where
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
-        doc: &str,
+        doc: Option<&str>,
         doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
@@ -166,7 +172,7 @@ impl<T: std::fmt::Debug> DumpField for crate::NonStdLenUint<T> {
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
-        doc: &str,
+        doc: Option<&str>,
         _doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
@@ -176,6 +182,9 @@ impl<T: std::fmt::Debug> DumpField for crate::NonStdLenUint<T> {
         if let Some(parent) = parent {
             write!(output, "{}.", parent)?;
         }
+        let doc = doc
+            .map(|s| format!("  // {}", s.trim()))
+            .unwrap_or_default();
         writeln!(output, "{} = {:?}{}", name, self.val(), doc,)
     }
 }
@@ -185,7 +194,7 @@ impl<T: Dump> DumpField for T {
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
-        _doc: &str,
+        _doc: Option<&str>,
         doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,

--- a/grib-template-helpers/src/dump.rs
+++ b/grib-template-helpers/src/dump.rs
@@ -8,7 +8,7 @@ use std::{
 /// # Examples
 ///
 /// ```
-/// use grib_template_helpers::Dump;
+/// use grib_template_helpers::{DocOverrides, Dump};
 ///
 /// struct VariableLength {
 ///     len: u8,
@@ -16,9 +16,10 @@ use std::{
 /// }
 ///
 /// impl Dump for VariableLength {
-///     fn dump<W: std::io::Write>(
+///     fn dump<'d, W: std::io::Write>(
 ///         &self,
 ///         parent: Option<&std::borrow::Cow<str>>,
+///         doc_overrides: Option<DocOverrides<'d>>,
 ///         pos: &mut usize,
 ///         output: &mut W,
 ///     ) -> Result<(), std::io::Error> {
@@ -37,7 +38,7 @@ use std::{
 ///     };
 ///     let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
 ///     let mut pos = 0;
-///     var.dump(None, &mut pos, &mut buf)?;
+///     var.dump(None, None, &mut pos, &mut buf)?;
 ///     assert_eq!(
 ///         String::from_utf8_lossy(buf.get_ref()),
 ///         "variable-length array (length = 3, content = [1, 2, 3])\n"
@@ -50,20 +51,22 @@ pub trait Dump {
     ///
     /// Users can use the `pos` argument to output the current byte offset, and
     /// `parent` to output information about nested structures.
-    fn dump<W: Write>(
+    fn dump<'d, W: Write>(
         &self,
         parent: Option<&Cow<str>>,
+        doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error>;
 }
 
 pub trait DumpField: OctetSize {
-    fn dump_field<W: Write>(
+    fn dump_field<'d, W: Write>(
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
         doc: &str,
+        doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error>;
@@ -72,11 +75,12 @@ pub trait DumpField: OctetSize {
 macro_rules! add_impl_of_dump_field_for_number_types {
     ($($ty:ty,)*) => ($(
         impl DumpField for $ty {
-            fn dump_field<W: Write>(
+            fn dump_field<'d, W: Write>(
                 &self,
                 name: &str,
                 parent: Option<&Cow<str>>,
                 doc: &str,
+                _doc_overrides: Option<DocOverrides<'d>>,
                 pos: &mut usize,
                 output: &mut W,
             ) -> Result<(), Error> {
@@ -119,11 +123,12 @@ add_impl_of_dump_field_for_number_types![
 ];
 
 impl<const N: usize> DumpField for [u8; N] {
-    fn dump_field<W: Write>(
+    fn dump_field<'d, W: Write>(
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
         doc: &str,
+        _doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
@@ -140,27 +145,29 @@ impl<T: OctetSize + DumpField> DumpField for Option<T>
 where
     Self: OctetSize,
 {
-    fn dump_field<W: Write>(
+    fn dump_field<'d, W: Write>(
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
         doc: &str,
+        doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
         if let Some(val) = self {
-            val.dump_field(name, parent, doc, pos, output)?;
+            val.dump_field(name, parent, doc, doc_overrides, pos, output)?;
         }
         Ok(())
     }
 }
 
 impl<T: std::fmt::Debug> DumpField for crate::NonStdLenUint<T> {
-    fn dump_field<W: Write>(
+    fn dump_field<'d, W: Write>(
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
         doc: &str,
+        _doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
@@ -174,18 +181,19 @@ impl<T: std::fmt::Debug> DumpField for crate::NonStdLenUint<T> {
 }
 
 impl<T: Dump> DumpField for T {
-    fn dump_field<W: Write>(
+    fn dump_field<'d, W: Write>(
         &self,
         name: &str,
         parent: Option<&Cow<str>>,
         _doc: &str,
+        doc_overrides: Option<DocOverrides<'d>>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
         let parent = parent
             .map(|s| Cow::Owned(format!("{}.{}", s, name)))
             .unwrap_or(Cow::Borrowed(name));
-        self.dump(Some(&parent), pos, output)
+        self.dump(Some(&parent), doc_overrides, pos, output)
     }
 }
 
@@ -271,6 +279,19 @@ pub fn write_position_column<W: Write>(
     Ok(())
 }
 
+pub struct DocOverrides<'a>(Vec<(&'a str, &'a str)>);
+
+impl<'a> DocOverrides<'a> {
+    pub fn new(items: Vec<(&'a str, &'a str)>) -> Self {
+        Self(items)
+    }
+
+    pub fn get(&self, key: &str) -> Option<&&'a str> {
+        let Self(inner) = self;
+        inner.iter().find(|(k, _v)| *k == key).map(|(_k, v)| v)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,9 +302,10 @@ mod tests {
     }
 
     impl Dump for Foo {
-        fn dump<W: Write>(
+        fn dump<'d, W: Write>(
             &self,
             _parent: Option<&Cow<str>>,
+            _doc_overrides: Option<DocOverrides<'d>>,
             _pos: &mut usize,
             output: &mut W,
         ) -> Result<(), Error> {
@@ -300,7 +322,7 @@ mod tests {
         };
         let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
         let mut pos = 0;
-        foo.dump(None, &mut pos, &mut buf)?;
+        foo.dump(None, None, &mut pos, &mut buf)?;
         assert_eq!(
             String::from_utf8_lossy(buf.get_ref()),
             "member1: 1\nmember2: 2\n"

--- a/grib-template-helpers/src/lib.rs
+++ b/grib-template-helpers/src/lib.rs
@@ -1,4 +1,4 @@
-pub use dump::{Dump, DumpField, write_position_column};
+pub use dump::{DocOverrides, Dump, DumpField, write_position_column};
 pub use try_from_slice::{TryEnumFromSlice, TryFromSlice, TryFromSliceResult};
 pub use types::NonStdLenUint;
 pub use write_to_buffer::WriteToBuffer;

--- a/src/context.rs
+++ b/src/context.rs
@@ -883,7 +883,7 @@ Data Representation:                    {}
             ($sect:expr) => {{
                 let mut pos = 1;
                 match $sect {
-                    Ok(s) => s.dump(None, &mut pos, writer)?,
+                    Ok(s) => s.dump(None, None, &mut pos, writer)?,
                     Err(e) => writeln!(writer, "error: {}", e)?,
                 }
             }};


### PR DESCRIPTION
This PR adds to grib-template-derive a feature to enable overriding the description of each field when dumping.

This PR introduces incompatible changes to the signatures of the trait methods of `Dump` and `DumpField`.