### PR TITLE
grib-template-derive: add support for deeply nested structs in the field description override feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 18        payload.template.forecast_time.time.unit = 0  // Indicator of unit of time range (see Code Table 4.4).
 19-22     payload.template.forecast_time.time.len = 0  // Forecast time in units defined by octet 18.
 23        payload.template.horizontal.first_surface.surface_type = 1  // Type of first fixed surface (see Code Table 4.5).
-24        payload.template.horizontal.first_surface.scale_factor = -127  // Scale factor of first fixed surface.
-25-28     payload.template.horizontal.first_surface.scaled_value = -2147483647  // Scaled value of first fixed surface.
+24        payload.template.horizontal.first_surface.value.scale_factor = -127  // Scale factor of first fixed surface.
+25-28     payload.template.horizontal.first_surface.value.scaled_value = -2147483647  // Scaled value of first fixed surface.
 29        payload.template.horizontal.second_surface.surface_type = 255  // Type of second fixed surface (see Code Table 4.5).
-30        payload.template.horizontal.second_surface.scale_factor = -127  // Scale factor of second fixed surface.
-31-34     payload.template.horizontal.second_surface.scaled_value = -2147483647  // Scaled value of second fixed surface.
+30        payload.template.horizontal.second_surface.value.scale_factor = -127  // Scale factor of second fixed surface.
+31-34     payload.template.horizontal.second_surface.value.scaled_value = -2147483647  // Scaled value of second fixed surface.
 ###  SECTION 5: DATA REPRESENTATION SECTION (length = 23)
 1-4       header.len = 23  // Length of section in octets (nn).
 5         header.sect_num = 5  // Number of section.

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -233,12 +233,12 @@ impl ToTokens for DocOverrides {
 
 fn parse_tree(
     list: syn::MetaList,
-    path: &Vec<String>,
+    path: &[String],
     out: &mut Vec<(Vec<String>, String)>,
 ) -> Result<(), &'static str> {
     const MESSAGE: &str = "error";
 
-    let mut path = path.clone();
+    let mut path = path.to_owned();
     let name = list
         .path
         .get_ident()

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -22,7 +22,7 @@ pub(crate) fn impl_for_struct(
                 fn dump<'d, W: std::io::Write>(
                     &self,
                     parent: Option<&std::borrow::Cow<str>>,
-                    doc_overrides: Option<grib_template_helpers::DocOverrides<'d>>,
+                    doc_overrides: grib_template_helpers::DocOverrides<'d>,
                     pos: &mut usize,
                     output: &mut W,
                 ) -> Result<(), std::io::Error> {
@@ -55,20 +55,11 @@ pub(crate) fn impl_for_struct(
 
         dumps.push(quote! {
             let name = stringify!(#ident);
-            let doc = if let Some(doc_overrides) = &doc_overrides
-                && let Some(val) = doc_overrides.get(name)
-            {
-                Some(*val)
-            } else {
-                #doc
-            };
+            let doc = doc_overrides.get(name).or(#doc);
         });
 
-        let doc_overrides = if let Ok(inner) = DocOverrides::try_from(field) {
-            quote! { Some(grib_template_helpers::DocOverrides::new(#inner)) }
-        } else {
-            quote! { None }
-        };
+        let doc_overrides = DocOverrides::try_from(field).unwrap_or(DocOverrides(Vec::new()));
+        let doc_overrides = quote! { grib_template_helpers::DocOverrides::new(#doc_overrides) };
 
         let (ty, self_ident) = if let Ok(num_octets) = super::helpers::NumOctets::try_from(field) {
             (
@@ -82,17 +73,8 @@ pub(crate) fn impl_for_struct(
         };
 
         dumps.push(quote! {
-            let mut child_doc_overrides = doc_overrides
-                .as_ref()
-                .and_then(|o| o.get_child_overrides(name));
-            let child_doc_overrides_added = #doc_overrides;
-            if let Some(parent) = child_doc_overrides.as_mut() {
-                if let Some(child) = child_doc_overrides_added.as_ref() {
-                    parent.merge(&child);
-                }
-            } else {
-                child_doc_overrides = child_doc_overrides_added;
-            }
+            let mut child_doc_overrides = doc_overrides.get_child_overrides(name);
+            child_doc_overrides.merge(&#doc_overrides);
 
             <#ty as grib_template_helpers::DumpField>::dump_field(
                 #self_ident,
@@ -111,7 +93,7 @@ pub(crate) fn impl_for_struct(
             fn dump<'d, W: std::io::Write>(
                 &self,
                 parent: Option<&std::borrow::Cow<str>>,
-                doc_overrides: Option<grib_template_helpers::DocOverrides<'d>>,
+                doc_overrides: grib_template_helpers::DocOverrides<'d>,
                 pos: &mut usize,
                 output: &mut W,
             ) -> Result<(), std::io::Error> {
@@ -142,7 +124,7 @@ pub(crate) fn impl_for_enum(
                 #name::#variant_ident(inner) => <#inner_ty as grib_template_helpers::Dump>::dump(
                     inner,
                     parent,
-                    None,
+                    grib_template_helpers::DocOverrides::empty(),
                     pos,
                     output
                 )
@@ -157,7 +139,7 @@ pub(crate) fn impl_for_enum(
             fn dump<'d, W: std::io::Write>(
                 &self,
                 parent: Option<&std::borrow::Cow<str>>,
-                doc_overrides: Option<grib_template_helpers::DocOverrides<'d>>,
+                doc_overrides: grib_template_helpers::DocOverrides<'d>,
                 pos: &mut usize,
                 output: &mut W,
             ) -> Result<(), std::io::Error> {

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -175,7 +175,7 @@ pub(crate) fn get_doc(attrs: &[syn::Attribute]) -> Option<String> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct DocOverrides(Vec<(String, String)>);
+struct DocOverrides(Vec<(Vec<String>, String)>);
 
 impl TryFrom<&syn::Field> for DocOverrides {
     type Error = &'static str;
@@ -199,34 +199,12 @@ impl TryFrom<&syn::Attribute> for DocOverrides {
         }
         let meta = value.parse_args::<syn::Meta>().map_err(|_| MESSAGE)?;
         if let syn::Meta::List(list) = meta {
-            if !list.path.is_ident("doc") {
+            let mut map = Vec::with_capacity(16);
+            parse_tree(list, &Vec::new(), &mut map)?;
+            if let Some((k, _v)) = map.first()
+                && k[0] != "doc"
+            {
                 return Err(MESSAGE);
-            }
-            let items = list
-                .parse_args_with(
-                    syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated,
-                )
-                .map_err(|_| MESSAGE)?;
-
-            let mut map = Vec::with_capacity(items.len());
-            for item in items {
-                if let syn::Meta::NameValue(nv) = item {
-                    let k = nv
-                        .path
-                        .get_ident()
-                        .map(|i| i.to_string())
-                        .unwrap_or_default();
-                    let v = if let syn::Expr::Lit(lit) = &nv.value
-                        && let syn::Lit::Str(s) = &lit.lit
-                    {
-                        s.value()
-                    } else {
-                        return Err(MESSAGE);
-                    };
-                    map.push((k, v));
-                } else {
-                    return Err(MESSAGE);
-                }
             }
             Ok(Self(map))
         } else {
@@ -240,13 +218,65 @@ impl ToTokens for DocOverrides {
         let Self(inner) = self;
         let iter = inner
             .iter()
-            .map(|(k, v)| quote! { (#k, #v) })
+            .map(|(k, v)| {
+                // the 0th element should be "doc"
+                let k = &k[1..].join(".");
+                quote! { (#k, #v) }
+            })
             .collect::<Vec<_>>();
         let tok = quote! {
             vec![#(#iter),*]
         };
         tokens.extend(tok);
     }
+}
+
+fn parse_tree(
+    list: syn::MetaList,
+    path: &Vec<String>,
+    out: &mut Vec<(Vec<String>, String)>,
+) -> Result<(), &'static str> {
+    const MESSAGE: &str = "error";
+
+    let mut path = path.clone();
+    let name = list
+        .path
+        .get_ident()
+        .map(|i| i.to_string())
+        .unwrap_or_default();
+    path.push(name);
+
+    let items = list
+        .parse_args_with(syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated)
+        .map_err(|_| MESSAGE)?;
+
+    for item in items {
+        match item {
+            syn::Meta::NameValue(nv) => {
+                let mut k = path.clone();
+                let name = nv
+                    .path
+                    .get_ident()
+                    .map(|i| i.to_string())
+                    .unwrap_or_default();
+                k.push(name);
+
+                let v = if let syn::Expr::Lit(lit) = &nv.value
+                    && let syn::Lit::Str(s) = &lit.lit
+                {
+                    s.value()
+                } else {
+                    return Err(MESSAGE);
+                };
+                out.push((k, v));
+            }
+            syn::Meta::List(sublist) => parse_tree(sublist, &path, out)?,
+            _ => {
+                return Err(MESSAGE);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -258,19 +288,30 @@ mod tests {
         let attr: syn::Attribute = syn::parse_quote! {
             #[dump(doc(
                 key1 = "val1",
-                key2 = "val2",
+                key2(key1 = "val21"),
+                key3 = "val3",
             ))]
         };
         let actual = DocOverrides::try_from(&attr)?;
-        let expected = vec![("key1", "val1"), ("key2", "val2")]
-            .into_iter()
-            .map(|(k, v)| (k.to_owned(), v.to_owned()))
-            .collect::<Vec<_>>();
+        let expected = vec![
+            (vec!["doc", "key1"], "val1"),
+            (vec!["doc", "key2", "key1"], "val21"),
+            (vec!["doc", "key3"], "val3"),
+        ]
+        .into_iter()
+        .map(|(k, v)| {
+            (
+                k.into_iter().map(|s| s.to_owned()).collect::<Vec<_>>(),
+                v.to_owned(),
+            )
+        })
+        .collect::<Vec<_>>();
         let expected = DocOverrides(expected);
         assert_eq!(actual, expected);
 
         let actual_stream = actual.to_token_stream().to_string();
-        let expected_stream = r#"vec ! [("key1" , "val1") , ("key2" , "val2")]"#;
+        let expected_stream =
+            r#"vec ! [("key1" , "val1") , ("key2.key1" , "val21") , ("key3" , "val3")]"#;
         assert_eq!(actual_stream, expected_stream);
 
         Ok(())

--- a/grib-template-derive/src/dump.rs
+++ b/grib-template-derive/src/dump.rs
@@ -82,12 +82,24 @@ pub(crate) fn impl_for_struct(
         };
 
         dumps.push(quote! {
+            let mut child_doc_overrides = doc_overrides
+                .as_ref()
+                .and_then(|o| o.get_child_overrides(name));
+            let child_doc_overrides_added = #doc_overrides;
+            if let Some(parent) = child_doc_overrides.as_mut() {
+                if let Some(child) = child_doc_overrides_added.as_ref() {
+                    parent.merge(&child);
+                }
+            } else {
+                child_doc_overrides = child_doc_overrides_added;
+            }
+
             <#ty as grib_template_helpers::DumpField>::dump_field(
                 #self_ident,
                 name,
                 parent,
                 doc,
-                #doc_overrides,
+                child_doc_overrides,
                 pos,
                 output,
             )?;

--- a/grib-template-derive/tests/dump.rs
+++ b/grib-template-derive/tests/dump.rs
@@ -1,4 +1,4 @@
-use grib_template_helpers::Dump;
+use grib_template_helpers::{DocOverrides, Dump};
 
 #[derive(grib_template_derive::Dump)]
 pub struct Params {
@@ -95,7 +95,9 @@ fn main() {
 
     let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
     let mut pos = 1;
-    params.dump(None, None, &mut pos, &mut buf).unwrap();
+    params
+        .dump(None, DocOverrides::empty(), &mut pos, &mut buf)
+        .unwrap();
     assert_eq!(
         String::from_utf8_lossy(buf.get_ref()),
         "\

--- a/grib-template-derive/tests/dump_for_option.rs
+++ b/grib-template-derive/tests/dump_for_option.rs
@@ -1,4 +1,4 @@
-use grib_template_helpers::Dump;
+use grib_template_helpers::{DocOverrides, Dump};
 
 #[derive(Debug, PartialEq, grib_template_derive::Dump)]
 pub struct OptionalStruct {
@@ -50,7 +50,7 @@ macro_rules! test {
     ),)*) => ($(
         let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
         let mut pos = 1;
-        $input.dump(None, None, &mut pos, &mut buf).unwrap();
+        $input.dump(None, DocOverrides::empty(), &mut pos, &mut buf).unwrap();
         assert_eq!(String::from_utf8_lossy(buf.get_ref()), $expected);
     )*);
 }

--- a/grib-template-derive/tests/dump_with_doc_overrides.rs
+++ b/grib-template-derive/tests/dump_with_doc_overrides.rs
@@ -1,4 +1,4 @@
-use grib_template_helpers::Dump;
+use grib_template_helpers::{DocOverrides, Dump};
 
 #[derive(grib_template_derive::Dump)]
 pub struct Params {
@@ -58,7 +58,9 @@ fn main() {
 
     let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
     let mut pos = 1;
-    params.dump(None, None, &mut pos, &mut buf).unwrap();
+    params
+        .dump(None, DocOverrides::empty(), &mut pos, &mut buf)
+        .unwrap();
     assert_eq!(
         String::from_utf8_lossy(buf.get_ref()),
         "\

--- a/grib-template-derive/tests/dump_with_doc_overrides.rs
+++ b/grib-template-derive/tests/dump_with_doc_overrides.rs
@@ -4,11 +4,23 @@ use grib_template_helpers::Dump;
 pub struct Params {
     /// Field 1
     field1: ReusableType,
-    #[dump(doc(
-        element_id = "Id of the second element",
-        factor = "Scale factor of the second element",
-    ))]
+    #[dump(doc(field1 = "Field 2.1", field2(element_id = "Super-overrided id",),))]
     /// Field 2
+    field2: ReusableComponent,
+    #[dump(doc(
+        element_id = "Id of the third element",
+        factor = "Scale factor of the third element",
+    ))]
+    /// Field 3
+    field3: ReusableType,
+}
+
+#[derive(grib_template_derive::Dump)]
+pub struct ReusableComponent {
+    /// Component field 1
+    field1: u8,
+    #[dump(doc(element_id = "Overrided id", factor = "Overrided scale factor",))]
+    /// Component field 2
     field2: ReusableType,
 }
 
@@ -29,10 +41,18 @@ fn main() {
             factor: 1,
             value: 1,
         },
-        field2: ReusableType {
-            element_id: 2,
-            factor: 2,
-            value: 2,
+        field2: ReusableComponent {
+            field1: 2,
+            field2: ReusableType {
+                element_id: 2,
+                factor: 2,
+                value: 2,
+            },
+        },
+        field3: ReusableType {
+            element_id: 3,
+            factor: 3,
+            value: 3,
         },
     };
 
@@ -45,9 +65,13 @@ fn main() {
 1         field1.element_id = 1  // Id
 2         field1.factor = 1  // Scale factor
 3-6       field1.value = 1  // Scaled value
-7         field2.element_id = 2  // Id of the second element
-8         field2.factor = 2  // Scale factor of the second element
-9-12      field2.value = 2  // Scaled value
+7         field2.field1 = 2  // Field 2.1
+8         field2.field2.element_id = 2  // Super-overrided id
+9         field2.field2.factor = 2  // Overrided scale factor
+10-13     field2.field2.value = 2  // Scaled value
+14        field3.element_id = 3  // Id of the third element
+15        field3.factor = 3  // Scale factor of the third element
+16-19     field3.value = 3  // Scaled value
 "
     )
 }

--- a/grib-template-helpers/src/dump.rs
+++ b/grib-template-helpers/src/dump.rs
@@ -19,7 +19,7 @@ use std::{
 ///     fn dump<'d, W: std::io::Write>(
 ///         &self,
 ///         parent: Option<&std::borrow::Cow<str>>,
-///         doc_overrides: Option<DocOverrides<'d>>,
+///         doc_overrides: DocOverrides<'d>,
 ///         pos: &mut usize,
 ///         output: &mut W,
 ///     ) -> Result<(), std::io::Error> {
@@ -38,7 +38,7 @@ use std::{
 ///     };
 ///     let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
 ///     let mut pos = 0;
-///     var.dump(None, None, &mut pos, &mut buf)?;
+///     var.dump(None, DocOverrides::empty(), &mut pos, &mut buf)?;
 ///     assert_eq!(
 ///         String::from_utf8_lossy(buf.get_ref()),
 ///         "variable-length array (length = 3, content = [1, 2, 3])\n"
@@ -54,7 +54,7 @@ pub trait Dump {
     fn dump<'d, W: Write>(
         &self,
         parent: Option<&Cow<str>>,
-        doc_overrides: Option<DocOverrides<'d>>,
+        doc_overrides: DocOverrides<'d>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error>;
@@ -66,7 +66,7 @@ pub trait DumpField: OctetSize {
         name: &str,
         parent: Option<&Cow<str>>,
         doc: Option<&str>,
-        doc_overrides: Option<DocOverrides<'d>>,
+        doc_overrides: DocOverrides<'d>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error>;
@@ -80,7 +80,7 @@ macro_rules! add_impl_of_dump_field_for_number_types {
                 name: &str,
                 parent: Option<&Cow<str>>,
                 doc: Option<&str>,
-                _doc_overrides: Option<DocOverrides<'d>>,
+                _doc_overrides: DocOverrides<'d>,
                 pos: &mut usize,
                 output: &mut W,
             ) -> Result<(), Error> {
@@ -131,7 +131,7 @@ impl<const N: usize> DumpField for [u8; N] {
         name: &str,
         parent: Option<&Cow<str>>,
         doc: Option<&str>,
-        _doc_overrides: Option<DocOverrides<'d>>,
+        _doc_overrides: DocOverrides<'d>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
@@ -154,7 +154,7 @@ where
         name: &str,
         parent: Option<&Cow<str>>,
         doc: Option<&str>,
-        doc_overrides: Option<DocOverrides<'d>>,
+        doc_overrides: DocOverrides<'d>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
@@ -171,7 +171,7 @@ impl<T: std::fmt::Debug> DumpField for crate::NonStdLenUint<T> {
         name: &str,
         parent: Option<&Cow<str>>,
         doc: Option<&str>,
-        _doc_overrides: Option<DocOverrides<'d>>,
+        _doc_overrides: DocOverrides<'d>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
@@ -191,7 +191,7 @@ impl<T: Dump> DumpField for T {
         name: &str,
         parent: Option<&Cow<str>>,
         _doc: Option<&str>,
-        doc_overrides: Option<DocOverrides<'d>>,
+        doc_overrides: DocOverrides<'d>,
         pos: &mut usize,
         output: &mut W,
     ) -> Result<(), Error> {
@@ -288,16 +288,20 @@ pub fn write_position_column<W: Write>(
 pub struct DocOverrides<'a>(Vec<(&'a str, &'a str)>);
 
 impl<'a> DocOverrides<'a> {
+    pub fn empty() -> Self {
+        Self(Vec::new())
+    }
+
     pub fn new(items: Vec<(&'a str, &'a str)>) -> Self {
         Self(items)
     }
 
-    pub fn get(&self, key: &str) -> Option<&&'a str> {
+    pub fn get(&self, key: &str) -> Option<&str> {
         let Self(inner) = self;
-        inner.iter().find(|(k, _v)| *k == key).map(|(_k, v)| v)
+        inner.iter().find(|(k, _v)| *k == key).map(|(_k, v)| *v)
     }
 
-    pub fn get_child_overrides(&self, key: &str) -> Option<Self> {
+    pub fn get_child_overrides(&self, key: &str) -> Self {
         let Self(inner) = self;
         let found = inner
             .iter()
@@ -311,11 +315,7 @@ impl<'a> DocOverrides<'a> {
                 }
             })
             .collect::<Vec<_>>();
-        if found.is_empty() {
-            None
-        } else {
-            Some(Self(found))
-        }
+        Self(found)
     }
 
     pub fn merge(&mut self, other: &Self) {
@@ -338,7 +338,7 @@ mod tests {
         fn dump<'d, W: Write>(
             &self,
             _parent: Option<&Cow<str>>,
-            _doc_overrides: Option<DocOverrides<'d>>,
+            _doc_overrides: DocOverrides<'d>,
             _pos: &mut usize,
             output: &mut W,
         ) -> Result<(), Error> {
@@ -355,7 +355,7 @@ mod tests {
         };
         let mut buf = std::io::Cursor::new(Vec::with_capacity(1024));
         let mut pos = 0;
-        foo.dump(None, None, &mut pos, &mut buf)?;
+        foo.dump(None, DocOverrides::empty(), &mut pos, &mut buf)?;
         assert_eq!(
             String::from_utf8_lossy(buf.get_ref()),
             "member1: 1\nmember2: 2\n"
@@ -425,7 +425,7 @@ mod tests {
                 ("key2.key1", "field2.1"),
                 ("key3", "field3"),
             ]),
-            Some(DocOverrides::new(vec![("key1", "field2.1")]))
+            DocOverrides::new(vec![("key1", "field2.1")])
         ),
         (
             doc_overrides_get_children_returns_none,
@@ -434,7 +434,7 @@ mod tests {
                 ("key2", "field2"),
                 ("key3", "field3"),
             ]),
-            None
+            DocOverrides::empty()
         ),
     }
 }

--- a/grib-template-helpers/src/dump.rs
+++ b/grib-template-helpers/src/dump.rs
@@ -284,6 +284,7 @@ pub fn write_position_column<W: Write>(
     Ok(())
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct DocOverrides<'a>(Vec<(&'a str, &'a str)>);
 
 impl<'a> DocOverrides<'a> {
@@ -294,6 +295,33 @@ impl<'a> DocOverrides<'a> {
     pub fn get(&self, key: &str) -> Option<&&'a str> {
         let Self(inner) = self;
         inner.iter().find(|(k, _v)| *k == key).map(|(_k, v)| v)
+    }
+
+    pub fn get_child_overrides(&self, key: &str) -> Option<Self> {
+        let Self(inner) = self;
+        let found = inner
+            .iter()
+            .filter_map(|(k, v)| {
+                if let Some((first, remaining)) = k.split_once(".")
+                    && first == key
+                {
+                    Some((remaining, *v))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        if found.is_empty() {
+            None
+        } else {
+            Some(Self(found))
+        }
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        let Self(inner) = self;
+        let Self(other) = other;
+        inner.extend_from_slice(other);
     }
 }
 
@@ -375,5 +403,38 @@ mod tests {
 ";
         assert_eq!(String::from_utf8_lossy(buf.get_ref()), expected);
         Ok(())
+    }
+
+    macro_rules! test_doc_overrides_get_children {
+        ($(($name:ident, $input:expr, $expected:expr),)*) => ($(
+            #[test]
+            fn $name() {
+                let parent = $input;
+                let actual = parent.get_child_overrides("key2");
+                let expected = $expected;
+                assert_eq!(actual, expected);
+            }
+        )*);
+    }
+
+    test_doc_overrides_get_children! {
+        (
+            doc_overrides_get_children_returns_some,
+            DocOverrides::new(vec![
+                ("key1", "field1"),
+                ("key2.key1", "field2.1"),
+                ("key3", "field3"),
+            ]),
+            Some(DocOverrides::new(vec![("key1", "field2.1")]))
+        ),
+        (
+            doc_overrides_get_children_returns_none,
+            DocOverrides::new(vec![
+                ("key1", "field1"),
+                ("key2", "field2"),
+                ("key3", "field3"),
+            ]),
+            None
+        ),
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -937,7 +937,12 @@ Data Representation:                    {}
             ($sect:expr) => {{
                 let mut pos = 1;
                 match $sect {
-                    Ok(s) => s.dump(None, None, &mut pos, writer)?,
+                    Ok(s) => s.dump(
+                        None,
+                        grib_template_helpers::DocOverrides::empty(),
+                        &mut pos,
+                        writer,
+                    )?,
                     Err(e) => writeln!(writer, "error: {}", e)?,
                 }
             }};

--- a/src/context.rs
+++ b/src/context.rs
@@ -689,13 +689,17 @@ Data Representation:                    {}
     ///                     horizontal: grib::def::grib2::template::param_set::Horizontal {
     ///                         first_surface: grib::def::grib2::template::param_set::FixedSurface {
     ///                             surface_type: 1,
-    ///                             scale_factor: -127,
-    ///                             scaled_value: -2147483647,
+    ///                             value: grib::def::grib2::template::param_set::ScaledValue {
+    ///                                 scale_factor: -127,
+    ///                                 scaled_value: -2147483647,
+    ///                             },
     ///                         },
     ///                         second_surface: grib::def::grib2::template::param_set::FixedSurface {
     ///                             surface_type: 255,
-    ///                             scale_factor: -127,
-    ///                             scaled_value: -2147483647,
+    ///                             value: grib::def::grib2::template::param_set::ScaledValue {
+    ///                                 scale_factor: -127,
+    ///                                 scaled_value: -2147483647,
+    ///                             },
     ///                         },
     ///                     },
     ///                 },
@@ -898,11 +902,11 @@ Data Representation:                    {}
     /// 18        payload.template.forecast_time.time.unit = 0  // Indicator of unit of time range (see Code Table 4.4).
     /// 19-22     payload.template.forecast_time.time.len = 0  // Forecast time in units defined by octet 18.
     /// 23        payload.template.horizontal.first_surface.surface_type = 1  // Type of first fixed surface (see Code Table 4.5).
-    /// 24        payload.template.horizontal.first_surface.scale_factor = -127  // Scale factor of first fixed surface.
-    /// 25-28     payload.template.horizontal.first_surface.scaled_value = -2147483647  // Scaled value of first fixed surface.
+    /// 24        payload.template.horizontal.first_surface.value.scale_factor = -127  // Scale factor of first fixed surface.
+    /// 25-28     payload.template.horizontal.first_surface.value.scaled_value = -2147483647  // Scaled value of first fixed surface.
     /// 29        payload.template.horizontal.second_surface.surface_type = 255  // Type of second fixed surface (see Code Table 4.5).
-    /// 30        payload.template.horizontal.second_surface.scale_factor = -127  // Scale factor of second fixed surface.
-    /// 31-34     payload.template.horizontal.second_surface.scaled_value = -2147483647  // Scaled value of second fixed surface.
+    /// 30        payload.template.horizontal.second_surface.value.scale_factor = -127  // Scale factor of second fixed surface.
+    /// 31-34     payload.template.horizontal.second_surface.value.scaled_value = -2147483647  // Scaled value of second fixed surface.
     /// ###  SECTION 5: DATA REPRESENTATION SECTION (length = 23)
     /// 1-4       header.len = 23  // Length of section in octets (nn).
     /// 5         header.sect_num = 5  // Number of section.

--- a/src/def/grib2/template4.rs
+++ b/src/def/grib2/template4.rs
@@ -111,14 +111,18 @@ pub(crate) mod param_set {
     pub struct Horizontal {
         #[dump(doc(
             surface_type = "Type of first fixed surface (see Code Table 4.5).",
-            scale_factor = "Scale factor of first fixed surface.",
-            scaled_value = "Scaled value of first fixed surface."
+            value(
+                scale_factor = "Scale factor of first fixed surface.",
+                scaled_value = "Scaled value of first fixed surface.",
+            ),
         ))]
         pub first_surface: FixedSurface,
         #[dump(doc(
             surface_type = "Type of second fixed surface (see Code Table 4.5).",
-            scale_factor = "Scale factor of second fixed surface.",
-            scaled_value = "Scaled value of second fixed surface."
+            value(
+                scale_factor = "Scale factor of second fixed surface.",
+                scaled_value = "Scaled value of second fixed surface.",
+            ),
         ))]
         pub second_surface: FixedSurface,
     }
@@ -127,10 +131,8 @@ pub(crate) mod param_set {
     pub struct FixedSurface {
         /// Type of fixed surface (see Code Table 4.5).
         pub surface_type: u8,
-        /// Scale factor of fixed surface.
-        pub scale_factor: i8,
         /// Scaled value of fixed surface.
-        pub scaled_value: i32,
+        pub value: ScaledValue<i8, i32>,
     }
 
     #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]


### PR DESCRIPTION
This PR adds support for deeply nested structs in the field description override feature, which was introduced by PR #206.
Incompatible changes to the signatures of the trait methods of `Dump` and `DumpField` are made once again.

Additionally, the data structure of `def::grib2::template::param_set::Horizontal` is improved using this new support.