### PR TITLE
True Template Support: support for templates 3.2, 3.3, 3.10, 3.41, 3.42, and 3.43

### DIFF
--- a/src/def/grib2/template3.rs
+++ b/src/def/grib2/template3.rs
@@ -48,7 +48,7 @@ pub struct Template3_0 {
 ///                 scaled_value: 0xffffffff,
 ///             },
 ///         },
-///         rotated: param_set::LatLonGrid {
+///         lat_lon: param_set::LatLonGrid {
 ///             grid: param_set::Grid {
 ///                 ni: 2540,
 ///                 nj: 1290,
@@ -80,7 +80,7 @@ pub struct Template3_0 {
 #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_1 {
     pub earth: param_set::EarthShape,
-    pub rotated: param_set::LatLonGrid,
+    pub lat_lon: param_set::LatLonGrid,
     pub rotation: param_set::Rotation,
 }
 
@@ -319,7 +319,7 @@ pub struct Template3_40 {
 #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_41 {
     pub earth: param_set::EarthShape,
-    pub rotated: param_set::GaussianGrid,
+    pub gaussian: param_set::GaussianGrid,
     pub rotation: param_set::Rotation,
 }
 

--- a/src/def/grib2/template3.rs
+++ b/src/def/grib2/template3.rs
@@ -84,6 +84,25 @@ pub struct Template3_1 {
     pub rotation: param_set::Rotation,
 }
 
+/// Grid definition template 3.2 - stretched latitude/longitude (or equidistant
+/// cylindrical, or Plate Carrée).
+#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+pub struct Template3_2 {
+    pub earth: param_set::EarthShape,
+    pub lat_lon: param_set::LatLonGrid,
+    pub stretching: param_set::Stretching,
+}
+
+/// Grid definition template 3.3 - stretched and rotated latitude/longitude (or
+/// equidistant cylindrical, or Plate Carrée).
+#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+pub struct Template3_3 {
+    pub earth: param_set::EarthShape,
+    pub lat_lon: param_set::LatLonGrid,
+    pub rotation: param_set::Rotation,
+    pub stretching: param_set::Stretching,
+}
+
 /// Grid definition template 3.10 - Mercator.
 #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_10 {
@@ -304,6 +323,24 @@ pub struct Template3_41 {
     pub rotation: param_set::Rotation,
 }
 
+/// Grid definition template 3.42 - stretched Gaussian latitude/longitude.
+#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+pub struct Template3_42 {
+    pub earth: param_set::EarthShape,
+    pub gaussian: param_set::GaussianGrid,
+    pub stretching: param_set::Stretching,
+}
+
+/// Grid definition template 3.43 - stretched and rotated Gaussian
+/// latitude/longitude.
+#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+pub struct Template3_43 {
+    pub earth: param_set::EarthShape,
+    pub gaussian: param_set::GaussianGrid,
+    pub rotation: param_set::Rotation,
+    pub stretching: param_set::Stretching,
+}
+
 /// Grid definition template 3.101 - general unstructured grid.
 #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_101 {
@@ -410,6 +447,16 @@ pub(crate) mod param_set {
         pub south_pole_lon: u32,
         /// Angle of rotation of projection.
         pub rot_angle: f32,
+    }
+
+    #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+    pub struct Stretching {
+        /// Latitude of the pole of stretching.
+        pub pole_lat: i32,
+        /// Longitude of the pole of stretching.
+        pub pole_lon: u32,
+        /// Stretching factor.
+        pub factor: u32,
     }
 
     #[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromSlice, WriteToBuffer, Dump)]

--- a/src/def/grib2/template3.rs
+++ b/src/def/grib2/template3.rs
@@ -84,6 +84,36 @@ pub struct Template3_1 {
     pub rotation: param_set::Rotation,
 }
 
+/// Grid definition template 3.10 - Mercator.
+#[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+pub struct Template3_10 {
+    pub earth_shape: param_set::EarthShape,
+    /// Ni - number of points along a parallel.
+    pub ni: u32,
+    /// Nj - number of points along a meridian.
+    pub nj: u32,
+    /// La1 - latitude of first grid point.
+    pub first_point_lat: i32,
+    /// Lo1 - longitude of first grid point.
+    pub first_point_lon: u32,
+    pub resolution_and_component_flags: param_set::ResolutionAndComponentFlags,
+    /// LaD - Latitude(s) at which the Mercator projection intersects the Earth
+    /// (Latitude(s) where Di and Dj are specified).
+    pub lad: i32,
+    /// La2 - latitude of last grid point.
+    pub last_point_lat: i32,
+    /// Lo2 - longitude of last grid point.
+    pub last_point_lon: u32,
+    pub scanning_mode: param_set::ScanningMode,
+    /// Orientation of the grid, angle between i direction on the map and the
+    /// equator (see Note 1).
+    pub orientation: u32,
+    /// Di - longitudinal direction grid length (see Note 2).
+    pub di: u32,
+    /// Dj - latitudinal direction grid length (see Note 2).
+    pub dj: u32,
+}
+
 /// Grid definition template 3.20 - polar stereographic projection.
 ///
 /// # Examples
@@ -264,6 +294,14 @@ pub struct Template3_30 {
 pub struct Template3_40 {
     pub earth: param_set::EarthShape,
     pub gaussian: param_set::GaussianGrid,
+}
+
+/// Grid definition template 3.41 - rotated Gaussian latitude/longitude.
+#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+pub struct Template3_41 {
+    pub earth: param_set::EarthShape,
+    pub rotated: param_set::GaussianGrid,
+    pub rotation: param_set::Rotation,
 }
 
 /// Grid definition template 3.101 - general unstructured grid.

--- a/src/grid/rotated_ll.rs
+++ b/src/grid/rotated_ll.rs
@@ -14,15 +14,15 @@ impl crate::GridShortName for Template3_1 {
 
 impl GridPointIndex for Template3_1 {
     fn grid_shape(&self) -> (usize, usize) {
-        self.rotated.grid_shape()
+        self.lat_lon.grid_shape()
     }
 
     fn scanning_mode(&self) -> &crate::def::grib2::template::param_set::ScanningMode {
-        self.rotated.scanning_mode()
+        self.lat_lon.scanning_mode()
     }
 
     fn ij(&self) -> Result<GridPointIndexIterator, GribError> {
-        self.rotated.ij()
+        self.lat_lon.ij()
     }
 }
 
@@ -34,7 +34,7 @@ impl LatLons for Template3_1 {
 
     fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
         let iter = Unrotate::new(
-            self.rotated.latlons_unchecked()?,
+            self.lat_lon.latlons_unchecked()?,
             &self.rotation,
             self.angle_unit() as f32,
         );
@@ -44,7 +44,7 @@ impl LatLons for Template3_1 {
 
 impl AngleUnit for Template3_1 {
     fn angle_unit(&self) -> f64 {
-        self.rotated.grid.angle_unit()
+        self.lat_lon.grid.angle_unit()
     }
 }
 


### PR DESCRIPTION
This PR adds support for templates 3.2, 3.3, 3.10, 3.41, 3.42, and 3.43 as part of "True Template Support" (#140).
Additionally, for consistency, the `rotated` parameter in Template 3.1 is changed to `lat_lon`.