### PR TITLE
Generalize the implementation of "missing" parameter values in templates

### DIFF
--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -2,7 +2,10 @@ use std::fmt::{self, Display, Formatter};
 
 use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 
-use crate::codetables::{grib2::*, *};
+use crate::{
+    MissingValue,
+    codetables::{grib2::*, *},
+};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ForecastTime {
@@ -67,7 +70,7 @@ impl FixedSurface {
     }
 
     pub fn value(&self) -> f64 {
-        if self.value_is_nan() {
+        if self.scaled_value.is_missing() {
             f64::NAN
         } else {
             let factor: f64 = 10_f64.powi(-i32::from(self.scale_factor));
@@ -122,30 +125,16 @@ impl FixedSurface {
         Some(unit)
     }
 
-    /// Checks if the scale factor should be treated as missing.
-    pub fn scale_factor_is_nan(&self) -> bool {
-        // Handle as NaN if all bits are 1. Note that this is i8::MIN + 1 and not
-        // i8::MIN.
-        self.scale_factor == i8::MIN + 1
-    }
-
-    /// Checks if the scaled value should be treated as missing.
-    pub fn value_is_nan(&self) -> bool {
-        // Handle as NaN if all bits are 1. Note that this is i32::MIN + 1 and not
-        // i32::MIN.
-        self.scaled_value == i32::MIN + 1
-    }
-
     pub fn describe(&self) -> (String, String, String) {
         let stype = CodeTable4_5
             .lookup(usize::from(self.surface_type))
             .to_string();
-        let scale_factor = if self.scale_factor_is_nan() {
+        let scale_factor = if self.scale_factor.is_missing() {
             "Missing".to_owned()
         } else {
             self.scale_factor.to_string()
         };
-        let scaled_value = if self.value_is_nan() {
+        let scaled_value = if self.scaled_value.is_missing() {
             "Missing".to_owned()
         } else {
             self.scaled_value.to_string()

--- a/src/def/grib2.rs
+++ b/src/def/grib2.rs
@@ -1,4 +1,8 @@
 //! Definitions of parameters contained in GRIB2 data.
+//!
+//! For parameter values represented as unsigned or signed integers,
+//! [`MissingValue`](crate::MissingValue) trait can be used to check whether
+//! they are missing values.
 
 use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod reader;
 mod test_utils;
 mod time;
 pub mod utils;
+mod value;
 
 pub use grib_template_helpers::{Dump, TryFromSlice, WriteToBuffer};
 
@@ -33,6 +34,7 @@ pub use crate::{
     parser::*,
     reader::*,
     time::*,
+    value::*,
 };
 
 #[doc = include_str!("../README.md")]

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,88 @@
+/// Missing values defined in the GRIB2 regulation.
+///
+/// Regulation 92.1.4 states as follows:
+///
+/// > All bits set to "1" for any value indicates that value is missing. This
+/// > rule shall not apply to packed data.
+///
+/// # Examples
+///
+/// ```
+/// use grib::{MissingValue, TryFromSlice};
+///
+/// let missing = i32::missing();
+/// let read_from_slice =
+///     i32::try_from_slice(&[0xff, 0xff, 0xff, 0xff].as_slice(), &mut 0).unwrap();
+/// assert_eq!(missing, read_from_slice);
+/// assert!(missing.is_missing());
+/// ```
+pub trait MissingValue {
+    /// Returns missing value.
+    fn missing() -> Self;
+
+    /// Checks if the value is regarded as a missing value.
+    fn is_missing(&self) -> bool;
+}
+
+macro_rules! add_missing_value_impl_for_unsigned_integer_types {
+    ($($ty:ty,)*) => ($(
+        impl MissingValue for $ty {
+            fn missing() -> Self {
+                Self::MAX
+            }
+
+            fn is_missing(&self) -> bool {
+                *self == Self::MAX
+            }
+        }
+    )*);
+}
+
+add_missing_value_impl_for_unsigned_integer_types![u8, u16, u32, u64,];
+
+macro_rules! add_missing_value_impl_for_signed_integer_types {
+    ($($ty:ty,)*) => ($(
+        impl MissingValue for $ty {
+            fn missing() -> Self {
+                Self::MIN + 1
+            }
+
+            fn is_missing(&self) -> bool {
+                *self == Self::MIN + 1
+            }
+        }
+    )*);
+}
+
+add_missing_value_impl_for_signed_integer_types![i8, i16, i32, i64,];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TryFromSlice as _;
+
+    macro_rules! test_missing_values {
+        ($(($name:ident, $ty:ty),)*) => ($(
+            #[test]
+            fn $name() -> Result<(), Box<dyn std::error::Error>> {
+                let expected = [0xff_u8; (<$ty>::BITS / 8) as usize];
+                let expected = <$ty>::try_from_slice(expected.as_slice(), &mut 0)?;
+                let actual = <$ty>::missing();
+                assert_eq!(actual, expected);
+                assert!(actual.is_missing());
+                Ok(())
+            }
+        )*);
+    }
+
+    test_missing_values! {
+        (missing_value_for_u8, u8),
+        (missing_value_for_u16, u16),
+        (missing_value_for_u32, u32),
+        (missing_value_for_u64, u64),
+        (missing_value_for_i8, i8),
+        (missing_value_for_i16, i16),
+        (missing_value_for_i32, i32),
+        (missing_value_for_i64, i64),
+    }
+}


### PR DESCRIPTION
This PR generalizes the implementation of "missing" parameter values in templates.

With the help of the methods in the newly added `MissingValue` trait, users can now write code like `value.is_missing()`.
So, `FixedSurface::scale_factor_is_nan` and `FixedSurface::value_is_nan` will be removed in this PR.