### PR TITLE
Usability improvements by adding trait implementations

### DIFF
--- a/grib-template-helpers/src/dump.rs
+++ b/grib-template-helpers/src/dump.rs
@@ -60,6 +60,18 @@ pub trait Dump {
     ) -> Result<(), Error>;
 }
 
+impl<T: Dump + ?Sized> Dump for &T {
+    fn dump<'d, W: Write>(
+        &self,
+        parent: Option<&Cow<str>>,
+        doc_overrides: DocOverrides<'d>,
+        pos: &mut usize,
+        output: &mut W,
+    ) -> Result<(), Error> {
+        (*self).dump(parent, doc_overrides, pos, output)
+    }
+}
+
 pub trait DumpField: OctetSize {
     fn dump_field<'d, W: Write>(
         &self,

--- a/grib-template-helpers/src/write_to_buffer.rs
+++ b/grib-template-helpers/src/write_to_buffer.rs
@@ -55,6 +55,16 @@ pub trait WriteToBuffer {
     fn num_bytes_required(&self) -> usize;
 }
 
+impl<T: WriteToBuffer + ?Sized> WriteToBuffer for &T {
+    fn write_to_buffer(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
+        (*self).write_to_buffer(buf)
+    }
+
+    fn num_bytes_required(&self) -> usize {
+        (*self).num_bytes_required()
+    }
+}
+
 macro_rules! add_impl_for_unsigned_integer_types {
     ($($ty:ty,)*) => ($(
         impl WriteToBuffer for $ty {

--- a/src/def/grib2.rs
+++ b/src/def/grib2.rs
@@ -6,7 +6,7 @@
 
 use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 
-#[derive(Debug, PartialEq, TryFromSlice, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, Dump)]
 pub struct Section<T>
 where
     T: PartialEq + crate::TryFromSlice + crate::Dump,
@@ -15,7 +15,7 @@ where
     pub payload: T,
 }
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct SectionHeader {
     /// Length of section in octets (nn).
     pub len: u32,
@@ -24,7 +24,7 @@ pub struct SectionHeader {
 }
 
 /// SECTION 0 - Indicator section.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Section0 {
     /// "GRIB" (coded according to the International Alphabet No. 5).
     pub identifier: [u8; 4],
@@ -41,7 +41,7 @@ pub struct Section0 {
 /// Section 1 - Identification section.
 pub type Section1 = Section<Section1Payload>;
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Section1Payload {
     /// Identification of originating/generating centre (see Common Code table
     /// C-11).
@@ -74,7 +74,7 @@ pub struct Section1Payload {
     pub optional: Option<Section1PayloadOptional>,
 }
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Section1PayloadOptional {
     /// Identification template number (optional, see Code table 1.5).
     pub template_num: u16,
@@ -84,7 +84,7 @@ pub struct Section1PayloadOptional {
     pub template: IdentificationTemplate,
 }
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum IdentificationTemplate {
@@ -96,7 +96,7 @@ pub enum IdentificationTemplate {
 /// Section 3 - Grid definition section.
 pub type Section3 = Section<Section3Payload>;
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Section3Payload {
     /// Source of grid definition (see Code table 3.0 and Note 1).
     pub grid_def_source: u8,
@@ -114,7 +114,7 @@ pub struct Section3Payload {
     pub template: GridDefinitionTemplate,
 }
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum GridDefinitionTemplate {
@@ -129,7 +129,7 @@ pub enum GridDefinitionTemplate {
 /// Section 4 - Product definition section.
 pub type Section4 = Section<Section4Payload>;
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Section4Payload {
     /// Number of coordinate values after template or number of information
     /// according to 3D vertical coordinate GRIB2 message (see Notes 1 and 5).
@@ -142,7 +142,7 @@ pub struct Section4Payload {
     pub template: ProductDefinitionTemplate,
 }
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum ProductDefinitionTemplate {
@@ -156,7 +156,7 @@ pub enum ProductDefinitionTemplate {
 /// Section 5 - Data representation section.
 pub type Section5 = Section<Section5Payload>;
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Section5Payload {
     /// Number of data points where one or more values are specified in Section
     /// 7 when a bit map is present, total number of data points when a bit map
@@ -170,7 +170,7 @@ pub struct Section5Payload {
     pub template: DataRepresentationTemplate,
 }
 
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum DataRepresentationTemplate {
@@ -192,7 +192,7 @@ pub enum DataRepresentationTemplate {
 /// Section 6 - Bit-map section.
 pub type Section6 = Section<Section6Payload>;
 
-#[derive(Debug, PartialEq, TryFromSlice, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, Dump)]
 pub struct Section6Payload {
     /// Bit-map indicator (see Code table 6.0 and the Note).
     pub bitmap_indicator: u8,
@@ -213,7 +213,7 @@ pub mod template {
         };
 
         /// Date and time.
-        #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+        #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
         pub struct DateTime {
             /// Year (4 digits).
             pub year: u16,
@@ -230,7 +230,7 @@ pub mod template {
         }
 
         /// Value with a scaling.
-        #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+        #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
         pub struct ScaledValue<F, V>
         where
             F: crate::TryFromSlice + crate::WriteToBuffer + grib_template_helpers::DumpField,
@@ -243,7 +243,7 @@ pub mod template {
         }
 
         /// Time range.
-        #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+        #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
         pub struct TimeRange<L>
         where
             L: crate::TryFromSlice + crate::WriteToBuffer + grib_template_helpers::DumpField,

--- a/src/def/grib2/template1.rs
+++ b/src/def/grib2/template1.rs
@@ -1,14 +1,14 @@
 use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 
 /// Identification template 1.0 - calendar definition.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template1_0 {
     /// Type of calendar (see Code table 1.6).
     pub calendar_type: u8,
 }
 
 /// Identification template 1.1 - paleontological offset.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template1_1 {
     /// Number of tens of thousands of years of offset.
     pub paleontological_offset: u16,
@@ -16,7 +16,7 @@ pub struct Template1_1 {
 
 /// Identification template 1.2 - calendar definition and paleontological
 /// offset.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template1_2 {
     /// Type of calendar (see Code table 1.6).
     pub calendar_type: u8,

--- a/src/def/grib2/template3.rs
+++ b/src/def/grib2/template3.rs
@@ -2,7 +2,7 @@ use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 
 /// Grid definition template 3.0 - latitude/longitude (or equidistant
 /// cylindrical, or Plate Carrée).
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_0 {
     pub earth: param_set::EarthShape,
     pub lat_lon: param_set::LatLonGrid,
@@ -77,7 +77,7 @@ pub struct Template3_0 {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_1 {
     pub earth: param_set::EarthShape,
     pub lat_lon: param_set::LatLonGrid,
@@ -86,7 +86,7 @@ pub struct Template3_1 {
 
 /// Grid definition template 3.2 - stretched latitude/longitude (or equidistant
 /// cylindrical, or Plate Carrée).
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_2 {
     pub earth: param_set::EarthShape,
     pub lat_lon: param_set::LatLonGrid,
@@ -95,7 +95,7 @@ pub struct Template3_2 {
 
 /// Grid definition template 3.3 - stretched and rotated latitude/longitude (or
 /// equidistant cylindrical, or Plate Carrée).
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_3 {
     pub earth: param_set::EarthShape,
     pub lat_lon: param_set::LatLonGrid,
@@ -104,7 +104,7 @@ pub struct Template3_3 {
 }
 
 /// Grid definition template 3.10 - Mercator.
-#[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_10 {
     pub earth_shape: param_set::EarthShape,
     /// Ni - number of points along a parallel.
@@ -190,7 +190,7 @@ pub struct Template3_10 {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_20 {
     pub earth_shape: param_set::EarthShape,
     /// Nx - number of points along the x-axis.
@@ -273,7 +273,7 @@ pub struct Template3_20 {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_30 {
     pub earth_shape: param_set::EarthShape,
     /// Nx - number of points along the x-axis.
@@ -309,14 +309,14 @@ pub struct Template3_30 {
 }
 
 /// Grid definition template 3.40 - Gaussian latitude/longitude.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_40 {
     pub earth: param_set::EarthShape,
     pub gaussian: param_set::GaussianGrid,
 }
 
 /// Grid definition template 3.41 - rotated Gaussian latitude/longitude.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_41 {
     pub earth: param_set::EarthShape,
     pub gaussian: param_set::GaussianGrid,
@@ -324,7 +324,7 @@ pub struct Template3_41 {
 }
 
 /// Grid definition template 3.42 - stretched Gaussian latitude/longitude.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_42 {
     pub earth: param_set::EarthShape,
     pub gaussian: param_set::GaussianGrid,
@@ -333,7 +333,7 @@ pub struct Template3_42 {
 
 /// Grid definition template 3.43 - stretched and rotated Gaussian
 /// latitude/longitude.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_43 {
     pub earth: param_set::EarthShape,
     pub gaussian: param_set::GaussianGrid,
@@ -342,7 +342,7 @@ pub struct Template3_43 {
 }
 
 /// Grid definition template 3.101 - general unstructured grid.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template3_101 {
     /// Shape of the Earth (see Code table 3.2).
     pub earth_shape: u8,
@@ -361,7 +361,7 @@ pub(crate) mod param_set {
 
     use super::super::template::param_set::ScaledValue;
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct EarthShape {
         /// Shape of the Earth (see Code table 3.2).
         pub shape: u8,
@@ -385,7 +385,7 @@ pub(crate) mod param_set {
         pub minor_axis: ScaledValue<u8, u32>,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct LatLonGrid {
         pub grid: Grid,
         /// Di - i direction increment (see Notes 1 and 5).
@@ -395,7 +395,7 @@ pub(crate) mod param_set {
         pub scanning_mode: ScanningMode,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct GaussianGrid {
         pub grid: Grid,
         /// Di - i direction increment (see Notes 1 and 5).
@@ -405,7 +405,7 @@ pub(crate) mod param_set {
         pub scanning_mode: ScanningMode,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct Grid {
         /// Ni - number of points along a parallel.
         pub ni: u32,
@@ -439,7 +439,7 @@ pub(crate) mod param_set {
         pub u8,
     );
 
-    #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct Rotation {
         /// Latitude of the southern pole of projection.
         pub south_pole_lat: i32,
@@ -449,7 +449,7 @@ pub(crate) mod param_set {
         pub rot_angle: f32,
     }
 
-    #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct Stretching {
         /// Latitude of the pole of stretching.
         pub pole_lat: i32,

--- a/src/def/grib2/template4.rs
+++ b/src/def/grib2/template4.rs
@@ -2,7 +2,7 @@ use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 
 /// Product definition template 4.0 - Analysis or forecast at a horizontal level
 /// or in a horizontal layer at a point in time.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template4_0 {
     pub param: param_set::ProductParam,
     pub generating_process: param_set::GeneratingProcess,
@@ -17,7 +17,7 @@ pub struct Template4_0 {
 /// Product definition template 4.1 - Individual ensemble forecast, control and
 /// perturbed, at a horizontal level or in a horizontal layer at a point in
 /// time.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template4_1 {
     pub param: param_set::ProductParam,
     #[dump(doc(
@@ -31,7 +31,7 @@ pub struct Template4_1 {
 
 /// Product definition template 4.2 - Derived forecast based on all ensemble
 /// members at a horizontal level or in a horizontal layer at a point in time.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template4_2 {
     pub param: param_set::ProductParam,
     #[dump(doc(
@@ -45,7 +45,7 @@ pub struct Template4_2 {
 
 /// Product definition template 4.5 - Probability forecasts at a horizontal
 /// level or in a horizontal layer at a point in time.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template4_5 {
     pub param: param_set::ProductParam,
     #[dump(doc(
@@ -59,7 +59,7 @@ pub struct Template4_5 {
 
 /// Product definition template 4.6 - Percentile forecasts at a horizontal level
 /// or in a horizontal layer at a point in time.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template4_6 {
     pub param: param_set::ProductParam,
     pub generating_process: param_set::GeneratingProcess,
@@ -73,7 +73,7 @@ pub(crate) mod param_set {
 
     use super::super::template::param_set::{ScaledValue, TimeRange};
 
-    #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct ProductParam {
         /// Parameter category (see Code Table 4.1).
         pub category: u8,
@@ -81,7 +81,7 @@ pub(crate) mod param_set {
         pub num: u8,
     }
 
-    #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct GeneratingProcess {
         /// Type of generating process (see Code Table 4.3).
         pub process_type: u8,
@@ -93,7 +93,7 @@ pub(crate) mod param_set {
         pub process_id: u8,
     }
 
-    #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct ForecastTime {
         /// Hours after reference time of data cutoff (see Note 1).
         pub cutoff_hours: u16,
@@ -107,7 +107,7 @@ pub(crate) mod param_set {
         pub time: TimeRange<i32>,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct Horizontal {
         #[dump(doc(
             surface_type = "Type of first fixed surface (see Code Table 4.5).",
@@ -127,7 +127,7 @@ pub(crate) mod param_set {
         pub second_surface: FixedSurface,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct FixedSurface {
         /// Type of fixed surface (see Code Table 4.5).
         pub surface_type: u8,
@@ -135,7 +135,7 @@ pub(crate) mod param_set {
         pub value: ScaledValue<i8, i32>,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct EnsembleForecast {
         /// Type of ensemble forecast (see Code Table 4.6).
         pub ensemble_forecast_type: u8,
@@ -145,7 +145,7 @@ pub(crate) mod param_set {
         pub num_forecasts: u8,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct DerivedForecast {
         /// Derived forecast (see Code Table 4.7).
         pub derived_forecast_type: u8,
@@ -153,7 +153,7 @@ pub(crate) mod param_set {
         pub num_forecasts: u8,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct ProbabilityForecasts {
         /// Forecast probability number.
         pub forecast_probability_num: u8,
@@ -175,7 +175,7 @@ pub(crate) mod param_set {
         pub upper_limit: ScaledValue<i8, i32>,
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct PercentileForecasts {
         /// Percentile value (from 100% to 0%).
         pub percentile_value: u8,

--- a/src/def/grib2/template5.rs
+++ b/src/def/grib2/template5.rs
@@ -1,7 +1,7 @@
 use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 
 /// Data representation template 5.0 - Grid point data - simple packing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_0 {
     pub simple: param_set::SimplePacking,
     /// Type of original field values (see Code table 5.1).
@@ -10,7 +10,7 @@ pub struct Template5_0 {
 
 /// Data representation template 5.1 - Matrix value at grid point - simple
 /// packing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_1 {
     pub simple: param_set::SimplePacking,
     /// Type of original field values (see Code table 5.1).
@@ -50,7 +50,7 @@ pub struct Template5_1 {
 }
 
 /// Data representation template 5.2 - Grid point data - complex packing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_2 {
     pub simple: param_set::SimplePacking,
     /// Type of original field values (see Code table 5.1).
@@ -60,7 +60,7 @@ pub struct Template5_2 {
 
 /// Data representation template 5.3 - Grid point data - complex packing and
 /// spatial differencing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_3 {
     pub simple: param_set::SimplePacking,
     /// Type of original field values (see Code table 5.1).
@@ -76,7 +76,7 @@ pub struct Template5_3 {
 
 /// Data representation template 5.4 - Grid point data - IEEE floating point
 /// data.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_4 {
     /// Precision (see Code table 5.7).
     pub precision: u8,
@@ -84,7 +84,7 @@ pub struct Template5_4 {
 
 /// Data representation template 5.40 - Grid point data - JPEG 2000 code stream
 /// format.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_40 {
     pub simple: param_set::SimplePacking,
     /// Type of original field values (see Code table 5.1).
@@ -99,7 +99,7 @@ pub struct Template5_40 {
 
 /// Data representation template 5.41 - Grid point data - Portable Network
 /// Graphics (PNG).
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_41 {
     pub simple: param_set::SimplePacking,
     /// Type of original field values (see Code table 5.1).
@@ -108,7 +108,7 @@ pub struct Template5_41 {
 
 /// Data representation template 5.42 - Grid point data - CCSDS recommended
 /// lossless compression.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_42 {
     pub simple: param_set::SimplePacking,
     /// Type of original field values (see Code table 5.1).
@@ -122,7 +122,7 @@ pub struct Template5_42 {
 }
 
 /// Data representation template 5.50 - Spectral data - simple packing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_50 {
     pub simple: param_set::SimplePacking,
     /// Real part of (0.0) coefficient (IEEE 32-bit floating-point value).
@@ -131,7 +131,7 @@ pub struct Template5_50 {
 
 /// Data representation template 5.51 - Spherical harmonics data - complex
 /// packing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_51 {
     pub simple: param_set::SimplePacking,
     /// P - Laplacian scaling factor (expressed in 10-6 units).
@@ -153,7 +153,7 @@ pub struct Template5_51 {
 
 /// Data representation template 5.53 - Spectral data for limited area models -
 /// complex packing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_53 {
     pub simple: param_set::SimplePacking,
     /// Bi-Fourier sub-truncation type (see Code table 5.25).
@@ -176,7 +176,7 @@ pub struct Template5_53 {
 
 /// Data representation template 5.61 - Grid point data - simple packing with
 /// logarithm pre-processing.
-#[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_61 {
     pub simple: param_set::SimplePacking,
     /// Pre-processing parameter (B) (IEEE 32-bit floating-point value).
@@ -184,7 +184,7 @@ pub struct Template5_61 {
 }
 
 /// Data representation template 5.200 - Run length packing with level values.
-#[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+#[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
 pub struct Template5_200 {
     /// Number of bits used for each packed value in the run length packing with
     /// level value.
@@ -203,7 +203,7 @@ pub struct Template5_200 {
 pub(crate) mod param_set {
     use grib_template_derive::{Dump, TryFromSlice, WriteToBuffer};
 
-    #[derive(Debug, PartialEq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct SimplePacking {
         /// Reference value (R) (IEEE 32-bit floating-point value).
         pub ref_val: f32,
@@ -223,7 +223,7 @@ pub(crate) mod param_set {
         }
     }
 
-    #[derive(Debug, PartialEq, Eq, TryFromSlice, WriteToBuffer, Dump)]
+    #[derive(Debug, PartialEq, Eq, Clone, TryFromSlice, WriteToBuffer, Dump)]
     pub struct ComplexPacking {
         /// Group splitting method used (see Code table 5.4).
         pub group_splitting_method: u8,

--- a/src/encoder/message.rs
+++ b/src/encoder/message.rs
@@ -313,81 +313,6 @@ pub trait WriteGrib2PointValues {
     fn write_data_sections(&self, buf: &mut [u8]) -> Result<usize, &'static str>;
 }
 
-macro_rules! add_impl_for_u8_slices {
-    ($(($trait:ty,$len_method:ident,$write_method:ident,$sect_num:expr),)*) => ($(
-        impl $trait for [u8] {
-            fn $len_method(&self) -> usize {
-                self.as_ref().len() + 5
-            }
-
-            fn $write_method(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
-                let len = self.$len_method();
-                if buf.len() < len {
-                    return Err("destination buffer is too small");
-                }
-
-                let mut pos = 0;
-                pos += write_section_header(len as u32, $sect_num, &mut buf[pos..])?;
-                buf[pos..len].copy_from_slice(self.as_ref());
-                Ok(len)
-            }
-        }
-    )*);
-}
-
-add_impl_for_u8_slices![
-    (WriteGrib2Ident, section1_len, write_section1, 1),
-    (WriteGrib2LocalUse, section2_len, write_section2, 2),
-    (WriteGrib2GridDef, section3_len, write_section3, 3),
-    (WriteGrib2ProductDef, section4_len, write_section4, 4),
-];
-
-macro_rules! add_impl_for_payload_structs {
-    ($(($trait:ty,$ty:ty,$len_method:ident,$write_method:ident,$sect_num:expr),)*) => ($(
-        impl $trait for $ty {
-            fn $len_method(&self) -> usize {
-                self.num_bytes_required() + 5
-            }
-
-            fn $write_method(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
-                let len = self.$len_method();
-                if buf.len() < len {
-                    return Err("destination buffer is too small");
-                }
-
-                let mut pos = 0;
-                pos += write_section_header(len as u32, $sect_num, &mut buf[pos..])?;
-                pos += self.write_to_buffer(&mut buf[pos..])?;
-                Ok(pos)
-            }
-        }
-    )*);
-}
-
-add_impl_for_payload_structs![
-    (
-        WriteGrib2Ident,
-        crate::def::grib2::Section1Payload,
-        section1_len,
-        write_section1,
-        1
-    ),
-    (
-        WriteGrib2GridDef,
-        crate::def::grib2::Section3Payload,
-        section3_len,
-        write_section3,
-        3
-    ),
-    (
-        WriteGrib2ProductDef,
-        crate::def::grib2::Section4Payload,
-        section4_len,
-        write_section4,
-        4
-    ),
-];
-
 /// A serializer that writes the byte sequence of sections concerning GPV data
 /// to the output buffer.
 pub trait WriteGrib2DataSections {
@@ -447,29 +372,6 @@ pub(crate) fn write_section_header(
     buf: &mut [u8],
 ) -> Result<usize, &'static str> {
     crate::def::grib2::SectionHeader { len, sect_num }.write_to_buffer(buf)
-}
-
-impl<'a, 'd, P> WriteGrib2MessageIterL3 for (&'a P, &'a GpvEncoder<'d>)
-where
-    P: WriteGrib2ProductDef,
-{
-    type S4<'s>
-        = P
-    where
-        Self: 's;
-
-    type SD<'s>
-        = GpvEncoder<'d>
-    where
-        Self: 's;
-
-    fn section4(&self) -> &Self::S4<'_> {
-        self.0
-    }
-
-    fn data_sections(&self) -> &Self::SD<'_> {
-        self.1
-    }
 }
 
 mod impls;

--- a/src/encoder/message.rs
+++ b/src/encoder/message.rs
@@ -315,7 +315,7 @@ pub trait WriteGrib2PointValues {
 
 macro_rules! add_impl_for_u8_slices {
     ($(($trait:ty,$len_method:ident,$write_method:ident,$sect_num:expr),)*) => ($(
-        impl<T: AsRef<[u8]>> $trait for T {
+        impl $trait for [u8] {
             fn $len_method(&self) -> usize {
                 self.as_ref().len() + 5
             }
@@ -472,6 +472,7 @@ where
     }
 }
 
+mod impls;
 mod multigrid;
 mod multiproduct;
 mod single;

--- a/src/encoder/message/impls.rs
+++ b/src/encoder/message/impls.rs
@@ -125,6 +125,81 @@ add_impl_for_references![
     ),
 ];
 
+macro_rules! add_impl_for_u8_slices {
+    ($(($trait:ty,$len_method:ident,$write_method:ident,$sect_num:expr),)*) => ($(
+        impl $trait for [u8] {
+            fn $len_method(&self) -> usize {
+                self.as_ref().len() + 5
+            }
+
+            fn $write_method(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
+                let len = self.$len_method();
+                if buf.len() < len {
+                    return Err("destination buffer is too small");
+                }
+
+                let mut pos = 0;
+                pos += write_section_header(len as u32, $sect_num, &mut buf[pos..])?;
+                buf[pos..len].copy_from_slice(self.as_ref());
+                Ok(len)
+            }
+        }
+    )*);
+}
+
+add_impl_for_u8_slices![
+    (WriteGrib2Ident, section1_len, write_section1, 1),
+    (WriteGrib2LocalUse, section2_len, write_section2, 2),
+    (WriteGrib2GridDef, section3_len, write_section3, 3),
+    (WriteGrib2ProductDef, section4_len, write_section4, 4),
+];
+
+macro_rules! add_impl_for_payload_structs {
+    ($(($trait:ty,$ty:ty,$len_method:ident,$write_method:ident,$sect_num:expr),)*) => ($(
+        impl $trait for $ty {
+            fn $len_method(&self) -> usize {
+                self.num_bytes_required() + 5
+            }
+
+            fn $write_method(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
+                let len = self.$len_method();
+                if buf.len() < len {
+                    return Err("destination buffer is too small");
+                }
+
+                let mut pos = 0;
+                pos += write_section_header(len as u32, $sect_num, &mut buf[pos..])?;
+                pos += self.write_to_buffer(&mut buf[pos..])?;
+                Ok(pos)
+            }
+        }
+    )*);
+}
+
+add_impl_for_payload_structs![
+    (
+        WriteGrib2Ident,
+        crate::def::grib2::Section1Payload,
+        section1_len,
+        write_section1,
+        1
+    ),
+    (
+        WriteGrib2GridDef,
+        crate::def::grib2::Section3Payload,
+        section3_len,
+        write_section3,
+        3
+    ),
+    (
+        WriteGrib2ProductDef,
+        crate::def::grib2::Section4Payload,
+        section4_len,
+        write_section4,
+        4
+    ),
+];
+
 impl<T: WriteGrib2DataSections + ?Sized> WriteGrib2DataSections for &T {
     fn section5_len(&self) -> usize {
         (*self).section5_len()
@@ -148,5 +223,28 @@ impl<T: WriteGrib2DataSections + ?Sized> WriteGrib2DataSections for &T {
 
     fn write_section7(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
         (*self).write_section7(buf)
+    }
+}
+
+impl<'a, 'd, P> WriteGrib2MessageIterL3 for (&'a P, &'a GpvEncoder<'d>)
+where
+    P: WriteGrib2ProductDef,
+{
+    type S4<'s>
+        = P
+    where
+        Self: 's;
+
+    type SD<'s>
+        = GpvEncoder<'d>
+    where
+        Self: 's;
+
+    fn section4(&self) -> &Self::S4<'_> {
+        self.0
+    }
+
+    fn data_sections(&self) -> &Self::SD<'_> {
+        self.1
     }
 }

--- a/src/encoder/message/impls.rs
+++ b/src/encoder/message/impls.rs
@@ -1,0 +1,152 @@
+use super::*;
+
+impl<T: WriteGrib2Message + ?Sized> WriteGrib2Message for &T {
+    type S1<'a>
+        = <T as WriteGrib2Message>::S1<'a>
+    where
+        Self: 'a;
+
+    type Item<'a>
+        = <T as WriteGrib2Message>::Item<'a>
+    where
+        Self: 'a;
+
+    type Iter<'a>
+        = <T as WriteGrib2Message>::Iter<'a>
+    where
+        Self: 'a;
+
+    fn discipline(&self) -> u8 {
+        (*self).discipline()
+    }
+
+    fn section1(&self) -> &Self::S1<'_> {
+        (*self).section1()
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        (*self).iter()
+    }
+}
+
+impl<T: WriteGrib2MessageIterL1 + ?Sized> WriteGrib2MessageIterL1 for &T {
+    type S2<'a>
+        = <T as WriteGrib2MessageIterL1>::S2<'a>
+    where
+        Self: 'a;
+
+    type Item<'a>
+        = <T as WriteGrib2MessageIterL1>::Item<'a>
+    where
+        Self: 'a;
+
+    type Iter<'a>
+        = <T as WriteGrib2MessageIterL1>::Iter<'a>
+    where
+        Self: 'a;
+
+    fn section2(&self) -> Option<&Self::S2<'_>> {
+        (*self).section2()
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        (*self).iter()
+    }
+}
+
+impl<T: WriteGrib2MessageIterL2 + ?Sized> WriteGrib2MessageIterL2 for &T {
+    type S3<'a>
+        = <T as WriteGrib2MessageIterL2>::S3<'a>
+    where
+        Self: 'a;
+
+    type Item<'a>
+        = <T as WriteGrib2MessageIterL2>::Item<'a>
+    where
+        Self: 'a;
+
+    type Iter<'a>
+        = <T as WriteGrib2MessageIterL2>::Iter<'a>
+    where
+        Self: 'a;
+
+    fn section3(&self) -> &Self::S3<'_> {
+        (*self).section3()
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        (*self).iter()
+    }
+}
+
+impl<T: WriteGrib2MessageIterL3 + ?Sized> WriteGrib2MessageIterL3 for &T {
+    type S4<'a>
+        = <T as WriteGrib2MessageIterL3>::S4<'a>
+    where
+        Self: 'a;
+
+    type SD<'a>
+        = <T as WriteGrib2MessageIterL3>::SD<'a>
+    where
+        Self: 'a;
+
+    fn section4(&self) -> &Self::S4<'_> {
+        (*self).section4()
+    }
+
+    fn data_sections(&self) -> &Self::SD<'_> {
+        (*self).data_sections()
+    }
+}
+
+macro_rules! add_impl_for_references {
+    ($(($trait:path,$len_method:ident,$write_method:ident),)*) => ($(
+        impl<T: $trait + ?Sized> $trait for &T {
+            fn $len_method(&self) -> usize {
+                (*self).$len_method()
+            }
+
+            fn $write_method(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
+                (*self).$write_method(buf)
+            }
+        }
+    )*);
+}
+
+add_impl_for_references![
+    (WriteGrib2Ident, section1_len, write_section1),
+    (WriteGrib2LocalUse, section2_len, write_section2),
+    (WriteGrib2GridDef, section3_len, write_section3),
+    (WriteGrib2ProductDef, section4_len, write_section4),
+    (
+        WriteGrib2PointValues,
+        data_sections_len,
+        write_data_sections
+    ),
+];
+
+impl<T: WriteGrib2DataSections + ?Sized> WriteGrib2DataSections for &T {
+    fn section5_len(&self) -> usize {
+        (*self).section5_len()
+    }
+
+    fn write_section5(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
+        (*self).write_section5(buf)
+    }
+
+    fn section6_len(&self) -> usize {
+        (*self).section6_len()
+    }
+
+    fn write_section6(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
+        (*self).write_section6(buf)
+    }
+
+    fn section7_len(&self) -> usize {
+        (*self).section7_len()
+    }
+
+    fn write_section7(&self, buf: &mut [u8]) -> Result<usize, &'static str> {
+        (*self).write_section7(buf)
+    }
+}

--- a/src/encoder/message/multigrid.rs
+++ b/src/encoder/message/multigrid.rs
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<'a, 'd, G, P> WriteGrib2MessageIterL2 for &'a (G, P, GpvEncoder<'d>)
+impl<'d, G, P> WriteGrib2MessageIterL2 for (G, P, GpvEncoder<'d>)
 where
     G: WriteGrib2GridDef,
     P: WriteGrib2ProductDef,
@@ -106,12 +106,12 @@ where
         Self: 's;
 
     type Item<'s>
-        = (&'a P, &'a GpvEncoder<'d>)
+        = (&'s P, &'s GpvEncoder<'d>)
     where
         Self: 's;
 
     type Iter<'s>
-        = Once<(&'a P, &'a GpvEncoder<'d>)>
+        = Once<(&'s P, &'s GpvEncoder<'d>)>
     where
         Self: 's;
 

--- a/src/encoder/message/multiproduct.rs
+++ b/src/encoder/message/multiproduct.rs
@@ -129,7 +129,7 @@ where
     }
 }
 
-impl<'d, P> WriteGrib2MessageIterL3 for &(P, GpvEncoder<'d>)
+impl<'d, P> WriteGrib2MessageIterL3 for (P, GpvEncoder<'d>)
 where
     P: WriteGrib2ProductDef,
 {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -151,6 +151,12 @@ pub trait GridShortName {
     fn short_name(&self) -> &'static str;
 }
 
+impl<T: GridShortName + ?Sized> GridShortName for &T {
+    fn short_name(&self) -> &'static str {
+        (*self).short_name()
+    }
+}
+
 /// A functionality to generate an iterator over latitude/longitude of grid
 /// points.
 pub trait LatLons {
@@ -179,6 +185,17 @@ pub trait LatLons {
             .latlons_unchecked()?
             .map(helpers::normalize_latlon as fn((f32, f32)) -> (f32, f32));
         Ok(iter)
+    }
+}
+
+impl<T: LatLons + ?Sized> LatLons for &T {
+    type Iter<'a>
+        = <T as LatLons>::Iter<'a>
+    where
+        Self: 'a;
+
+    fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
+        (*self).latlons_unchecked()
     }
 }
 
@@ -288,6 +305,16 @@ pub trait GridPointIndex {
     /// Returns an iterator over 2D index `(i, j)` of grid points.
     fn ij(&self) -> Result<GridPointIndexIterator, GribError> {
         GridPointIndexIterator::new(self.grid_shape(), *self.scanning_mode())
+    }
+}
+
+impl<T: GridPointIndex + ?Sized> GridPointIndex for &T {
+    fn grid_shape(&self) -> (usize, usize) {
+        (*self).grid_shape()
+    }
+
+    fn scanning_mode(&self) -> &ScanningMode {
+        (*self).scanning_mode()
     }
 }
 

--- a/tests/encoder.rs
+++ b/tests/encoder.rs
@@ -1,0 +1,99 @@
+use grib::{def::grib2, encoder, encoder::WriteGrib2Message as _};
+
+#[allow(unused)]
+fn grib2_message_from_references(
+    discipline: u8,
+    ident: &grib2::Section1Payload,
+    product: &[u8],
+    lats: &[f64],
+    lngs: &[f64],
+    values: &[f64],
+) -> Result<Vec<u8>, String> {
+    let grid = LatLngGridDef::try_from((lats, lngs))?;
+    if values.len() != grid.num_points() {
+        return Err(format!(
+            "inconsistent numbers of points: values = {}, grid = {}",
+            values.len(),
+            grid.num_points()
+        ));
+    }
+    let encoded = encoder::GpvEncoder::new(
+        std::borrow::Cow::Borrowed(values),
+        encoder::EncodingMethod::ComplexPacking(
+            encoder::SimplePackingStrategy::Decimal(1),
+            encoder::ComplexPackingStrategy::LookAhead(4),
+            encoder::SpatialDifferencingOption::None,
+        ),
+    );
+
+    let sect3_payload = grid.section3();
+    let message = encoder::SingleGrib2Message::new(
+        discipline,
+        ident,
+        None::<&[u8]>,
+        sect3_payload,
+        product,
+        encoded,
+    );
+    let mut buf = vec![0; message.num_octets()];
+    let mut _pos = 0;
+    message.write(&mut buf).map_err(|_e| "unexpected error")?;
+
+    Ok(buf)
+}
+
+struct LatLngGridDef(encoder::LatLonGrid);
+
+impl LatLngGridDef {
+    fn section3(&self) -> grib2::Section3Payload {
+        grib2::Section3Payload {
+            grid_def_source: 0,
+            num_points: self.num_points() as u32,
+            num_point_list_octets: 0,
+            point_list_interpretation: 0,
+            template_num: 0,
+            template: grib2::GridDefinitionTemplate::_3_0(grib2::template::Template3_0 {
+                earth: grib2::template::param_set::EarthShape {
+                    shape: 6,
+                    spherical_earth_radius: grib2::template::param_set::ScaledValue {
+                        scale_factor: 0xff,
+                        scaled_value: 0xffffffff,
+                    },
+                    major_axis: grib2::template::param_set::ScaledValue {
+                        scale_factor: 0xff,
+                        scaled_value: 0xffffffff,
+                    },
+                    minor_axis: grib2::template::param_set::ScaledValue {
+                        scale_factor: 0xff,
+                        scaled_value: 0xffffffff,
+                    },
+                },
+                lat_lon: grib2::template::param_set::LatLonGrid::from(&self.0),
+            }),
+        }
+    }
+
+    fn num_points(&self) -> usize {
+        self.0.shape.0 * self.0.shape.1
+    }
+}
+
+impl TryFrom<(&[f64], &[f64])> for LatLngGridDef {
+    type Error = String;
+
+    fn try_from(value: (&[f64], &[f64])) -> Result<Self, Self::Error> {
+        let (lats, lngs) = value;
+        let ni = lngs.len();
+        let nj = lats.len();
+        if ni == 0 || nj == 0 {
+            return Err(format!("invalid shape: ({ni}, {nj})"));
+        }
+
+        Ok(Self(encoder::LatLonGrid {
+            shape: (ni, nj),
+            first_point: (lats[0], lngs[0]),
+            last_point: (*lats.last().unwrap(), *lngs.last().unwrap()),
+            i_consecutive: true,
+        }))
+    }
+}


### PR DESCRIPTION
This PR makes usability improvements by adding trait implementations.

### Motivation

When using `encoder::WriteGrib2Message` to output a GRIB2 message, users need a type that implements the `encoder::WriteGrib2Ident` trait as a component.
However, until now, for example, while the `encoder::WriteGrib2Ident` trait was implemented for `def::grib2::Section1Payload`, it was not implemented for `&def::grib2::Section1Payload`.
As a result, instances of `def::grib2::Section1Payload` had to be owned rather than borrowed.

Furthermore, the structs and enums under `def::grib2` did not implement the `Clone` trait.
Consequently, the workaround of cloning borrowed data and taking ownership of it could not be used either.

These represent significant usability constraints.

### Solution

The goal of this PR is to eliminate these usability constraints related to ownership by implementing most of the public traits for borrowed types.
Additionally, by adding `Clone` trait implementations to the structs and enums under `def::grib2`, I improve their usability.