### PR TITLE
Avoid computing lat/lon coordinates for binary decode exports

### DIFF
--- a/cli/src/commands/decode.rs
+++ b/cli/src/commands/decode.rs
@@ -46,7 +46,11 @@ pub fn exec(args: &ArgMatches) -> Result<()> {
         .iter()
         .find(|(index, _)| index == message_index)
         .ok_or_else(|| anyhow::anyhow!("no such index: {}.{}", message_index.0, message_index.1))?;
-    let latlons = submessage.latlons();
+    let latlons = if args.contains_id("big-endian") || args.contains_id("little-endian") {
+        None
+    } else {
+        Some(submessage.latlons())
+    };
     let decoder = grib::Grib2SubmessageDecoder::from(submessage)?;
     let values = decoder.dispatch()?;
 
@@ -58,7 +62,7 @@ pub fn exec(args: &ArgMatches) -> Result<()> {
         write_output(out_path, values, |f| f.to_le_bytes())
     } else {
         let values = values.collect::<Vec<_>>().into_iter(); // workaround for mutability
-        let latlons = match latlons {
+        let latlons = match latlons.expect("lat/lon result is present for text output") {
             Ok(iter) => LatLonIteratorWrapper::LatLon(iter),
             Err(GribError::NotSupported(_)) => {
                 let nan_iter = vec![(f32::NAN, f32::NAN); values.len()].into_iter();


### PR DESCRIPTION
## Summary

- Compute latitude/longitude coordinates only for text output.
- Preserve big-endian and little-endian binary exports byte-for-byte.

## Validation

- `cargo test -p grib-cli --test cli commands::decode`
- `cargo test --workspace --quiet`
- `cargo build -p grib-cli --release`
- Compared binary exports before and after with `cmp -s`.

## Benchmark

Fixture: 770,440-point polar stereographic GRIB2 message.

`gribber decode -l /dev/null FILE 0.0`

| Version | Median maximum RSS |
| --- | ---: |
| Before | 65,175,552 bytes |
| After | 20,692,992 bytes |

This reduces median maximum RSS by 44,482,560 bytes (42.42 MiB, 68.25%).

Fixes #224