### PR TITLE
chore: comment wrapping changes in newer rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
+
   lint_and_clippy:
     name: Lint and Clippy
     runs-on: ubuntu-latest
@@ -22,9 +37,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
         with:
-          components: clippy, rustfmt
-      - name: Run rustfmt
-        run: cargo fmt --all -- --check
+          components: clippy
       - name: Install dependencies needed to build proj
         run: sudo apt install libsqlite3-dev
       - name: Run clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      - name: Print rustfmt version
+        run: cargo fmt --version
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 
@@ -40,6 +42,8 @@ jobs:
           components: clippy
       - name: Install dependencies needed to build proj
         run: sudo apt install libsqlite3-dev
+      - name: Print clippy version
+        run: cargo clippy --version
       - name: Run clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/build/doc.rs
+++ b/build/doc.rs
@@ -115,8 +115,8 @@ impl std::str::FromStr for ReadMeSections {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Line terminators are not included in the lines returned by the iterator from
-        // `str::lines`.
+        // Line terminators are not included in the lines returned by the
+        // iterator from `str::lines`.
         let mut lines = s.split_inclusive("\n");
 
         let mut map = HashMap::<String, String>::new();

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -38,9 +38,10 @@ pub fn exec(args: &ArgMatches) -> Result<()> {
         submessage.dump(&mut stream)?;
     } else {
         // TODO: Implement multithreading for the coloring process.
-        // Since the current `SubMessage` is not thread-safe and cannot be used in a
-        // multithreaded environment, we will first write everything to a buffer and
-        // then apply the coloring process to it.
+        // Since the current `SubMessage` is not thread-safe and cannot be used
+        // in a multithreaded environment, we will first write
+        // everything to a buffer and then apply the coloring process to
+        // it.
 
         let mut buf = std::io::Cursor::new(Vec::with_capacity(4096));
         submessage.dump(&mut buf)?;

--- a/examples/check_decoding_of_files.rs
+++ b/examples/check_decoding_of_files.rs
@@ -10,9 +10,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // This example script checks if all messages/submessages in all given GRIB2
     // files can be decoded.
     //
-    // This script is a practical example and does not include detailed explanatory
-    // comments. If you are interested in how to write code to decode, please check
-    // the example `decode_layers`.
+    // This script is a practical example and does not include detailed
+    // explanatory comments. If you are interested in how to write code to
+    // decode, please check the example `decode_layers`.
 
     let fnames = env::args().skip(1);
     for fname in fnames {

--- a/examples/decode_layer.rs
+++ b/examples/decode_layer.rs
@@ -3,12 +3,13 @@ use std::{env, error::Error, fs::File, io::BufReader, path::Path};
 use grib::LatLons;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // This example shows how to decode values inside a layer in a GRIB2 message.
-    // The example also shows how to obtain the latitude-longitude locations of grid
-    // points, which are usually used in conjunction with the grid point values.
+    // This example shows how to decode values inside a layer in a GRIB2
+    // message. The example also shows how to obtain the latitude-longitude
+    // locations of grid points, which are usually used in conjunction with
+    // the grid point values.
 
-    // Take the first argument as an input file path and the second argument as a
-    // layer index.
+    // Take the first argument as an input file path and the second argument as
+    // a layer index.
     let mut args = env::args().skip(1);
     if let (Some(file_path), Some(index), Some(subindex)) = (args.next(), args.next(), args.next())
     {
@@ -42,9 +43,10 @@ where
     // Prepare a decoder.
     let decoder = grib::Grib2SubmessageDecoder::from(submessage)?;
 
-    // Actually dispatch a decoding process and get an iterator of decoded values.
-    // There are various methods available for compressing GRIB2 data, but some are
-    // not yet supported by this library and may return errors.
+    // Actually dispatch a decoding process and get an iterator of decoded
+    // values. There are various methods available for compressing GRIB2
+    // data, but some are not yet supported by this library and may return
+    // errors.
     let values = decoder.dispatch()?;
 
     // Iterate over decoded values along with locations.

--- a/examples/list_layers.rs
+++ b/examples/list_layers.rs
@@ -3,8 +3,8 @@ use std::{env, error::Error, fs::File, io::BufReader, path::Path};
 use grib::codetables::{CodeTable4_2, Lookup};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // This example shows how to get information of element names, forecast time and
-    // elevation levels for all layers in a GRIB2 message.
+    // This example shows how to get information of element names, forecast time
+    // and elevation levels for all layers in a GRIB2 message.
 
     // Take the first argument as an input file path.
     let mut args = env::args().skip(1);
@@ -28,38 +28,41 @@ where
 
     // Iterate over layers.
     for (_index, submessage) in grib2.iter() {
-        // In GRIB data, attribute information such as elements are represented as
-        // numeric values. To convert those numeric values to strings, we use
-        // tables called Code Tables. Code Table 4.2 is required for the textual
-        // representation of element names, and Code Table 4.3 is required for
-        // the textual representation of forecast time units.
+        // In GRIB data, attribute information such as elements are represented
+        // as numeric values. To convert those numeric values to
+        // strings, we use tables called Code Tables. Code Table 4.2 is
+        // required for the textual representation of element names, and
+        // Code Table 4.3 is required for the textual representation of
+        // forecast time units.
         //
-        // Code Table 4.2 does not actually give you a unique text if you just specify a
-        // number. It has a hierarchical structure in which multiple product
-        // disciplines are defined, each containing multiple parameter
-        // categories, and many parameters within each category. For example,
-        // the product discipline includes meteorological products (0), hydrological
-        // products (1), etc. and in the meteorological products, there are temperature
+        // Code Table 4.2 does not actually give you a unique text if you just
+        // specify a number. It has a hierarchical structure in which
+        // multiple product disciplines are defined, each containing
+        // multiple parameter categories, and many parameters within
+        // each category. For example, the product discipline includes
+        // meteorological products (0), hydrological products (1), etc.
+        // and in the meteorological products, there are temperature
         // (0), moisture (1), momentum (2), etc.
-        // The momentum includes wind direction (0), wind speed (1), u-component of wind
-        // (2), v-component of wind (3), and so on.
+        // The momentum includes wind direction (0), wind speed (1), u-component
+        // of wind (2), v-component of wind (3), and so on.
         //
-        // Therefore, it would be easy to just get the numerical representation of the
-        // elements, but since we want to display the element names here, we
-        // also need to get the product discipline and parameter category, and
-        // then convert the parameter number using Code Table 4.2.
+        // Therefore, it would be easy to just get the numerical representation
+        // of the elements, but since we want to display the element
+        // names here, we also need to get the product discipline and
+        // parameter category, and then convert the parameter number
+        // using Code Table 4.2.
 
-        // Product discipline is included in the indicator section (and common in a
-        // GRIB2 message).
+        // Product discipline is included in the indicator section (and common
+        // in a GRIB2 message).
         let discipline = submessage.indicator().discipline;
-        // Parameter category and number are included in the product definition section.
-        // They are wrapped by `Option` because some GRIB2 data may not contain such
-        // information.
+        // Parameter category and number are included in the product definition
+        // section. They are wrapped by `Option` because some GRIB2 data
+        // may not contain such information.
         let category = submessage.prod_def().parameter_category().unwrap();
         let parameter = submessage.prod_def().parameter_number().unwrap();
 
-        // When using the `lookup()` function, `use grib::codetables::Lookup;` is
-        // necessary.
+        // When using the `lookup()` function, `use grib::codetables::Lookup;`
+        // is necessary.
         let parameter = CodeTable4_2::new(discipline, category).lookup(usize::from(parameter));
 
         // `forecast_time()` returns `ForecastTime` wrapped by `Option`.

--- a/src/datatypes/product_attributes.rs
+++ b/src/datatypes/product_attributes.rs
@@ -168,8 +168,8 @@ impl FixedSurface {
     /// assert_eq!(grib::FixedSurface::new(100, 0, 0).unit(), Some("Pa"));
     /// ```
     pub fn unit(&self) -> Option<&str> {
-        // Tentative implementation; pattern matching should be generated from the
-        // CodeFlag CSV file.
+        // Tentative implementation; pattern matching should be generated from
+        // the CodeFlag CSV file.
         let unit = match self.surface_type {
             11 => "m",
             12 => "m",

--- a/src/decoder/complex.rs
+++ b/src/decoder/complex.rs
@@ -294,13 +294,14 @@ where
             self.length_iter.next(),
         ) {
             (Some(_ref), Some(width), Some(length)) if width.to_usize().unwrap() == 0 => {
-                // The specification states as follows: "For groups with a constant value,
-                // associated field width is 0, and no incremental data are physically present."
+                // The specification states as follows: "For groups with a
+                // constant value, associated field width is 0,
+                // and no incremental data are physically present."
                 let _ref = _ref.to_u32().unwrap();
                 let length = length.to_usize().unwrap();
                 let missing1: u32 = (1 << self.num_bits) - 1;
-                // if missing1 == 0 (i.e. width == 0), missing2 should not be used, so it can be
-                // set to any value.
+                // if missing1 == 0 (i.e. width == 0), missing2 should not be
+                // used, so it can be set to any value.
                 let missing2 = if missing1 == 0 { 0 } else { missing1 - 1 };
 
                 if self.missing_value_management > 0 && _ref == missing1 {

--- a/src/decoder/png.rs
+++ b/src/decoder/png.rs
@@ -43,11 +43,12 @@ impl<'d> Grib2GpvUnpack for Png<'d> {
         //
         // - 1, 2, 4, 8, or 16 : Treat as greyscale image
         // - 24 : Treat as RGB colour image (each component having 8-bit depth)
-        // - 32 : Treat as RGB w/ alpha sample colour image (each component having 8-bit
-        //   depth)
+        // - 32 : Treat as RGB w/ alpha sample colour image (each component
+        //   having 8-bit depth)
         //
-        // Since we have verified the decoding process through testing for cases where
-        // `num_bits` is 8, 16, and 24, we believe other cases should also be fine.
+        // Since we have verified the decoding process through testing for cases
+        // where `num_bits` is 8, 16, and 24, we believe other cases
+        // should also be fine.
 
         let buf = read_image_buffer(target.sect7_payload())
             .map_err(|e| DecodeError::from(format!("PNG decode error: {e}")))?;

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -97,8 +97,8 @@ impl TryFrom<&GridDefinition> for GridDefinitionTemplateValues {
         // ```
         //
         // However, since the current implementation of the templates has many
-        // limitations, to prevent errors, the template reading process is implemented
-        // as follows.
+        // limitations, to prevent errors, the template reading process is
+        // implemented as follows.
         let buf = &value.payload[9..];
         let mut pos = 0;
         let num = value.grid_tmpl_num();
@@ -420,8 +420,8 @@ mod tests {
     #[test]
     fn grid_definition_template_0() {
         // data taken from submessage #0.0 of
-        // `Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.bin.xz`
-        // in `testdata`
+        // `Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.
+        // bin.xz` in `testdata`
         let data = GridDefinition::from_payload(
             vec![
                 0x00, 0x00, 0x01, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff, 0xff,

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -118,7 +118,8 @@ mod tests {
         };
         let latlons = grid_def.latlons()?.collect::<Vec<_>>();
 
-        // Following lat/lon values are taken from the calculation results using pygrib.
+        // Following lat/lon values are taken from the calculation results using
+        // pygrib.
         let delta = 1e-4;
         assert_coord_almost_eq(latlons[0], (20.19, -121.550004), delta);
         assert_coord_almost_eq(latlons[1], (20.19442682, -121.52621665), delta);

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -97,7 +97,8 @@ mod tests {
     fn polar_stereographic_grid_latlon_computation() -> Result<(), Box<dyn std::error::Error>> {
         use crate::grid::helpers::test_helpers::assert_coord_almost_eq;
         // grid point definition extracted from
-        // testdata/CMC_RDPA_APCP-024-0100cutoff_SFC_0_ps10km_2023121806_000.grib2.xz
+        // testdata/CMC_RDPA_APCP-024-0100cutoff_SFC_0_ps10km_2023121806_000.
+        // grib2.xz
         let grid_def = Template3_20 {
             earth_shape: param_set::EarthShape {
                 shape: 6,
@@ -128,7 +129,8 @@ mod tests {
         };
         let latlons = grid_def.latlons()?.collect::<Vec<_>>();
 
-        // Following lat/lon values are taken from the calculation results using pygrib.
+        // Following lat/lon values are taken from the calculation results using
+        // pygrib.
         let delta = 1e-4;
         assert_coord_almost_eq(latlons[0], (18.14503, -142.892544), delta);
         assert_coord_almost_eq(latlons[1], (18.17840149, -142.83604096), delta);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -10,8 +10,8 @@ pub(crate) use read_as;
 
 pub(crate) fn grib_int_from_bytes(bytes: &[u8]) -> i32 {
     let len = bytes.len();
-    // Although there is logic that can be used to generalize, not so many patterns
-    // exist that generalization is necessary.
+    // Although there is logic that can be used to generalize, not so many
+    // patterns exist that generalization is necessary.
     let mut pos = 0;
     match len {
         1 => i32::from(i8::try_from_slice(bytes, &mut pos).unwrap()),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -77,8 +77,8 @@ where
     #[inline]
     fn next_sect0(&mut self) -> Option<Result<SectionInfo, ParseError>> {
         if self.whole_size == 0 {
-            // if the offset value is left at the initial value, reset it to the current
-            // position
+            // if the offset value is left at the initial value, reset it to the
+            // current position
             let result = self.reset_pos();
             if let Err(e) = result {
                 return Some(Err(ParseError::ReadError(format!(


### PR DESCRIPTION
This PR fixes a CI workflow failure caused by a change in comment wrapping behavior in the rustfmt nightly build.
The daily format check began returning errors starting with the run at 21:00 UTC on August 30.

Also, this PR separates the format check from the lint check CI workflow.
It was inconvenient that sequential checks prevented us from getting reports from both the formatter and the linter at the same time.

I have also made it possible to view the version information for `rustfmt` and `rust-clippy` in the CI workflow execution results.
This is to make it easier to verify whether changes in the nightly builds are intentional.

Closes #222.