### PR TITLE
Buffer standard output for binary decode exports

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -102,7 +102,7 @@ impl std::str::FromStr for CliMessageIndex {
 
 pub(crate) enum WriteStream {
     File(BufWriter<std::fs::File>),
-    Stdout(std::io::Stdout),
+    Stdout(BufWriter<std::io::Stdout>),
 }
 
 impl WriteStream {
@@ -111,7 +111,7 @@ impl WriteStream {
         P: AsRef<Path>,
     {
         let stream = if is_dash(&out_path) {
-            Self::Stdout(std::io::stdout())
+            Self::Stdout(BufWriter::new(std::io::stdout()))
         } else {
             let f = File::create(out_path)?;
             let f = BufWriter::new(f);


### PR DESCRIPTION
Hi @noritada,

This replaces the direct `Stdout` writer with `BufWriter<Stdout>` for binary decode exports to `-`.

Each decoded `f32` previously called `write_all()` directly on `Stdout`, acquiring its shared lock per value. File exports already use `BufWriter`; this makes standard output follow the same buffered path.

## Measurement

Local release measurements, five runs each, with the same fixture streamed through `xzcat` and binary output redirected to `/dev/null`:

| Export path | Run 1 | Runs 2-5 | Median, 5 runs |
| --- | ---: | ---: | ---: |
| Current master, direct `Stdout` | 0.74 s | 0.12 s | 0.12 s |
| This patch, `BufWriter<Stdout>` | 0.41 s | 0.07 s | 0.07 s |

This is a 42% reduction in median elapsed time, or 1.71x faster.

## Validation

- Byte-for-byte identical binary output before and after the patch (SHA-256).
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --workspace -- -D warnings`
- Workspace build and tests with and without `time-calculation`
- CCSDS Rust AEC and JPEG2000 Hayro/OpenJPEG backend tests

Closes #227