### PR TITLE
Stream decoded values in text exports

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -37,19 +37,22 @@ pub(crate) fn display_in_pager<V>(view: V)
 where
     V: PredictableNumLines + std::fmt::Display,
 {
+    prepare_pager(view.num_lines());
+    print!("{view}");
+}
+
+pub(crate) fn prepare_pager(num_lines: usize) {
     let user_attended = console::user_attended();
 
     let term = console::Term::stdout();
     let (height, _width) = term.size();
-    if view.num_lines() > height.into() {
+    if num_lines > height.into() {
         start_pager();
     }
 
     if user_attended {
         console::set_colors_enabled(true);
     }
-
-    print!("{view}");
 }
 
 pub(crate) trait PredictableNumLines {

--- a/cli/src/commands/decode.rs
+++ b/cli/src/commands/decode.rs
@@ -1,4 +1,7 @@
-use std::{fmt, path::PathBuf};
+use std::{
+    io::{BufWriter, Write},
+    path::PathBuf,
+};
 
 use anyhow::Result;
 use clap::{ArgMatches, Command, arg};
@@ -61,22 +64,19 @@ pub fn exec(args: &ArgMatches) -> Result<()> {
         let out_path = args.get_one::<PathBuf>("little-endian").unwrap();
         write_output(out_path, values, |f| f.to_le_bytes())
     } else {
-        let values = values.collect::<Vec<_>>().into_iter(); // workaround for mutability
+        let num_values = values.size_hint().0;
         let latlons = match latlons.expect("lat/lon result is present for text output") {
             Ok(iter) => LatLonIteratorWrapper::LatLon(iter),
             Err(GribError::NotSupported(_)) => {
-                let nan_iter = vec![(f32::NAN, f32::NAN); values.len()].into_iter();
+                let nan_iter = std::iter::repeat_n((f32::NAN, f32::NAN), num_values);
                 LatLonIteratorWrapper::NaN(nan_iter)
             }
             Err(e) => anyhow::bail!("something unexpected happened:: {e}"),
         };
-        let values = latlons.zip(values);
-        cli::display_in_pager(DecodeTextDisplay(values));
-        Ok(())
+        write_text_output(latlons.zip(values))
     }
 }
 
-#[derive(Clone)]
 enum LatLonIteratorWrapper<L, N> {
     LatLon(L),
     NaN(N),
@@ -104,34 +104,22 @@ where
     }
 }
 
-struct DecodeTextDisplay<I>(I);
-
-impl<I> cli::PredictableNumLines for DecodeTextDisplay<I>
+fn write_text_output(values: impl Iterator<Item = ((f32, f32), f32)>) -> Result<()>
 where
-    I: Iterator<Item = ((f32, f32), f32)>,
 {
-    fn num_lines(&self) -> usize {
-        let Self(inner) = self;
-        let (len, _) = inner.size_hint();
-        len + 1
-    }
-}
+    let num_lines = values.size_hint().0 + 1;
+    cli::prepare_pager(num_lines);
 
-impl<I> fmt::Display for DecodeTextDisplay<I>
-where
-    I: Iterator<Item = ((f32, f32), f32)> + Clone,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let header = format!("{:>10} {:>11} {:>9}", "Latitude", "Longitude", "Value",);
-        let style = Style::new().bold();
-        writeln!(f, "{}", style.apply_to(header.trim_end()))?;
+    let stdout = std::io::stdout();
+    let mut out = BufWriter::new(stdout.lock());
+    let header = format!("{:>10} {:>11} {:>9}", "Latitude", "Longitude", "Value",);
+    let style = Style::new().bold();
+    writeln!(out, "{}", style.apply_to(header.trim_end()))?;
 
-        let Self(inner) = self;
-        // cloning just to work around a mutability issue
-        for ((lat, lon), value) in inner.clone() {
-            // lat/lons are formatted in "-?\d{2}.\d{6} -?\d{2}.\d{6}"
-            writeln!(f, "{lat:>10.6} {lon:>11.6} {value:>9}")?;
-        }
-        Ok(())
+    for ((lat, lon), value) in values {
+        // lat/lons are formatted in "-?\d{2}.\d{6} -?\d{2}.\d{6}"
+        writeln!(out, "{lat:>10.6} {lon:>11.6} {value:>9}")?;
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Hi @noritada,

This removes the full-field `Vec<f32>` and iterator clone from text-mode `gribber decode`.

Pager setup is now separate from rendering, so decoded values can be consumed directly. The output writes the header and rows through `BufWriter<StdoutLock>`. The fallback for unsupported grids remains lazy with `repeat_n()`.

## Measurement

Local release measurements, five text exports of the same uncompressed GDAS fixture, with output redirected to `/dev/null`:

| Export path | Median RSS | Difference |
| --- | ---: | ---: |
| Current master, collected and cloned values | 47,218,688 bytes (45.03 MiB) | |
| This patch, streamed values | 9,388,032 bytes (8.95 MiB) | -37,830,656 bytes (-80.1%) |

A SHA-256 comparison confirmed identical text output before and after the change.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --workspace -- -D warnings`
- `cargo +stable test --workspace --quiet`
- `cargo +stable build -p grib-cli --release`

Closes #233