### PR TITLE
Follow-ups to pure Rust implementations of projections

### DIFF
--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -1,10 +1,13 @@
-#[cfg(feature = "gridpoints-proj")]
-use crate::LatLons;
 use crate::{
     GridPointIndex,
     def::grib2::template::{Template3_30, param_set},
     error::GribError,
     grid::AngleUnit,
+};
+#[cfg(feature = "gridpoints-proj")]
+use crate::{
+    LatLons,
+    projection::{self, OsgeoProj},
 };
 
 impl crate::GridShortName for Template3_30 {
@@ -40,9 +43,13 @@ impl LatLons for Template3_30 {
                 self.earth_shape.shape
             ))
         })?;
-        let proj_def = format!(
-            "+a={a} +b={b} +proj=lcc +lat_0={lad} +lon_0={lov} +lat_1={latin1} +lat_2={latin2}"
-        );
+        let params = projection::LccParams {
+            ellipsoid: projection::Ellipsoid::from_a_and_b(a, b),
+            lat_0: lad,
+            lon_0: lov,
+            lat_1: latin1,
+            lat_2: latin2,
+        };
 
         let dx = self.dx as f64 * 1e-3;
         let dy = self.dy as f64 * 1e-3;
@@ -58,7 +65,7 @@ impl LatLons for Template3_30 {
         };
 
         super::helpers::latlons_from_projection_definition_and_first_point(
-            &proj_def,
+            &params.proj_args(),
             (
                 self.first_point_lat as f64 * angle_units,
                 self.first_point_lon as f64 * angle_units,

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -1,9 +1,12 @@
-#[cfg(feature = "gridpoints-proj")]
-use crate::error::GribError;
 use crate::{
     GridPointIndex, LatLons,
     def::grib2::template::{Template3_20, param_set},
     grid::AngleUnit,
+};
+#[cfg(feature = "gridpoints-proj")]
+use crate::{
+    error::GribError,
+    projection::{self, OsgeoProj},
 };
 
 impl crate::GridShortName for Template3_20 {
@@ -54,8 +57,12 @@ impl LatLons for Template3_20 {
             -90.
         };
 
-        let proj_def =
-            format!("+a={a} +b={b} +proj=stere +lat_ts={lad} +lat_0={lat_origin} +lon_0={lov}");
+        let params = projection::StereParams {
+            ellipsoid: projection::Ellipsoid::from_a_and_b(a, b),
+            lat_ts: lad,
+            lat_0: lat_origin,
+            lon_0: lov,
+        };
 
         let dx = self.dx as f64 * 1e-3;
         let dy = self.dy as f64 * 1e-3;
@@ -71,7 +78,7 @@ impl LatLons for Template3_20 {
         };
 
         super::helpers::latlons_from_projection_definition_and_first_point(
-            &proj_def,
+            &params.proj_args(),
             (
                 self.first_point_lat as f64 * angle_units,
                 self.first_point_lon as f64 * angle_units,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 mod grid;
 mod helpers;
 mod parser;
-mod projection;
+pub mod projection;
 mod reader;
 #[cfg(test)]
 mod test_utils;
@@ -33,7 +33,6 @@ pub use crate::{
         GridShortName, LatLons,
     },
     parser::*,
-    projection::*,
     reader::*,
     time::*,
     value::*,

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -48,12 +48,16 @@ pub trait Project {
     }
 }
 
+pub(crate) trait OsgeoProj {
+    fn proj_args(&self) -> String;
+}
+
 /// Projection parameters.
 pub enum ProjectionParams {
     /// Lambert Conformal Conic projection
-    Lcc(LccParams),
+    Lcc(lcc::Params),
     /// Mercator projection
-    Merc(MercParams),
+    Merc(merc::Params),
     /// Stereographic projection
     Stere(StereParams),
 }
@@ -65,56 +69,6 @@ impl ProjectionParams {
             Self::Merc(p) => p.proj_args(),
             Self::Stere(p) => p.proj_args(),
         }
-    }
-}
-
-/// Parameters for Lambert Conformal Conic projection.
-pub struct LccParams {
-    /// Ellipsoid definition
-    pub ellipsoid: Ellipsoid,
-    /// Latitude of origin (in degree)
-    pub lat_0: f64,
-    /// Central meridian (in degree)
-    pub lon_0: f64,
-    /// First standard parallel (in degree)
-    pub lat_1: f64,
-    /// Second standard parallel (in degree)
-    pub lat_2: f64,
-}
-
-impl LccParams {
-    fn proj_args(&self) -> String {
-        let Self {
-            ellipsoid: Ellipsoid { a, b, .. },
-            lat_0,
-            lon_0,
-            lat_1,
-            lat_2,
-        } = self;
-        format!(
-            "+a={a} +b={b} +proj=lcc +lat_0={lat_0} +lon_0={lon_0} +lat_1={lat_1} +lat_2={lat_2}"
-        )
-    }
-}
-
-/// Parameters for Mercator projection.
-pub struct MercParams {
-    /// Ellipsoid definition
-    pub ellipsoid: Ellipsoid,
-    /// Latitude of true scale (in degree)
-    pub lat_ts: f64,
-    /// Central meridian (in degree)
-    pub lon_0: f64,
-}
-
-impl MercParams {
-    fn proj_args(&self) -> String {
-        let Self {
-            ellipsoid: Ellipsoid { a, b, .. },
-            lat_ts,
-            lon_0,
-        } = self;
-        format!("+a={a} +b={b} +proj=merc +lat_ts={lat_ts} +lon_0={lon_0}")
     }
 }
 
@@ -130,7 +84,7 @@ pub struct StereParams {
     pub lon_0: f64,
 }
 
-impl StereParams {
+impl OsgeoProj for StereParams {
     fn proj_args(&self) -> String {
         let Self {
             ellipsoid: Ellipsoid { a, b, .. },

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -1,27 +1,7 @@
 #![allow(unused)] // FIXME
 
-pub enum Projection {
-    Lcc(lcc::Projection),
-    Merc(merc::Projection),
-}
-
-impl Projection {
-    pub fn new(params: &ProjectionParams) -> Result<Self, &'static str> {
-        let inner = match params {
-            ProjectionParams::Lcc(p) => Self::Lcc(lcc::Projection::new(p)?),
-            ProjectionParams::Merc(p) => Self::Merc(merc::Projection::new(p)?),
-            ProjectionParams::Stere(_) => todo!(),
-        };
-        Ok(inner)
-    }
-
-    pub fn project(&self, xy: &(f64, f64), inverse: bool) -> Result<(f64, f64), &'static str> {
-        match self {
-            Self::Lcc(inner) => inner.project(xy, inverse),
-            Self::Merc(inner) => inner.project(xy, inverse),
-        }
-    }
-}
+pub use lcc::{Params as LccParams, Projection as Lcc};
+pub use merc::{Params as MercParams, Projection as Merc};
 
 pub trait Project {
     fn forward(&self, xy: &(f64, f64)) -> Result<(f64, f64), &'static str>;
@@ -50,26 +30,6 @@ pub trait Project {
 
 pub(crate) trait OsgeoProj {
     fn proj_args(&self) -> String;
-}
-
-/// Projection parameters.
-pub enum ProjectionParams {
-    /// Lambert Conformal Conic projection
-    Lcc(lcc::Params),
-    /// Mercator projection
-    Merc(merc::Params),
-    /// Stereographic projection
-    Stere(StereParams),
-}
-
-impl ProjectionParams {
-    pub(crate) fn osgeo_proj_args(&self) -> String {
-        match self {
-            Self::Lcc(p) => p.proj_args(),
-            Self::Merc(p) => p.proj_args(),
-            Self::Stere(p) => p.proj_args(),
-        }
-    }
 }
 
 /// Parameters for Stereographic projection.

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -1,5 +1,3 @@
-#![allow(unused)] // FIXME
-
 pub use lcc::{Params as LccParams, Projection as Lcc};
 pub use merc::{Params as MercParams, Projection as Merc};
 
@@ -28,6 +26,7 @@ pub trait Project {
     }
 }
 
+#[cfg(feature = "gridpoints-proj")]
 pub(crate) trait OsgeoProj {
     fn proj_args(&self) -> String;
 }
@@ -44,6 +43,7 @@ pub struct StereParams {
     pub lon_0: f64,
 }
 
+#[cfg(feature = "gridpoints-proj")]
 impl OsgeoProj for StereParams {
     fn proj_args(&self) -> String {
         let Self {

--- a/src/projection/helpers.rs
+++ b/src/projection/helpers.rs
@@ -1,16 +1,16 @@
 const TWO_PI: f64 = std::f64::consts::TAU;
 
-pub(crate) fn m(sin_phi: f64, cos_phi: f64, e_sq: f64) -> f64 {
-    cos_phi / (1. - e_sq * sin_phi * sin_phi).sqrt()
+pub(crate) fn m(sinφ: f64, cosφ: f64, e_sq: f64) -> f64 {
+    cosφ / (1. - e_sq * sinφ * sinφ).sqrt()
 }
 
 // See formula deformation for pj_tsfn().
-pub(crate) fn t(cos_phi: f64, sin_phi: f64, e: f64) -> f64 {
-    (e * (e * sin_phi).atanh()).exp()
-        * if sin_phi > 0. {
-            cos_phi / (1. + sin_phi)
+pub(crate) fn t(cosφ: f64, sinφ: f64, e: f64) -> f64 {
+    (e * (e * sinφ).atanh()).exp()
+        * if sinφ > 0. {
+            cosφ / (1. + sinφ)
         } else {
-            (1. - sin_phi) / cos_phi
+            (1. - sinφ) / cosφ
         }
 }
 

--- a/src/projection/lcc.rs
+++ b/src/projection/lcc.rs
@@ -38,10 +38,9 @@ impl Projection {
             return Err("Invalid value for lat_1 and lat_2: |lat_1 + lat_2| should be > 0");
         }
 
-        let sin_phi1 = phi1.sin();
-        let cos_phi1 = phi1.cos();
+        let (sinφ1, cosφ1) = phi1.sin_cos();
 
-        if cos_phi1.abs() < EPS10 || phi1.abs() >= HALF_PI {
+        if cosφ1.abs() < EPS10 || phi1.abs() >= HALF_PI {
             return Err("Invalid value for lat_1: |lat_1| should be < 90°");
         }
         if phi2.cos().abs() < EPS10 || phi2.abs() >= HALF_PI {
@@ -53,12 +52,12 @@ impl Projection {
         let is_phi0_almost_equal_to_half_pi = (phi0.abs() - HALF_PI).abs() < EPS10;
 
         let context = if is_ellipsoidal {
-            let m1 = m(sin_phi1, cos_phi1, *e_sq);
-            let t1 = t(cos_phi1, sin_phi1, *e);
+            let m1 = m(sinφ1, cosφ1, *e_sq);
+            let t1 = t(cosφ1, sinφ1, *e);
             let n = if is_secant_cone {
                 n_in_secant_cone_ellipsoidal(phi2, *e, *e_sq, m1, t1)?
             } else {
-                sin_phi1
+                sinφ1
             };
             let c = m1 * t1.powf(-n) / n;
             let rho0 = if is_phi0_almost_equal_to_half_pi {
@@ -78,14 +77,14 @@ impl Projection {
             }
         } else {
             let n = if is_secant_cone {
-                n_in_secant_cone_spherical(phi1, phi2, cos_phi1, phi2.cos())
+                n_in_secant_cone_spherical(phi1, phi2, cosφ1, phi2.cos())
             } else {
-                sin_phi1
+                sinφ1
             };
             if n == 0. {
                 return Err("Invalid value for lat_1 and lat_2: |lat_1 + lat_2| should be > 0");
             }
-            let c = cos_phi1 * (FORTH_PI + 0.5 * phi1).tan().powf(n) / n;
+            let c = cosφ1 * (FORTH_PI + 0.5 * phi1).tan().powf(n) / n;
             let rho0 = if is_phi0_almost_equal_to_half_pi {
                 0.
             } else {
@@ -203,13 +202,12 @@ fn n_in_secant_cone_ellipsoidal(
     t1: f64,
 ) -> Result<f64, &'static str> {
     let err_message = "Invalid value for eccentricity";
-    let sin_phi2 = phi2.sin();
-    let cos_phi2 = phi2.cos();
-    let n = (m1 / m(sin_phi2, cos_phi2, e_sq)).ln();
+    let (sinφ2, cosφ2) = phi2.sin_cos();
+    let n = (m1 / m(sinφ2, cosφ2, e_sq)).ln();
     if n == 0. {
         return Err(err_message);
     }
-    let denom = (t1 / t(cos_phi2, sin_phi2, e)).ln();
+    let denom = (t1 / t(cosφ2, sinφ2, e)).ln();
     if denom == 0. {
         return Err(err_message);
     }
@@ -217,9 +215,8 @@ fn n_in_secant_cone_ellipsoidal(
     Ok(n)
 }
 
-fn n_in_secant_cone_spherical(phi1: f64, phi2: f64, cos_phi1: f64, cos_phi2: f64) -> f64 {
-    (cos_phi1 / cos_phi2).ln()
-        / ((FORTH_PI + 0.5 * phi2).tan() / (FORTH_PI + 0.5 * phi1).tan()).ln()
+fn n_in_secant_cone_spherical(phi1: f64, phi2: f64, cosφ1: f64, cosφ2: f64) -> f64 {
+    (cosφ1 / cosφ2).ln() / ((FORTH_PI + 0.5 * phi2).tan() / (FORTH_PI + 0.5 * phi1).tan()).ln()
 }
 
 #[cfg(all(test, feature = "gridpoints-proj"))]

--- a/src/projection/lcc.rs
+++ b/src/projection/lcc.rs
@@ -1,5 +1,5 @@
 use super::{
-    Ellipsoid, LccParams,
+    Ellipsoid, OsgeoProj,
     helpers::{m, phi2, t},
 };
 use crate::Project;
@@ -7,6 +7,35 @@ use crate::Project;
 const EPS10: f64 = f64::EPSILON;
 const HALF_PI: f64 = std::f64::consts::FRAC_PI_2;
 const FORTH_PI: f64 = std::f64::consts::FRAC_PI_4;
+
+/// Parameters for Lambert Conformal Conic projection.
+pub struct Params {
+    /// Ellipsoid definition
+    pub ellipsoid: Ellipsoid,
+    /// Latitude of origin (in degree)
+    pub lat_0: f64,
+    /// Central meridian (in degree)
+    pub lon_0: f64,
+    /// First standard parallel (in degree)
+    pub lat_1: f64,
+    /// Second standard parallel (in degree)
+    pub lat_2: f64,
+}
+
+impl OsgeoProj for Params {
+    fn proj_args(&self) -> String {
+        let Self {
+            ellipsoid: Ellipsoid { a, b, .. },
+            lat_0,
+            lon_0,
+            lat_1,
+            lat_2,
+        } = self;
+        format!(
+            "+a={a} +b={b} +proj=lcc +lat_0={lat_0} +lon_0={lon_0} +lat_1={lat_1} +lat_2={lat_2}"
+        )
+    }
+}
 
 pub struct Projection {
     lam0: f64,
@@ -20,8 +49,8 @@ pub struct Projection {
 }
 
 impl Projection {
-    pub fn new(p: &LccParams) -> Result<Self, &'static str> {
-        let LccParams {
+    pub fn new(p: &Params) -> Result<Self, &'static str> {
+        let Params {
             ellipsoid: Ellipsoid { a, e, e_sq, .. },
             lat_0,
             lon_0,
@@ -230,7 +259,7 @@ mod tests {
 
     #[test]
     fn agrees_with_proj_for_ellipsoidal_secant_cone() {
-        assert_agrees_with_proj(LccParams {
+        assert_agrees_with_proj(Params {
             ellipsoid: Ellipsoid::from_a_and_b(6_378_137., 6_356_752.314_245),
             lat_0: 40.,
             lon_0: 140.,
@@ -241,7 +270,7 @@ mod tests {
 
     #[test]
     fn agrees_with_proj_for_ellipsoidal_tangent_cone() {
-        assert_agrees_with_proj(LccParams {
+        assert_agrees_with_proj(Params {
             ellipsoid: Ellipsoid::from_a_and_b(6_378_137., 6_356_752.314_245),
             lat_0: 35.,
             lon_0: -100.,
@@ -252,7 +281,7 @@ mod tests {
 
     #[test]
     fn agrees_with_proj_for_spherical_secant_cone() {
-        assert_agrees_with_proj(LccParams {
+        assert_agrees_with_proj(Params {
             ellipsoid: Ellipsoid::from_a_and_b(6_371_229., 6_371_229.),
             lat_0: -40.,
             lon_0: 20.,
@@ -261,7 +290,7 @@ mod tests {
         });
     }
 
-    fn assert_agrees_with_proj(params: LccParams) {
+    fn assert_agrees_with_proj(params: Params) {
         let proj = Proj::new(&params.proj_args()).unwrap();
         let projection = Projection::new(&params).unwrap();
         let coordinates: [(f64, f64); 4] = [(-70., -10.), (0., 0.), (25., 45.), (70., 170.)];

--- a/src/projection/lcc.rs
+++ b/src/projection/lcc.rs
@@ -8,47 +8,12 @@ const EPS10: f64 = f64::EPSILON;
 const HALF_PI: f64 = std::f64::consts::FRAC_PI_2;
 const FORTH_PI: f64 = std::f64::consts::FRAC_PI_4;
 
-struct LccDefinition {
+pub struct Projection {
     lam0: f64,
-    phi0: f64,
-    phi1: f64,
-    phi2: f64,
     a: f64,
     e: f64,
     e_sq: f64,
     k0: f64,
-}
-
-impl From<&LccParams> for LccDefinition {
-    fn from(value: &LccParams) -> Self {
-        let LccParams {
-            ellipsoid: Ellipsoid { a, e, e_sq, .. },
-            lat_0,
-            lon_0,
-            lat_1,
-            lat_2,
-        } = value;
-
-        let lam0 = lon_0.to_radians();
-        let phi0 = lat_0.to_radians();
-        let phi1 = lat_1.to_radians();
-        let phi2 = lat_2.to_radians();
-
-        Self {
-            lam0,
-            phi0,
-            phi1,
-            phi2,
-            a: *a,
-            e: *e,
-            e_sq: *e_sq,
-            k0: 1.,
-        }
-    }
-}
-
-pub struct Projection {
-    params: LccDefinition,
     n: f64,
     c: f64,
     rho0: f64,
@@ -56,30 +21,42 @@ pub struct Projection {
 
 impl Projection {
     pub fn new(p: &LccParams) -> Result<Self, &'static str> {
-        let p = LccDefinition::from(p);
-        if (p.phi1 + p.phi2).abs() < EPS10 {
+        let LccParams {
+            ellipsoid: Ellipsoid { a, e, e_sq, .. },
+            lat_0,
+            lon_0,
+            lat_1,
+            lat_2,
+        } = p;
+        let lam0 = lon_0.to_radians();
+        let phi0 = lat_0.to_radians();
+        let phi1 = lat_1.to_radians();
+        let phi2 = lat_2.to_radians();
+        let k0 = 1.;
+
+        if (phi1 + phi2).abs() < EPS10 {
             return Err("Invalid value for lat_1 and lat_2: |lat_1 + lat_2| should be > 0");
         }
 
-        let sin_phi1 = p.phi1.sin();
-        let cos_phi1 = p.phi1.cos();
+        let sin_phi1 = phi1.sin();
+        let cos_phi1 = phi1.cos();
 
-        if cos_phi1.abs() < EPS10 || p.phi1.abs() >= HALF_PI {
+        if cos_phi1.abs() < EPS10 || phi1.abs() >= HALF_PI {
             return Err("Invalid value for lat_1: |lat_1| should be < 90°");
         }
-        if p.phi2.cos().abs() < EPS10 || p.phi2.abs() >= HALF_PI {
+        if phi2.cos().abs() < EPS10 || phi2.abs() >= HALF_PI {
             return Err("Invalid value for lat_2: |lat_2| should be < 90°");
         }
 
-        let is_secant_cone = (p.phi1 - p.phi2) >= EPS10; // otherwise, tangent cone
-        let is_ellipsoidal = p.e_sq != 0.;
-        let is_phi0_almost_equal_to_half_pi = (p.phi0.abs() - HALF_PI).abs() < EPS10;
+        let is_secant_cone = (phi1 - phi2) >= EPS10; // otherwise, tangent cone
+        let is_ellipsoidal = *e_sq != 0.;
+        let is_phi0_almost_equal_to_half_pi = (phi0.abs() - HALF_PI).abs() < EPS10;
 
         let context = if is_ellipsoidal {
-            let m1 = m(sin_phi1, cos_phi1, p.e_sq);
-            let t1 = t(cos_phi1, sin_phi1, p.e);
+            let m1 = m(sin_phi1, cos_phi1, *e_sq);
+            let t1 = t(cos_phi1, sin_phi1, *e);
             let n = if is_secant_cone {
-                n_in_secant_cone_ellipsoidal(&p, &m1, &t1)?
+                n_in_secant_cone_ellipsoidal(phi2, *e, *e_sq, m1, t1)?
             } else {
                 sin_phi1
             };
@@ -87,31 +64,39 @@ impl Projection {
             let rho0 = if is_phi0_almost_equal_to_half_pi {
                 0.
             } else {
-                c * t(p.phi0.cos(), p.phi0.sin(), p.e).powf(n)
+                c * t(phi0.cos(), phi0.sin(), *e).powf(n)
             };
             Projection {
-                params: p,
+                lam0,
+                a: *a,
+                e: *e,
+                e_sq: *e_sq,
+                k0,
                 n,
                 c,
                 rho0,
             }
         } else {
             let n = if is_secant_cone {
-                n_in_secant_cone_spherical(&p, cos_phi1, p.phi2.cos())
+                n_in_secant_cone_spherical(phi1, phi2, cos_phi1, phi2.cos())
             } else {
                 sin_phi1
             };
             if n == 0. {
                 return Err("Invalid value for lat_1 and lat_2: |lat_1 + lat_2| should be > 0");
             }
-            let c = cos_phi1 * (FORTH_PI + 0.5 * p.phi1).tan().powf(n) / n;
+            let c = cos_phi1 * (FORTH_PI + 0.5 * phi1).tan().powf(n) / n;
             let rho0 = if is_phi0_almost_equal_to_half_pi {
                 0.
             } else {
-                c * (FORTH_PI + 0.5 * p.phi0).tan().powf(-n)
+                c * (FORTH_PI + 0.5 * phi0).tan().powf(-n)
             };
             Projection {
-                params: p,
+                lam0,
+                a: *a,
+                e: *e,
+                e_sq: *e_sq,
+                k0,
                 n,
                 c,
                 rho0,
@@ -125,10 +110,13 @@ impl Projection {
 
     fn forward(&self, (lambda, phi): &(f64, f64)) -> Result<(f64, f64), &'static str> {
         let Self {
-            params: LccDefinition { e, e_sq, k0, .. },
+            e,
+            e_sq,
+            k0,
             n,
             c,
             rho0,
+            ..
         } = self;
 
         let rho = if (phi.abs() - HALF_PI).abs() < EPS10 {
@@ -151,10 +139,13 @@ impl Projection {
 
     fn inverse(&self, (x, y): &(f64, f64)) -> Result<(f64, f64), &'static str> {
         let Self {
-            params: LccDefinition { e, e_sq, k0, .. },
+            e,
+            e_sq,
+            k0,
             n,
             c,
             rho0,
+            ..
         } = self;
 
         let x = x / k0;
@@ -196,27 +187,29 @@ impl Project for Projection {
     }
 
     fn a(&self) -> &f64 {
-        &self.params.a
+        &self.a
     }
 
     fn lam0(&self) -> &f64 {
-        &self.params.lam0
+        &self.lam0
     }
 }
 
 fn n_in_secant_cone_ellipsoidal(
-    p: &LccDefinition,
-    m1: &f64,
-    t1: &f64,
+    phi2: f64,
+    e: f64,
+    e_sq: f64,
+    m1: f64,
+    t1: f64,
 ) -> Result<f64, &'static str> {
     let err_message = "Invalid value for eccentricity";
-    let sin_phi2 = p.phi2.sin();
-    let cos_phi2 = p.phi2.cos();
-    let n = (m1 / m(sin_phi2, cos_phi2, p.e_sq)).ln();
+    let sin_phi2 = phi2.sin();
+    let cos_phi2 = phi2.cos();
+    let n = (m1 / m(sin_phi2, cos_phi2, e_sq)).ln();
     if n == 0. {
         return Err(err_message);
     }
-    let denom = (t1 / t(cos_phi2, sin_phi2, p.e)).ln();
+    let denom = (t1 / t(cos_phi2, sin_phi2, e)).ln();
     if denom == 0. {
         return Err(err_message);
     }
@@ -224,9 +217,9 @@ fn n_in_secant_cone_ellipsoidal(
     Ok(n)
 }
 
-fn n_in_secant_cone_spherical(p: &LccDefinition, cos_phi1: f64, cos_phi2: f64) -> f64 {
+fn n_in_secant_cone_spherical(phi1: f64, phi2: f64, cos_phi1: f64, cos_phi2: f64) -> f64 {
     (cos_phi1 / cos_phi2).ln()
-        / ((FORTH_PI + 0.5 * p.phi2).tan() / (FORTH_PI + 0.5 * p.phi1).tan()).ln()
+        / ((FORTH_PI + 0.5 * phi2).tan() / (FORTH_PI + 0.5 * phi1).tan()).ln()
 }
 
 #[cfg(all(test, feature = "gridpoints-proj"))]

--- a/src/projection/lcc.rs
+++ b/src/projection/lcc.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "gridpoints-proj")]
+use super::OsgeoProj;
 use super::{
-    Ellipsoid, OsgeoProj, Project,
+    Ellipsoid, Project,
     helpers::{m, phi2, t},
 };
 
@@ -21,6 +23,7 @@ pub struct Params {
     pub lat_2: f64,
 }
 
+#[cfg(feature = "gridpoints-proj")]
 impl OsgeoProj for Params {
     fn proj_args(&self) -> String {
         let Self {

--- a/src/projection/lcc.rs
+++ b/src/projection/lcc.rs
@@ -1,8 +1,7 @@
 use super::{
-    Ellipsoid, OsgeoProj,
+    Ellipsoid, OsgeoProj, Project,
     helpers::{m, phi2, t},
 };
-use crate::Project;
 
 const EPS10: f64 = f64::EPSILON;
 const HALF_PI: f64 = std::f64::consts::FRAC_PI_2;

--- a/src/projection/merc.rs
+++ b/src/projection/merc.rs
@@ -1,9 +1,30 @@
 use super::{
-    Ellipsoid, MercParams, Project,
+    Ellipsoid, OsgeoProj, Project,
     helpers::{m, sinhpsi2tanphi},
 };
 
 const HALF_PI: f64 = std::f64::consts::FRAC_PI_2;
+
+/// Parameters for Mercator projection.
+pub struct Params {
+    /// Ellipsoid definition
+    pub ellipsoid: Ellipsoid,
+    /// Latitude of true scale (in degree)
+    pub lat_ts: f64,
+    /// Central meridian (in degree)
+    pub lon_0: f64,
+}
+
+impl OsgeoProj for Params {
+    fn proj_args(&self) -> String {
+        let Self {
+            ellipsoid: Ellipsoid { a, b, .. },
+            lat_ts,
+            lon_0,
+        } = self;
+        format!("+a={a} +b={b} +proj=merc +lat_ts={lat_ts} +lon_0={lon_0}")
+    }
+}
 
 pub struct Projection {
     lam0: f64,
@@ -13,8 +34,8 @@ pub struct Projection {
 }
 
 impl Projection {
-    pub fn new(p: &MercParams) -> Result<Self, &'static str> {
-        let MercParams {
+    pub fn new(p: &Params) -> Result<Self, &'static str> {
+        let Params {
             ellipsoid: Ellipsoid { a, e, e_sq, .. },
             lat_ts,
             lon_0,
@@ -110,7 +131,7 @@ mod tests {
 
     #[test]
     fn agrees_with_proj_for_ellipsoid() {
-        assert_agrees_with_proj(MercParams {
+        assert_agrees_with_proj(Params {
             ellipsoid: Ellipsoid::from_a_and_b(6_378_137., 6_356_752.314_245),
             lat_ts: 20.,
             lon_0: 140.,
@@ -119,14 +140,14 @@ mod tests {
 
     #[test]
     fn agrees_with_proj_for_sphere() {
-        assert_agrees_with_proj(MercParams {
+        assert_agrees_with_proj(Params {
             ellipsoid: Ellipsoid::from_a_and_b(6_371_229., 6_371_229.),
             lat_ts: -15.,
             lon_0: -30.,
         });
     }
 
-    fn assert_agrees_with_proj(params: MercParams) {
+    fn assert_agrees_with_proj(params: Params) {
         let proj = Proj::new(&params.proj_args()).unwrap();
         let projection = Projection::new(&params).unwrap();
         let coordinates: [(f64, f64); 4] = [(-10., -70.), (0., 0.), (25., 45.), (80., 170.)];

--- a/src/projection/merc.rs
+++ b/src/projection/merc.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "gridpoints-proj")]
+use super::OsgeoProj;
 use super::{
-    Ellipsoid, OsgeoProj, Project,
+    Ellipsoid, Project,
     helpers::{m, sinhpsi2tanphi},
 };
 
@@ -15,6 +17,7 @@ pub struct Params {
     pub lon_0: f64,
 }
 
+#[cfg(feature = "gridpoints-proj")]
 impl OsgeoProj for Params {
     fn proj_args(&self) -> String {
         let Self {

--- a/src/projection/merc.rs
+++ b/src/projection/merc.rs
@@ -5,64 +5,48 @@ use super::{
 
 const HALF_PI: f64 = std::f64::consts::FRAC_PI_2;
 
-struct MercDefinition {
+pub struct Projection {
     lam0: f64,
-    phi_ts: f64,
-    a: f64,
     e: f64,
     e_sq: f64,
-}
-
-impl From<&MercParams> for MercDefinition {
-    fn from(value: &MercParams) -> Self {
-        let MercParams {
-            ellipsoid: Ellipsoid { a, e, e_sq, .. },
-            lat_ts,
-            lon_0,
-        } = value;
-
-        let lam0 = lon_0.to_radians();
-        let phi_ts = lat_ts.to_radians().abs();
-
-        Self {
-            lam0,
-            phi_ts,
-            a: *a,
-            e: *e,
-            e_sq: *e_sq,
-        }
-    }
-}
-
-pub struct Projection {
-    params: MercDefinition,
     ak0: f64,
 }
 
 impl Projection {
     pub fn new(p: &MercParams) -> Result<Self, &'static str> {
-        let p = MercDefinition::from(p);
-        if p.phi_ts >= HALF_PI {
+        let MercParams {
+            ellipsoid: Ellipsoid { a, e, e_sq, .. },
+            lat_ts,
+            lon_0,
+        } = p;
+        let lam0 = lon_0.to_radians();
+        let phi_ts = lat_ts.to_radians().abs();
+        if phi_ts >= HALF_PI {
             return Err("Invalid value for lat_ts: |lat_ts| should be <= 90°");
         }
 
-        let k0 = if p.e_sq == 0.0 {
+        let k0 = if *e_sq == 0.0 {
             // sphere
-            p.phi_ts.cos()
+            phi_ts.cos()
         } else {
             // ellipsoid
-            let (sinφts, cosφts) = p.phi_ts.sin_cos();
-            m(sinφts, cosφts, p.e_sq)
+            let (sinφts, cosφts) = phi_ts.sin_cos();
+            m(sinφts, cosφts, *e_sq)
         };
-        let ak0 = p.a * k0;
-        let context = Projection { params: p, ak0 };
+        let ak0 = a * k0;
+        let context = Projection {
+            lam0,
+            e: *e,
+            e_sq: *e_sq,
+            ak0,
+        };
         Ok(context)
     }
 
     fn ellipsoidal_forward(&self, (lambda, phi): &(f64, f64)) -> Result<(f64, f64), &'static str> {
         let &x = lambda;
         let (sinφ, cosφ) = phi.sin_cos();
-        let y = (sinφ / cosφ).asinh() - self.params.e * (self.params.e * sinφ).atanh();
+        let y = (sinφ / cosφ).asinh() - self.e * (self.e * sinφ).atanh();
         Ok((x, y))
     }
 
@@ -73,7 +57,7 @@ impl Projection {
     }
 
     fn ellipsoidal_inverse(&self, (x, y): &(f64, f64)) -> Result<(f64, f64), &'static str> {
-        let phi = sinhpsi2tanphi(y.sinh(), self.params.e)
+        let phi = sinhpsi2tanphi(y.sinh(), self.e)
             .ok_or(
                 "the inverse of the isometric latitude function could not be solved numerically",
             )?
@@ -91,7 +75,7 @@ impl Projection {
 
 impl Project for Projection {
     fn forward(&self, xy: &(f64, f64)) -> Result<(f64, f64), &'static str> {
-        if self.params.e_sq == 0.0 {
+        if self.e_sq == 0.0 {
             self.spheroidal_forward(xy)
         } else {
             self.ellipsoidal_forward(xy)
@@ -99,7 +83,7 @@ impl Project for Projection {
     }
 
     fn inverse(&self, xy: &(f64, f64)) -> Result<(f64, f64), &'static str> {
-        if self.params.e_sq == 0.0 {
+        if self.e_sq == 0.0 {
             self.spheroidal_inverse(xy)
         } else {
             self.ellipsoidal_inverse(xy)
@@ -111,7 +95,7 @@ impl Project for Projection {
     }
 
     fn lam0(&self) -> &f64 {
-        &self.params.lam0
+        &self.lam0
     }
 }
 


### PR DESCRIPTION
This PR is a follow-up to #219 (import of the pure Rust implementations of projections).

Follow-ups are as follows:

- simplification of public and internal APIs
- minor improvements
- integration to the PROJ-based grid point coordinate calculation

The pure Rust implementation of projections itself has not yet been used to calculate grid point coordinates.