### PR TITLE
Improve the accuracy of lat/lon computation for Mercator grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For data using the following grid systems, latitudes and longitudes of grid poin
 
 #### Support for extraction/compression of grid point values
 
-For data using the following encoding methods, grid point values can be extracted.
+For data using the following encoding methods, grid point values can be extracted/compressed.
 
 | Template number | parameter access | built-in extraction support | extraction using other libraries | built-in compression support | Encoding method |
 | --- | --- | --- | --- | --- | --- |

--- a/src/grid/helpers.rs
+++ b/src/grid/helpers.rs
@@ -75,20 +75,18 @@ impl Iterator for RegularGridIterator {
 }
 
 #[cfg(feature = "gridpoints-proj")]
-pub(crate) fn latlons_from_projection_definition_and_first_point(
+pub(crate) fn latlons_from_projection_with_first_point_and_delta(
     proj_def: &str,
     first_point_latlon_in_degrees: (f64, f64),
     delta_in_meters: (f64, f64),
     indices: GridPointIndexIterator,
 ) -> Result<std::vec::IntoIter<(f32, f32)>, GribError> {
-    let projection = Proj::new(proj_def).map_err(|e| GribError::Unknown(e.to_string()))?;
+    let projection = Proj::new(proj_def)?;
     let (first_point_lat, first_point_lon) = first_point_latlon_in_degrees;
-    let (first_corner_x, first_corner_y) = projection
-        .project(
-            (first_point_lon.to_radians(), first_point_lat.to_radians()),
-            false,
-        )
-        .map_err(|e| GribError::Unknown(e.to_string()))?;
+    let (first_corner_x, first_corner_y) = projection.project(
+        (first_point_lon.to_radians(), first_point_lat.to_radians()),
+        false,
+    )?;
 
     let (dx, dy) = delta_in_meters;
     let mut xy = indices
@@ -100,9 +98,7 @@ pub(crate) fn latlons_from_projection_definition_and_first_point(
         })
         .collect::<Vec<_>>();
 
-    let lonlat = projection
-        .project_array(&mut xy, true)
-        .map_err(|e| GribError::Unknown(e.to_string()))?;
+    let lonlat = projection.project_array(&mut xy, true)?;
     let latlon = lonlat
         .iter_mut()
         .map(|(lon, lat)| (lat.to_degrees() as f32, lon.to_degrees() as f32))
@@ -114,6 +110,20 @@ pub(crate) fn latlons_from_projection_definition_and_first_point(
 pub(crate) fn normalize_latlon((lat, lon): (f32, f32)) -> (f32, f32) {
     let lon = (lon + 540.) % 360. - 180.;
     (lat, lon)
+}
+
+#[cfg(feature = "gridpoints-proj")]
+impl From<proj::ProjCreateError> for GribError {
+    fn from(e: proj::ProjCreateError) -> Self {
+        Self::Unknown(e.to_string())
+    }
+}
+
+#[cfg(feature = "gridpoints-proj")]
+impl From<proj::ProjError> for GribError {
+    fn from(e: proj::ProjError) -> Self {
+        Self::Unknown(e.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src/grid/helpers.rs
+++ b/src/grid/helpers.rs
@@ -107,6 +107,46 @@ pub(crate) fn latlons_from_projection_with_first_point_and_delta(
     Ok(latlon.into_iter())
 }
 
+#[cfg(feature = "gridpoints-proj")]
+pub(crate) fn latlons_from_projection_with_first_point_and_last_point(
+    proj_def: &str,
+    first_point_latlon_in_degrees: (f64, f64),
+    last_point_latlon_in_degrees: (f64, f64),
+    (ni, nj): (usize, usize),
+    indices: GridPointIndexIterator,
+) -> Result<std::vec::IntoIter<(f32, f32)>, GribError> {
+    let projection = Proj::new(proj_def)?;
+    let (first_point_lat, first_point_lon) = first_point_latlon_in_degrees;
+    let (first_corner_x, first_corner_y) = projection.project(
+        (first_point_lon.to_radians(), first_point_lat.to_radians()),
+        false,
+    )?;
+    let (last_point_lat, last_point_lon) = last_point_latlon_in_degrees;
+    let (last_corner_x, last_corner_y) = projection.project(
+        (last_point_lon.to_radians(), last_point_lat.to_radians()),
+        false,
+    )?;
+
+    let dx = (last_corner_x - first_corner_x) / (ni - 1) as f64;
+    let dy = (last_corner_y - first_corner_y) / (nj - 1) as f64;
+    let mut xy = indices
+        .map(|(i, j)| {
+            (
+                first_corner_x + dx * i as f64,
+                first_corner_y + dy * j as f64,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let lonlat = projection.project_array(&mut xy, true)?;
+    let latlon = lonlat
+        .iter_mut()
+        .map(|(lon, lat)| (lat.to_degrees() as f32, lon.to_degrees() as f32))
+        .collect::<Vec<_>>();
+
+    Ok(latlon.into_iter())
+}
+
 pub(crate) fn normalize_latlon((lat, lon): (f32, f32)) -> (f32, f32) {
     let lon = (lon + 540.) % 360. - 180.;
     (lat, lon)

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -69,7 +69,7 @@ impl LatLons for Template3_30 {
 
         #[cfg(feature = "gridpoints-proj")]
         {
-            super::helpers::latlons_from_projection_definition_and_first_point(
+            super::helpers::latlons_from_projection_with_first_point_and_delta(
                 &params.proj_args(),
                 first_point,
                 (dx, dy),
@@ -89,16 +89,15 @@ impl LatLons for Template3_30 {
             let latlons = self
                 .ij()?
                 .map(|(i, j)| {
-                    projection.project(
-                        &(
-                            first_corner_x + dx * i as f64,
-                            first_corner_y + dy * j as f64,
-                        ),
-                        true,
-                    )
-                })
-                .map(|result| {
-                    result.map(|(lon, lat)| (lat.to_degrees() as f32, lon.to_degrees() as f32))
+                    projection
+                        .project(
+                            &(
+                                first_corner_x + dx * i as f64,
+                                first_corner_y + dy * j as f64,
+                            ),
+                            true,
+                        )
+                        .map(|(lon, lat)| (lat.to_degrees() as f32, lon.to_degrees() as f32))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(latlons.into_iter())

--- a/src/grid/mercator.rs
+++ b/src/grid/mercator.rs
@@ -70,7 +70,7 @@ impl LatLons for Template3_10 {
 
         #[cfg(feature = "gridpoints-proj")]
         {
-            super::helpers::latlons_from_projection_definition_and_first_point(
+            super::helpers::latlons_from_projection_with_first_point_and_delta(
                 &params.proj_args(),
                 first_point,
                 (dx, dy),
@@ -90,18 +90,15 @@ impl LatLons for Template3_10 {
             let latlons = self
                 .ij()?
                 .map(|(i, j)| {
-                    projection.project(
-                        &(
-                            first_corner_x + dx * i as f64,
-                            first_corner_y + dy * j as f64,
-                        ),
-                        true,
-                    )
-                })
-                .map(|result| {
-                    result
+                    projection
+                        .project(
+                            &(
+                                first_corner_x + dx * i as f64,
+                                first_corner_y + dy * j as f64,
+                            ),
+                            true,
+                        )
                         .map(|(lon, lat)| (lat.to_degrees() as f32, lon.to_degrees() as f32))
-                        .map_err(|e| GribError::Unknown(e.to_owned()))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(latlons.into_iter())

--- a/src/grid/mercator.rs
+++ b/src/grid/mercator.rs
@@ -37,7 +37,31 @@ impl LatLons for Template3_10 {
             )));
         }
 
+        if !self.is_consistent_for_j() {
+            return Err(GribError::InvalidValueError(
+                "Latitudes for first/last grid points are not consistent with scanning mode"
+                    .to_owned(),
+            ));
+        }
+
         let angle_units = self.angle_unit();
+        let first_point_lon = self.first_point_lon as f64 * angle_units;
+        let last_point_lon = self.last_point_lon as f64 * angle_units;
+        let lon_diff = last_point_lon - first_point_lon;
+        let (first_point_lon, last_point_lon) =
+            if self.scanning_mode.scans_positively_for_i() && lon_diff < 0. {
+                (first_point_lon, last_point_lon + 360.)
+            } else if !self.scanning_mode.scans_positively_for_i() && lon_diff > 0. {
+                (first_point_lon + 360., last_point_lon)
+            } else {
+                (first_point_lon, last_point_lon)
+            };
+        let first_point = (self.first_point_lat as f64 * angle_units, first_point_lon);
+        let last_point = (self.last_point_lat as f64 * angle_units, last_point_lon);
+        // ensure that all points are within the interval `[lon_0 - 180., lon_0
+        // + 180.]` so that the delta can be calculated correctly.
+        let lon_0 = (first_point_lon + last_point_lon) / 2.;
+
         let (a, b) = self.earth_shape.radii().ok_or_else(|| {
             GribError::NotSupported(format!(
                 "unknown value of Code Table 3.2 (shape of the Earth): {}",
@@ -47,33 +71,16 @@ impl LatLons for Template3_10 {
         let params = projection::MercParams {
             ellipsoid: projection::Ellipsoid::from_a_and_b(a, b),
             lat_ts: self.lad as f64 * angle_units,
-            lon_0: 0.,
+            lon_0,
         };
-
-        let dx = self.di as f64 * 1e-3;
-        let dy = self.dj as f64 * 1e-3;
-        let dx = if !self.scanning_mode.scans_positively_for_i() && dx > 0. {
-            -dx
-        } else {
-            dx
-        };
-        let dy = if !self.scanning_mode.scans_positively_for_j() && dy > 0. {
-            -dy
-        } else {
-            dy
-        };
-
-        let first_point = (
-            self.first_point_lat as f64 * angle_units,
-            self.first_point_lon as f64 * angle_units,
-        );
 
         #[cfg(feature = "gridpoints-proj")]
         {
-            super::helpers::latlons_from_projection_with_first_point_and_delta(
+            super::helpers::latlons_from_projection_with_first_point_and_last_point(
                 &params.proj_args(),
                 first_point,
-                (dx, dy),
+                last_point,
+                self.grid_shape(),
                 self.ij()?,
             )
         }
@@ -86,7 +93,14 @@ impl LatLons for Template3_10 {
                 &(first_point_lon.to_radians(), first_point_lat.to_radians()),
                 false,
             )?;
+            let (last_point_lat, last_point_lon) = last_point;
+            let (last_corner_x, last_corner_y) = projection.project(
+                &(last_point_lon.to_radians(), last_point_lat.to_radians()),
+                false,
+            )?;
 
+            let dx = (last_corner_x - first_corner_x) / (self.ni - 1) as f64;
+            let dy = (last_corner_y - first_corner_y) / (self.nj - 1) as f64;
             let latlons = self
                 .ij()?
                 .map(|(i, j)| {
@@ -109,6 +123,13 @@ impl LatLons for Template3_10 {
 impl AngleUnit for Template3_10 {
     fn angle_unit(&self) -> f64 {
         1e-6
+    }
+}
+
+impl Template3_10 {
+    pub(crate) fn is_consistent_for_j(&self) -> bool {
+        let lat_diff = self.last_point_lat - self.first_point_lat;
+        !((lat_diff > 0) ^ self.scanning_mode.scans_positively_for_j())
     }
 }
 
@@ -159,7 +180,7 @@ mod tests {
         // pygrib.
         let num_points = latlons.len();
         let ni = grid_def.ni as usize;
-        let delta = 3e-2;
+        let delta = 3e-5;
         // lat[0], lon[0]
         assert_coord_almost_eq(latlons[0], (-30.4192, 129.906005), delta);
         // lat[0], lon[1]

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -77,7 +77,7 @@ impl LatLons for Template3_20 {
             dy
         };
 
-        super::helpers::latlons_from_projection_definition_and_first_point(
+        super::helpers::latlons_from_projection_with_first_point_and_delta(
             &params.proj_args(),
             (
                 self.first_point_lat as f64 * angle_units,


### PR DESCRIPTION
This PR improves the accuracy of lat/lon computation for Mercator grids.

In the definition of Mercator grid, both the grid spacing and the
coordinates of the last grid point are specified as parameters, even
though only one of them is actually needed for computational purposes.

Previous implementation have used the grid spacing, but since that
resulted in poor computational accuracy, the new implementation will
instead use the coordinates of the last grid point.
In general, since errors tend to accumulate in the grid spacing, the
coordinates of the last grid point are preferable.

Taking the test data `ds.wwa.bin`, which had poor accuracy, as an
example, I performed a calculation and found that the grid spacing
`(dx, dy)` calculated based on the final grid point was about
`(10000.862892, 10006.204199)`, which is considerably larger than the
defined grid spacing `(10000.0, 10000.0)`.