### PR TITLE
Reduce peak memory for projected grid coordinates

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "gridpoints-proj")]
+use helpers::ProjectionLatLonIterator;
 use helpers::RegularGridIterator;
 
 pub use self::{gaussian::compute_gaussian_latitudes, rotated_ll::Unrotate};
@@ -218,6 +220,8 @@ impl Iterator for GridPointLatLons {
             Self(LatLonsWrapper::SigR(iter)) => iter.next(),
             Self(LatLonsWrapper::SigUR(iter)) => iter.next(),
             Self(LatLonsWrapper::SigIf(iter)) => iter.next(),
+            #[cfg(feature = "gridpoints-proj")]
+            Self(LatLonsWrapper::SigP(iter)) => iter.next(),
         }
     }
 
@@ -226,6 +230,8 @@ impl Iterator for GridPointLatLons {
             Self(LatLonsWrapper::SigR(iter)) => iter.size_hint(),
             Self(LatLonsWrapper::SigUR(iter)) => iter.size_hint(),
             Self(LatLonsWrapper::SigIf(iter)) => iter.size_hint(),
+            #[cfg(feature = "gridpoints-proj")]
+            Self(LatLonsWrapper::SigP(iter)) => iter.size_hint(),
         }
     }
 }
@@ -248,11 +254,20 @@ impl From<std::vec::IntoIter<(f32, f32)>> for GridPointLatLons {
     }
 }
 
+#[cfg(feature = "gridpoints-proj")]
+impl From<ProjectionLatLonIterator> for GridPointLatLons {
+    fn from(value: ProjectionLatLonIterator) -> Self {
+        Self(LatLonsWrapper::SigP(value))
+    }
+}
+
 #[derive(Clone)]
 enum LatLonsWrapper {
     SigR(RegularGridIterator),
     SigUR(Unrotate<RegularGridIterator>),
     SigIf(std::vec::IntoIter<(f32, f32)>),
+    #[cfg(feature = "gridpoints-proj")]
+    SigP(ProjectionLatLonIterator),
 }
 
 /// A functionality to generate an iterator over 2D index `(i, j)` of grid

--- a/src/grid/helpers.rs
+++ b/src/grid/helpers.rs
@@ -74,13 +74,34 @@ impl Iterator for RegularGridIterator {
     }
 }
 
+#[derive(Clone)]
+#[cfg(feature = "gridpoints-proj")]
+pub struct ProjectionLatLonIterator {
+    xy: std::vec::IntoIter<(f64, f64)>,
+}
+
+#[cfg(feature = "gridpoints-proj")]
+impl Iterator for ProjectionLatLonIterator {
+    type Item = (f32, f32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.xy
+            .next()
+            .map(|(lon, lat)| (lat.to_degrees() as f32, lon.to_degrees() as f32))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.xy.size_hint()
+    }
+}
+
 #[cfg(feature = "gridpoints-proj")]
 pub(crate) fn latlons_from_projection_with_first_point_and_delta(
     proj_def: &str,
     first_point_latlon_in_degrees: (f64, f64),
     delta_in_meters: (f64, f64),
     indices: GridPointIndexIterator,
-) -> Result<std::vec::IntoIter<(f32, f32)>, GribError> {
+) -> Result<ProjectionLatLonIterator, GribError> {
     let projection = Proj::new(proj_def)?;
     let (first_point_lat, first_point_lon) = first_point_latlon_in_degrees;
     let (first_corner_x, first_corner_y) = projection.project(
@@ -98,13 +119,9 @@ pub(crate) fn latlons_from_projection_with_first_point_and_delta(
         })
         .collect::<Vec<_>>();
 
-    let lonlat = projection.project_array(&mut xy, true)?;
-    let latlon = lonlat
-        .iter_mut()
-        .map(|(lon, lat)| (lat.to_degrees() as f32, lon.to_degrees() as f32))
-        .collect::<Vec<_>>();
+    projection.project_array(&mut xy, true)?;
 
-    Ok(latlon.into_iter())
+    Ok(ProjectionLatLonIterator { xy: xy.into_iter() })
 }
 
 #[cfg(feature = "gridpoints-proj")]

--- a/src/grid/lambert.rs
+++ b/src/grid/lambert.rs
@@ -27,6 +27,9 @@ impl GridPointIndex for Template3_30 {
 }
 
 impl LatLons for Template3_30 {
+    #[cfg(feature = "gridpoints-proj")]
+    type Iter<'a> = super::helpers::ProjectionLatLonIterator;
+    #[cfg(not(feature = "gridpoints-proj"))]
     type Iter<'a> = std::vec::IntoIter<(f32, f32)>;
 
     fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {

--- a/src/grid/polar_stereographic.rs
+++ b/src/grid/polar_stereographic.rs
@@ -29,7 +29,7 @@ impl GridPointIndex for Template3_20 {
 #[cfg_attr(docsrs, doc(cfg(feature = "gridpoints-proj")))]
 impl LatLons for Template3_20 {
     type Iter<'a>
-        = std::vec::IntoIter<(f32, f32)>
+        = super::helpers::ProjectionLatLonIterator
     where
         Self: 'a;
 


### PR DESCRIPTION
Closes #242.

## Summary

Replace the intermediate `Vec<(f32, f32)>` used for projected Lambert and polar stereographic grids with a lazy iterator over the already projected `Vec<(f64, f64)>`.

`project_array` still completes before the iterator is returned, so PROJ errors are reported by `latlons()` at the same time as before. Coordinate values, ordering, and CLI output remain unchanged.

## Benchmark

Measured with `testdata/ds.minrh.bin.xz`, submessage `0.0` (Lambert, 2,953,665 points):

| Run | Before | After |
|---|---:|---:|
| 1 | 0.58 s / 168.0 MiB RSS | 0.53 s / 147.4 MiB RSS |
| 2 | 0.55 s / 169.9 MiB RSS | 0.52 s / 146.8 MiB RSS |
| 3 | 0.53 s / 168.0 MiB RSS | 0.52 s / 145.4 MiB RSS |

Median RSS decreases by about 21 MiB, with no time regression.

## Validation

- `cargo fmt --check`
- `cargo test --release -p grib grid::lambert::tests::lambert_grid_latlon_computation -- --exact`
- `cargo test --release -p grib grid::polar_stereographic::tests::polar_stereographic_grid_latlon_computation -- --exact`
- `cargo test --workspace --release`
- `git diff --check`