### PR TITLE
Add lat/lon computation support for Template 3.41 (rotated Gaussian latitude/longitude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For data using the following grid systems, latitudes and longitudes of grid poin
 | 3.20 | ✅ | | ✅ (OSGeo PROJ (`gridpoints-proj` feature)) | Polar stereographic projection |
 | 3.30 | ✅ | ✅ | ✅ (OSGeo PROJ (`gridpoints-proj` feature)) | Lambert conformal |
 | 3.40 | ✅ | ✅ | ✅ (built-in) | Gaussian latitude/longitude |
-| 3.41 | ✅ | | | rotated Gaussian latitude/longitude |
+| 3.41 | ✅ | ✅ | ✅ (built-in) | rotated Gaussian latitude/longitude |
 | 3.42 | ✅ | | | stretched Gaussian latitude/longitude |
 | 3.43 | ✅ | | | stretched and rotated Gaussian latitude/longitude |
 | 3.101 | ✅ | | | general unstructured grid |

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,6 +1,6 @@
 use helpers::RegularGridIterator;
 
-pub use self::{gaussian::compute_gaussian_latitudes, rotated_ll::Unrotate};
+pub use self::{gaussian::compute_gaussian_latitudes, rotation::Unrotate};
 use crate::{
     GribError, GridDefinition, TryFromSlice,
     def::grib2::template::{
@@ -476,4 +476,4 @@ mod lambert;
 mod latlon;
 mod mercator;
 mod polar_stereographic;
-mod rotated_ll;
+mod rotation;

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -5,6 +5,7 @@ use crate::{
     GribError, GridDefinition, TryFromSlice,
     def::grib2::template::{
         Template3_0, Template3_1, Template3_10, Template3_20, Template3_30, Template3_40,
+        Template3_41,
         param_set::{Grid, ScanningMode},
     },
 };
@@ -18,6 +19,7 @@ pub enum GridDefinitionTemplateValues {
     Template20(Template3_20),
     Template30(Template3_30),
     Template40(Template3_40),
+    Template41(Template3_41),
 }
 
 impl GridShortName for GridDefinitionTemplateValues {
@@ -29,6 +31,7 @@ impl GridShortName for GridDefinitionTemplateValues {
             Self::Template20(def) => def.short_name(),
             Self::Template30(def) => def.short_name(),
             Self::Template40(def) => def.gaussian.short_name(),
+            Self::Template41(def) => def.short_name(),
         }
     }
 }
@@ -42,6 +45,7 @@ impl GridPointIndex for GridDefinitionTemplateValues {
             Self::Template20(def) => def.grid_shape(),
             Self::Template30(def) => def.grid_shape(),
             Self::Template40(def) => def.gaussian.grid_shape(),
+            Self::Template41(def) => def.grid_shape(),
         }
     }
 
@@ -53,6 +57,7 @@ impl GridPointIndex for GridDefinitionTemplateValues {
             Self::Template20(def) => def.scanning_mode(),
             Self::Template30(def) => def.scanning_mode(),
             Self::Template40(def) => def.gaussian.scanning_mode(),
+            Self::Template41(def) => def.scanning_mode(),
         }
     }
 }
@@ -72,6 +77,7 @@ impl LatLons for GridDefinitionTemplateValues {
             Self::Template20(def) => GridPointLatLons::from(def.latlons_unchecked()?),
             Self::Template30(def) => GridPointLatLons::from(def.latlons_unchecked()?),
             Self::Template40(def) => GridPointLatLons::from(def.gaussian.latlons_unchecked()?),
+            Self::Template41(def) => GridPointLatLons::from(def.latlons_unchecked()?),
             #[cfg(not(feature = "gridpoints-proj"))]
             _ => {
                 return Err(GribError::NotSupported(
@@ -122,6 +128,9 @@ impl TryFrom<&GridDefinition> for GridDefinitionTemplateValues {
                 buf, &mut pos,
             )?),
             40 => GridDefinitionTemplateValues::Template40(Template3_40::try_from_slice(
+                buf, &mut pos,
+            )?),
+            41 => GridDefinitionTemplateValues::Template41(Template3_41::try_from_slice(
                 buf, &mut pos,
             )?),
             _ => {

--- a/src/grid/gaussian.rs
+++ b/src/grid/gaussian.rs
@@ -1,5 +1,13 @@
-use super::helpers::{RegularGridIterator, evenly_spaced_longitudes};
-use crate::{GridPointIndex, def::grib2::template::param_set, error::GribError, grid::AngleUnit};
+use super::{
+    GridPointIndexIterator, Unrotate,
+    helpers::{RegularGridIterator, evenly_spaced_longitudes},
+};
+use crate::{
+    GridPointIndex, LatLons,
+    def::grib2::template::{Template3_41, param_set},
+    error::GribError,
+    grid::AngleUnit,
+};
 
 const MAX_ITER: usize = 10;
 
@@ -19,7 +27,7 @@ impl GridPointIndex for param_set::GaussianGrid {
     }
 }
 
-impl crate::LatLons for param_set::GaussianGrid {
+impl LatLons for param_set::GaussianGrid {
     type Iter<'a> = RegularGridIterator;
 
     fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
@@ -59,6 +67,48 @@ impl param_set::GaussianGrid {
     pub(crate) fn is_consistent_for_j(&self) -> bool {
         let lat_diff = self.grid.last_point_lat - self.grid.first_point_lat;
         !((lat_diff > 0) ^ self.scanning_mode.scans_positively_for_j())
+    }
+}
+
+impl crate::GridShortName for Template3_41 {
+    fn short_name(&self) -> &'static str {
+        "rotated_gg"
+    }
+}
+
+impl GridPointIndex for Template3_41 {
+    fn grid_shape(&self) -> (usize, usize) {
+        self.gaussian.grid_shape()
+    }
+
+    fn scanning_mode(&self) -> &crate::def::grib2::template::param_set::ScanningMode {
+        self.gaussian.scanning_mode()
+    }
+
+    fn ij(&self) -> Result<GridPointIndexIterator, GribError> {
+        self.gaussian.ij()
+    }
+}
+
+impl LatLons for Template3_41 {
+    type Iter<'a>
+        = Unrotate<RegularGridIterator>
+    where
+        Self: 'a;
+
+    fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
+        let iter = Unrotate::new(
+            self.gaussian.latlons_unchecked()?,
+            &self.rotation,
+            self.angle_unit() as f32,
+        );
+        Ok(iter)
+    }
+}
+
+impl AngleUnit for Template3_41 {
+    fn angle_unit(&self) -> f64 {
+        self.gaussian.grid.angle_unit()
     }
 }
 

--- a/src/grid/latlon.rs
+++ b/src/grid/latlon.rs
@@ -1,6 +1,12 @@
-use super::helpers::{RegularGridIterator, evenly_spaced_degrees, evenly_spaced_longitudes};
+use super::{
+    GridPointIndexIterator, Unrotate,
+    helpers::{RegularGridIterator, evenly_spaced_degrees, evenly_spaced_longitudes},
+};
 use crate::{
-    GridPointIndex, LatLons, def::grib2::template::param_set, error::GribError, grid::AngleUnit,
+    GridPointIndex, LatLons,
+    def::grib2::template::{Template3_1, param_set},
+    error::GribError,
+    grid::AngleUnit,
 };
 
 impl crate::GridShortName for param_set::LatLonGrid {
@@ -61,6 +67,48 @@ impl param_set::LatLonGrid {
     pub(crate) fn is_consistent_for_j(&self) -> bool {
         let lat_diff = self.grid.last_point_lat - self.grid.first_point_lat;
         !((lat_diff > 0) ^ self.scanning_mode.scans_positively_for_j())
+    }
+}
+
+impl crate::GridShortName for Template3_1 {
+    fn short_name(&self) -> &'static str {
+        "rotated_ll"
+    }
+}
+
+impl GridPointIndex for Template3_1 {
+    fn grid_shape(&self) -> (usize, usize) {
+        self.lat_lon.grid_shape()
+    }
+
+    fn scanning_mode(&self) -> &crate::def::grib2::template::param_set::ScanningMode {
+        self.lat_lon.scanning_mode()
+    }
+
+    fn ij(&self) -> Result<GridPointIndexIterator, GribError> {
+        self.lat_lon.ij()
+    }
+}
+
+impl LatLons for Template3_1 {
+    type Iter<'a>
+        = Unrotate<RegularGridIterator>
+    where
+        Self: 'a;
+
+    fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
+        let iter = Unrotate::new(
+            self.lat_lon.latlons_unchecked()?,
+            &self.rotation,
+            self.angle_unit() as f32,
+        );
+        Ok(iter)
+    }
+}
+
+impl AngleUnit for Template3_1 {
+    fn angle_unit(&self) -> f64 {
+        self.lat_lon.grid.angle_unit()
     }
 }
 

--- a/src/grid/rotation.rs
+++ b/src/grid/rotation.rs
@@ -1,52 +1,4 @@
-use super::GridPointIndexIterator;
-use crate::{
-    GridPointIndex, LatLons,
-    def::grib2::template::{Template3_1, param_set::Rotation},
-    error::GribError,
-    grid::{AngleUnit, helpers::RegularGridIterator},
-};
-
-impl crate::GridShortName for Template3_1 {
-    fn short_name(&self) -> &'static str {
-        "rotated_ll"
-    }
-}
-
-impl GridPointIndex for Template3_1 {
-    fn grid_shape(&self) -> (usize, usize) {
-        self.lat_lon.grid_shape()
-    }
-
-    fn scanning_mode(&self) -> &crate::def::grib2::template::param_set::ScanningMode {
-        self.lat_lon.scanning_mode()
-    }
-
-    fn ij(&self) -> Result<GridPointIndexIterator, GribError> {
-        self.lat_lon.ij()
-    }
-}
-
-impl LatLons for Template3_1 {
-    type Iter<'a>
-        = Unrotate<RegularGridIterator>
-    where
-        Self: 'a;
-
-    fn latlons_unchecked<'a>(&'a self) -> Result<Self::Iter<'a>, GribError> {
-        let iter = Unrotate::new(
-            self.lat_lon.latlons_unchecked()?,
-            &self.rotation,
-            self.angle_unit() as f32,
-        );
-        Ok(iter)
-    }
-}
-
-impl AngleUnit for Template3_1 {
-    fn angle_unit(&self) -> f64 {
-        self.lat_lon.grid.angle_unit()
-    }
-}
+use crate::def::grib2::template::param_set::Rotation;
 
 #[derive(Clone)]
 pub struct Unrotate<I> {
@@ -58,7 +10,7 @@ pub struct Unrotate<I> {
 }
 
 impl<I> Unrotate<I> {
-    fn new(latlons: I, rot: &Rotation, angle_units: f32) -> Self {
+    pub(crate) fn new(latlons: I, rot: &Rotation, angle_units: f32) -> Self {
         let φp = (rot.south_pole_lat as f32 * angle_units).to_radians();
         let λp = (rot.south_pole_lon as f32 * angle_units).to_radians();
         let gamma = (rot.rot_angle * angle_units).to_radians();


### PR DESCRIPTION
This PR adds lat/lon computation support for Template 3.41 (rotated Gaussian latitude/longitude).

At this point, I have not been able to find or obtain the data for this grid.
Therefore, I have not conducted any tests using real-world data.
However, since the calculation method seems straightforward to me, I have implemented it.